### PR TITLE
Fix a retain cycle

### DIFF
--- a/Kingfisher/Info.plist
+++ b/Kingfisher/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>267</string>
+	<string>268</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
There is a retain cycle because we are capturing self strongly within a closure, this is causing the memory to not released. This can easily be fixed by capturing the self as weak.