### PR TITLE
add cfnetwork framework

### DIFF
--- a/Kingfisher.podspec
+++ b/Kingfisher.podspec
@@ -32,5 +32,6 @@ Pod::Spec.new do |s|
   s.source_files  = "Kingfisher/*.swift"
   s.requires_arc = true
   s.weak_framework = 'WatchKit'
-
+  s.framework = "CFNetwork"
+  
 end


### PR DESCRIPTION
ios8.0 device issue.

```
dyld: Symbol not found: _NSURLSessionTaskPriorityDefault
  Referenced from: /private/var/mobile/Containers/Bundle/Application/D032C3E0-95B8-4A98-9C2A-7C074DE5D512/ios8test.app/Frameworks/Kingfisher.framework/Kingfisher
  Expected in: /System/Library/Frameworks/Foundation.framework/Foundation
 in /private/var/mobile/Containers/Bundle/Application/D032C3E0-95B8-4A98-9C2A-7C074DE5D512/ios8test.app/Frameworks/Kingfisher.framework/Kingfisher
```

CFNetwork is necessary.
