### PR TITLE
Add queue resulting queue to KingfisherManager.Option, default to mai…

### DIFF
--- a/Kingfisher/ImageCache.swift
+++ b/Kingfisher/ImageCache.swift
@@ -247,7 +247,7 @@ extension ImageCache {
                 if options.shouldDecode {
                     dispatch_async(self.processQueue, { () -> Void in
                         let result = image.kf_decodedImage()
-                        dispatch_async(dispatch_get_main_queue(), { () -> Void in
+                        dispatch_async(options.queue, { () -> Void in
                             completionHandler?(result, .Memory)
                             return
                         })
@@ -266,14 +266,14 @@ extension ImageCache {
                                 let result = image.kf_decodedImage()
                                 self.storeImage(result!, forKey: key, toDisk: false, completionHandler: nil)
                                 
-                                dispatch_async(dispatch_get_main_queue(), { () -> Void in
+                                dispatch_async(options.queue, { () -> Void in
                                     completionHandler?(result, .Memory)
                                     return
                                 })
                             })
                         } else {
                             self.storeImage(image, forKey: key, toDisk: false, completionHandler: nil)
-                            dispatch_async(dispatch_get_main_queue(), { () -> Void in
+                            dispatch_async(options.queue, { () -> Void in
                                 if let completionHandler = completionHandler {
                                     completionHandler(image, .Disk)
                                 }
@@ -281,7 +281,7 @@ extension ImageCache {
                         }
                     } else {
                         // No image found from either memory or disk
-                        dispatch_async(dispatch_get_main_queue(), { () -> Void in
+                        dispatch_async(options.queue, { () -> Void in
                             if let completionHandler = completionHandler {
                                 completionHandler(nil, nil)
                             }
@@ -291,7 +291,7 @@ extension ImageCache {
             }
         }
         
-        dispatch_async(dispatch_get_main_queue(), block)
+        dispatch_async(options.queue, block)
         return block
     }
     

--- a/Kingfisher/KingfisherManager.swift
+++ b/Kingfisher/KingfisherManager.swift
@@ -65,11 +65,11 @@ public class KingfisherManager {
     /**
     *	Options to control some downloader and cache behaviors.
     */
-    public typealias Options = (forceRefresh: Bool, lowPriority: Bool, cacheMemoryOnly: Bool, shouldDecode: Bool)
+    public typealias Options = (forceRefresh: Bool, lowPriority: Bool, cacheMemoryOnly: Bool, shouldDecode: Bool, queue: dispatch_queue_t!)
     
     /// A preset option tuple with all value set to `false`.
     public static var OptionsNone: Options = {
-        return (forceRefresh: false, lowPriority: false, cacheMemoryOnly: false, shouldDecode: false)
+        return (forceRefresh: false, lowPriority: false, cacheMemoryOnly: false, shouldDecode: false, queue: dispatch_get_main_queue())
     }()
     
     /// Shared manager used by the extensions across Kingfisher.
@@ -117,12 +117,15 @@ public class KingfisherManager {
                 options = (forceRefresh: (optionsInOptionsInfo & KingfisherOptions.ForceRefresh) != KingfisherOptions.None,
                     lowPriority: (optionsInOptionsInfo & KingfisherOptions.LowPriority) != KingfisherOptions.None,
                     cacheMemoryOnly: (optionsInOptionsInfo & KingfisherOptions.CacheMemoryOnly) != KingfisherOptions.None,
-                    shouldDecode: (optionsInOptionsInfo & KingfisherOptions.BackgroundDecode) != KingfisherOptions.None)
+                    shouldDecode: (optionsInOptionsInfo & KingfisherOptions.BackgroundDecode) != KingfisherOptions.None,
+                    queue: dispatch_get_main_queue())
             } else {
                 options = (forceRefresh: false,
                     lowPriority: false,
                     cacheMemoryOnly: false,
-                    shouldDecode: false)
+                    shouldDecode: false,
+                    queue: dispatch_get_main_queue()
+                    )
             }
             
             let targetCache = optionsInfo?[.TargetCache] as? ImageCache ?? self.cache


### PR DESCRIPTION
Add queue resulting queue to KingfisherManager.Option, default to main queue

Thanks to this `retrieveImageWithURL()` is more configurable, in particular can be called synchronously easily if necessary.