### PR TITLE
fix compile error on xcode 7 beta 5

### DIFF
--- a/Kingfisher/ImageCache.swift
+++ b/Kingfisher/ImageCache.swift
@@ -112,7 +112,7 @@ public class ImageCache {
         memoryCache.name = cacheName
         
         let paths = NSSearchPathForDirectoriesInDomains(.CachesDirectory, NSSearchPathDomainMask.UserDomainMask, true)
-        diskCachePath = paths.first!.stringByAppendingPathComponent(cacheName)
+        diskCachePath = (paths.first! as NSString).stringByAppendingPathComponent(cacheName)
         
         ioQueue = dispatch_queue_create(ioQueueName + name, DISPATCH_QUEUE_SERIAL)
         processQueue = dispatch_queue_create(processQueueName + name, DISPATCH_QUEUE_CONCURRENT)
@@ -613,7 +613,7 @@ extension ImageCache {
     
     func cachePathForKey(key: String) -> String {
         let fileName = cacheFileNameForKey(key)
-        return diskCachePath.stringByAppendingPathComponent(fileName)
+        return (diskCachePath as NSString).stringByAppendingPathComponent(fileName)
     }
     
     func cacheFileNameForKey(key: String) -> String {

--- a/KingfisherTests/ImageCacheTests.swift
+++ b/KingfisherTests/ImageCacheTests.swift
@@ -133,7 +133,7 @@ class ImageCacheTests: XCTestCase {
         
         storeMultipleImages { () -> () in
             let paths = NSSearchPathForDirectoriesInDomains(.CachesDirectory, NSSearchPathDomainMask.UserDomainMask, true)
-            let diskCachePath = paths.first!.stringByAppendingPathComponent(cacheName)
+            let diskCachePath = (paths.first! as NSString).stringByAppendingPathComponent(cacheName)
             
             let files: [AnyObject]?
             do {


### PR DESCRIPTION
stringByAppendingPathComponent seems to have become a NSString exclusive method on Xcode 7 beta 5, this is just a quick fix.