### PR TITLE
Add cacheType param to CompletionHandler

### DIFF
--- a/Kingfisher-Demo/ViewController.swift
+++ b/Kingfisher-Demo/ViewController.swift
@@ -59,7 +59,7 @@ extension ViewController: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCellWithReuseIdentifier("collectionViewCell", forIndexPath: indexPath) as! CollectionViewCell
         cell.cellImageView.kf_setImageWithURL(NSURL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher/master/images/kingfisher-\(indexPath.row + 1).jpg")!, placeholderImage: nil, optionsInfo: nil, progressBlock: { (receivedSize, totalSize) -> () in
             println("\(indexPath.row + 1): \(receivedSize)/\(totalSize)")
-        }) { (image, error, imageURL) -> () in
+        }) { (image, error, imageURL, cacheType) -> () in
             println("\(indexPath.row + 1): Finished")
         }
         

--- a/Kingfisher/ImageCache.swift
+++ b/Kingfisher/ImageCache.swift
@@ -43,7 +43,7 @@ Cache type of a cached image.
 - Disk:   The image is cached in disk.
 */
 public enum CacheType {
-    case Memory, Disk
+    case Memory, Disk, None
 }
 
 public class ImageCache {

--- a/Kingfisher/ImageDownloader.swift
+++ b/Kingfisher/ImageDownloader.swift
@@ -138,7 +138,7 @@ public extension ImageDownloader {
         
         // There is a possiblility that request modifier changed the url to `nil`
         if request.URL == nil {
-            completionHandler?(image: nil, error: NSError(domain: KingfisherErrorDomain, code: KingfisherError.InvalidURL.rawValue, userInfo: nil), imageURL: nil)
+            completionHandler?(image: nil, error: NSError(domain: KingfisherErrorDomain, code: KingfisherError.InvalidURL.rawValue, userInfo: nil), imageURL: nil, cacheType: .None)
             return
         }
         
@@ -211,7 +211,7 @@ extension ImageDownloader: NSURLSessionDataDelegate {
     private func callbackWithImage(image: UIImage?, error: NSError?, imageURL: NSURL) {
         if let callbackPairs = self.fetchLoads[imageURL]?.callbacks {
             for callbackPair in callbackPairs {
-                callbackPair.completionHander?(image: image, error: error, imageURL: imageURL)
+                callbackPair.completionHander?(image: image, error: error, imageURL: imageURL, cacheType: .None)
             }
         }
     }

--- a/Kingfisher/ImageDownloader.swift
+++ b/Kingfisher/ImageDownloader.swift
@@ -138,7 +138,7 @@ public extension ImageDownloader {
         
         // There is a possiblility that request modifier changed the url to `nil`
         if request.URL == nil {
-            completionHandler?(image: nil, error: NSError(domain: KingfisherErrorDomain, code: KingfisherError.InvalidURL.rawValue, userInfo: nil), imageURL: nil, cacheType: .None)
+            completionHandler?(image: nil, error: NSError(domain: KingfisherErrorDomain, code: KingfisherError.InvalidURL.rawValue, userInfo: nil), cacheType: .None, imageURL: nil)
             return
         }
         
@@ -211,7 +211,7 @@ extension ImageDownloader: NSURLSessionDataDelegate {
     private func callbackWithImage(image: UIImage?, error: NSError?, imageURL: NSURL) {
         if let callbackPairs = self.fetchLoads[imageURL]?.callbacks {
             for callbackPair in callbackPairs {
-                callbackPair.completionHander?(image: image, error: error, imageURL: imageURL, cacheType: .None)
+                callbackPair.completionHander?(image: image, error: error, cacheType: .None, imageURL: imageURL)
             }
         }
     }

--- a/Kingfisher/KingfisherManager.swift
+++ b/Kingfisher/KingfisherManager.swift
@@ -153,7 +153,7 @@ public class KingfisherManager {
             } else {
                 let diskTask = targetCache.retrieveImageForKey(key, options: options, completionHandler: { (image, cacheType) -> () in
                     if image != nil {
-                        completionHandler?(image: image, error: nil, imageURL: URL, cacheType:cacheType)
+                        completionHandler?(image: image, error: nil, cacheType:cacheType, imageURL: URL)
                     } else {
                         self.downloadAndCacheImageWithURL(URL,
                             forKey: key,
@@ -184,8 +184,8 @@ public class KingfisherManager {
         downloader.downloadImageWithURL(URL, retrieveImageTask: retrieveImageTask, options: options, progressBlock: { (receivedSize, totalSize) -> () in
             progressBlock?(receivedSize: receivedSize, totalSize: totalSize)
             return
-        }) { (image, error, imageURL, cacheType) -> () in
-            completionHandler?(image: image, error: error, imageURL: URL, cacheType:cacheType)
+        }) { (image, error, cacheType, imageURL) -> () in
+            completionHandler?(image: image, error: error, cacheType:cacheType, imageURL: URL)
             if let image = image {
                 targetCache.storeImage(image, forKey: key, toDisk: !options.cacheMemoryOnly, completionHandler: nil)
             }

--- a/Kingfisher/KingfisherManager.swift
+++ b/Kingfisher/KingfisherManager.swift
@@ -153,7 +153,7 @@ public class KingfisherManager {
             } else {
                 let diskTask = targetCache.retrieveImageForKey(key, options: options, completionHandler: { (image, cacheType) -> () in
                     if image != nil {
-                        completionHandler?(image: image, error: nil, imageURL: URL)
+                        completionHandler?(image: image, error: nil, imageURL: URL, cacheType:cacheType)
                     } else {
                         self.downloadAndCacheImageWithURL(URL,
                             forKey: key,
@@ -184,8 +184,8 @@ public class KingfisherManager {
         downloader.downloadImageWithURL(URL, retrieveImageTask: retrieveImageTask, options: options, progressBlock: { (receivedSize, totalSize) -> () in
             progressBlock?(receivedSize: receivedSize, totalSize: totalSize)
             return
-        }) { (image, error, imageURL) -> () in
-            completionHandler?(image: image, error: error, imageURL: URL)
+        }) { (image, error, imageURL, cacheType) -> () in
+            completionHandler?(image: image, error: error, imageURL: URL, cacheType:cacheType)
             if let image = image {
                 targetCache.storeImage(image, forKey: key, toDisk: !options.cacheMemoryOnly, completionHandler: nil)
             }

--- a/Kingfisher/UIButton+Kingfisher.swift
+++ b/Kingfisher/UIButton+Kingfisher.swift
@@ -127,12 +127,12 @@ public extension UIButton {
                     progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 })
             }
-        }) { (image, error, imageURL) -> () in
+        }) { (image, error, imageURL, cacheType) -> () in
             dispatch_async(dispatch_get_main_queue(), { () -> Void in
                 if (imageURL == self.kf_webURLForState(state) && image != nil) {
                     self.setImage(image, forState: state)
                 }
-                completionHandler?(image: image, error: error, imageURL: imageURL)
+                completionHandler?(image: image, error: error, imageURL: imageURL, cacheType: cacheType)
             })
         }
         
@@ -275,12 +275,12 @@ public extension UIButton {
                     progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 })
             }
-            }) { (image, error, imageURL) -> () in
+            }) { (image, error, imageURL, cacheType) -> () in
                 dispatch_async(dispatch_get_main_queue(), { () -> Void in
                     if (imageURL == self.kf_backgroundWebURLForState(state) && image != nil) {
                         self.setBackgroundImage(image, forState: state)
                     }
-                    completionHandler?(image: image, error: error, imageURL: imageURL)
+                    completionHandler?(image: image, error: error, imageURL: imageURL, cacheType: cacheType)
                 })
         }
         

--- a/Kingfisher/UIButton+Kingfisher.swift
+++ b/Kingfisher/UIButton+Kingfisher.swift
@@ -127,12 +127,12 @@ public extension UIButton {
                     progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 })
             }
-        }) { (image, error, imageURL, cacheType) -> () in
+        }) { (image, error, cacheType, imageURL) -> () in
             dispatch_async(dispatch_get_main_queue(), { () -> Void in
                 if (imageURL == self.kf_webURLForState(state) && image != nil) {
                     self.setImage(image, forState: state)
                 }
-                completionHandler?(image: image, error: error, imageURL: imageURL, cacheType: cacheType)
+                completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
             })
         }
         
@@ -275,12 +275,12 @@ public extension UIButton {
                     progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 })
             }
