### PR TITLE
Try to fix issue 86

### DIFF
--- a/Kingfisher/ImageCache.swift
+++ b/Kingfisher/ImageCache.swift
@@ -386,8 +386,8 @@ extension ImageCache {
                             
                         if let resourceValues = fileURL.resourceValuesForKeys(resourceKeys, error: nil) {
                             // If it is a Directory. Continue to next file URL.
-                            if let isDirectory = resourceValues[NSURLIsDirectoryKey]?.boolValue {
-                                if isDirectory {
+                            if let isDirectory = resourceValues[NSURLIsDirectoryKey] as? NSNumber {
+                                if isDirectory.boolValue {
                                     continue
                                 }
                             }


### PR DESCRIPTION
According to logs in #86 , it seems there is a case that Swift failed to convert `AnyObject` to its dynamic type correctly.

I believe this commit fixed it by an explicitly type casting. However. since I cannot reproduce the crash in my development environment, it is just an attempt for it without verification.