-            }) { (image, error, imageURL, cacheType) -> () in
+            }) { (image, error, cacheType, imageURL) -> () in
                 dispatch_async(dispatch_get_main_queue(), { () -> Void in
                     if (imageURL == self.kf_backgroundWebURLForState(state) && image != nil) {
                         self.setBackgroundImage(image, forState: state)
                     }
-                    completionHandler?(image: image, error: error, imageURL: imageURL, cacheType: cacheType)
+                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                 })
         }
         

--- a/Kingfisher/UIImageView+Kingfisher.swift
+++ b/Kingfisher/UIImageView+Kingfisher.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 public typealias DownloadProgressBlock = ((receivedSize: Int64, totalSize: Int64) -> ())
-public typealias CompletionHandler = ((image: UIImage?, error: NSError?, imageURL: NSURL?) -> ())
+public typealias CompletionHandler = ((image: UIImage?, error: NSError?, imageURL: NSURL?, cacheType:CacheType) -> ())
 
 // MARK: - Set Images
 /**
@@ -122,12 +122,12 @@ public extension UIImageView {
                     progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 })
             }
-        }) { (image, error, imageURL) -> () in
+        }) { (image, error, imageURL, cacheType) -> () in
             dispatch_async(dispatch_get_main_queue(), { () -> Void in
                 if (imageURL == self.kf_webURL && image != nil) {
                     self.image = image;
                 }
-                completionHandler?(image: image, error: error, imageURL: imageURL)
+                completionHandler?(image: image, error: error, imageURL: imageURL, cacheType: cacheType)
             })
         }
         

--- a/Kingfisher/UIImageView+Kingfisher.swift
+++ b/Kingfisher/UIImageView+Kingfisher.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 public typealias DownloadProgressBlock = ((receivedSize: Int64, totalSize: Int64) -> ())
-public typealias CompletionHandler = ((image: UIImage?, error: NSError?, imageURL: NSURL?, cacheType:CacheType) -> ())
+public typealias CompletionHandler = ((image: UIImage?, error: NSError?, cacheType:CacheType, imageURL: NSURL?) -> ())
 
 // MARK: - Set Images
 /**
@@ -122,12 +122,12 @@ public extension UIImageView {
                     progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 })
             }
-        }) { (image, error, imageURL, cacheType) -> () in
+        }) { (image, error, cacheType, imageURL) -> () in
             dispatch_async(dispatch_get_main_queue(), { () -> Void in
                 if (imageURL == self.kf_webURL && image != nil) {
                     self.image = image;
                 }
-                completionHandler?(image: image, error: error, imageURL: imageURL, cacheType: cacheType)
+                completionHandler?(image: image, error: error, cacheType:cacheType, imageURL: imageURL)
             })
         }
         

--- a/KingfisherTests/ImageDownloaderTests.swift
+++ b/KingfisherTests/ImageDownloaderTests.swift
@@ -64,7 +64,7 @@ class ImageDownloaderTests: XCTestCase {
         let URL = NSURL(string: URLString)!
         downloader.downloadImageWithURL(URL, options: KingfisherManager.OptionsNone, progressBlock: { (receivedSize, totalSize) -> () in
             return
-        }) { (image, error, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> () in
             expectation.fulfill()
             XCTAssert(image != nil, "Download should be able to finished for URL: \(imageURL)")
         }
@@ -83,7 +83,7 @@ class ImageDownloaderTests: XCTestCase {
                 stubRequest("GET", URLString).andReturn(200).withBody(testImageData)
                 downloader.downloadImageWithURL(URL, options: KingfisherManager.OptionsNone, progressBlock: { (receivedSize, totalSize) -> () in
                     
-                }, completionHandler: { (image, error, imageURL) -> () in
+                }, completionHandler: { (image, error, cacheType, imageURL) -> () in
                     XCTAssert(image != nil, "Download should be able to finished for URL: \(imageURL).")
                     dispatch_group_leave(group)
                 })
@@ -108,7 +108,7 @@ class ImageDownloaderTests: XCTestCase {
             dispatch_group_enter(group)
             downloader.downloadImageWithURL(NSURL(string: URLString)!, options: KingfisherManager.OptionsNone, progressBlock: { (receivedSize, totalSize) -> () in
                 
-                }) { (image, error, imageURL) -> () in
+                }) { (image, error, cacheType, imageURL) -> () in
                     XCTAssert(image != nil, "Download should be able to finished for URL: \(imageURL).")
                     dispatch_group_leave(group)
                     
@@ -136,7 +136,7 @@ class ImageDownloaderTests: XCTestCase {
         let someURL = NSURL(string: "some_strange_url")!
         downloader.downloadImageWithURL(someURL, options: KingfisherManager.OptionsNone, progressBlock: { (receivedSize, totalSize) -> () in
             
-        }) { (image, error, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> () in
             XCTAssert(image != nil, "Download should be able to finished for URL: \(imageURL).")
             XCTAssertEqual(imageURL!, NSURL(string: URLString)!, "The returned imageURL should be the replaced one")
             expectation.fulfill()
@@ -153,7 +153,7 @@ class ImageDownloaderTests: XCTestCase {
         
         let expectation = expectationWithDescription("wait for download from an invalid ssl site.")
         
-        downloader.downloadImageWithURL(URL, progressBlock: nil, completionHandler: { (image, error, imageURL) -> () in
+        downloader.downloadImageWithURL(URL, progressBlock: nil, completionHandler: { (image, error, cacheType, imageURL) -> () in
             XCTAssertNotNil(error, "Error should not be nil")
             XCTAssert(error?.code == NSURLErrorServerCertificateUntrusted, "Error should be NSURLErrorServerCertificateUntrusted")
             expectation.fulfill()


### PR DESCRIPTION
This adds a cacheType:CacheType parameter to the CompletionHandler. It also adds a .None case to the CacheType enum.
This allows for checking where the image came from, to for example, decide whether to animate a transition to this image (ie, if the cacheType == .None then fade in image as it's just been download, otherwise do nothing)

This also aligns with the SDWebImage completion handler, making switching frameworks easier