### PR TITLE
Fix options types

### DIFF
--- a/Kingfisher-Demo/Base.lproj/Main.storyboard
+++ b/Kingfisher-Demo/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D131" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="peg-r0-mlo">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="peg-r0-mlo">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -20,7 +21,7 @@
                         </collectionViewFlowLayout>
                         <cells>
                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="collectionViewCell" id="jYH-ix-b6K" customClass="CollectionViewCell" customModule="Kingfisher_Demo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="50" height="50"/>
+                                <rect key="frame" x="0.0" y="74" width="250" height="250"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
                                     <rect key="frame" x="0.0" y="0.0" width="250" height="250"/>

--- a/Kingfisher-Demo/ViewController.swift
+++ b/Kingfisher-Demo/ViewController.swift
@@ -63,7 +63,7 @@ extension ViewController {
         let URL = NSURL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher/master/images/kingfisher-\(indexPath.row + 1).jpg")!
         
         cell.cellImageView.kf_setImageWithURL(URL, placeholderImage: nil,
-                                                        optionsInfo: [.Transition: ImageTransition.Fade(1)],
+                                                        optionsInfo: [.Transition(ImageTransition.Fade(1))],
                                                       progressBlock: { (receivedSize, totalSize) -> () in
                                                           print("\(indexPath.row + 1): \(receivedSize)/\(totalSize)")
                                                       }) { (image, error, cacheType, imageURL) -> () in

--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		4B164AD01B8D556900768EC6 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B164ACE1B8D554200768EC6 /* CFNetwork.framework */; };
 		4B2C4DF81B7D7ACD000912CA /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2C4DF71B7D7ACD000912CA /* Resource.swift */; };
 		4B412CA51AE8A2F9008D530A /* KingfisherOptionsInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B412CA41AE8A2F9008D530A /* KingfisherOptionsInfo.swift */; };
+		4B5083381BD88C3E00AEA807 /* KingfisherManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5083371BD88C3E00AEA807 /* KingfisherManagerTests.swift */; };
 		4B6D4F651AE0A46D0084D15B /* UIImageViewExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6D4F641AE0A46D0084D15B /* UIImageViewExtensionTests.swift */; };
 		4B6D4F671AE0B82A0084D15B /* UIButtonExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6D4F661AE0B82A0084D15B /* UIButtonExtensionTests.swift */; };
 		4B82DDFC1AD7701900074995 /* ImageCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B82DDFB1AD7701900074995 /* ImageCacheTests.swift */; };
@@ -18,10 +19,10 @@
 		4BAFBA3D1AD671E400FB0300 /* CollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAFBA3C1AD671E400FB0300 /* CollectionViewCell.swift */; };
 		4BBA04C21AD795C500A5CF82 /* ImageDownloaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBA04C11AD795C500A5CF82 /* ImageDownloaderTests.swift */; };
 		4BBA04C41AD7986100A5CF82 /* KingfisherTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BBA04C31AD7986100A5CF82 /* KingfisherTestHelper.swift */; };
-		D11250C11BAC4B6300B986EF /* ImageTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D11250C01BAC4B6300B986EF /* ImageTransition.swift */; settings = {ASSET_TAGS = (); }; };
+		D11250C11BAC4B6300B986EF /* ImageTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D11250C01BAC4B6300B986EF /* ImageTransition.swift */; };
 		D151E72B1AD3C48D004FD4AE /* UIImage+Decode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D151E72A1AD3C48D004FD4AE /* UIImage+Decode.swift */; };
 		D166E4CD1B73820700B129E3 /* UIImage+Normalize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D166E4CC1B73820700B129E3 /* UIImage+Normalize.swift */; };
-		D1B1B9901BC7EB7100DE20D8 /* ThreadHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B1B98F1BC7EB7100DE20D8 /* ThreadHelper.swift */; settings = {ASSET_TAGS = (); }; };
+		D1B1B9901BC7EB7100DE20D8 /* ThreadHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B1B98F1BC7EB7100DE20D8 /* ThreadHelper.swift */; };
 		D1ED2D111AD2CFA600CFC3EB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1ED2D101AD2CFA600CFC3EB /* AppDelegate.swift */; };
 		D1ED2D131AD2CFA600CFC3EB /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1ED2D121AD2CFA600CFC3EB /* ViewController.swift */; };
 		D1ED2D161AD2CFA600CFC3EB /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D1ED2D141AD2CFA600CFC3EB /* Main.storyboard */; };
@@ -92,6 +93,7 @@
 		4B2C4DF71B7D7ACD000912CA /* Resource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
 		4B3E714D1B01FEB200F5AAED /* WatchKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchKit.framework; path = System/Library/Frameworks/WatchKit.framework; sourceTree = SDKROOT; };
 		4B412CA41AE8A2F9008D530A /* KingfisherOptionsInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KingfisherOptionsInfo.swift; sourceTree = "<group>"; };
+		4B5083371BD88C3E00AEA807 /* KingfisherManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KingfisherManagerTests.swift; sourceTree = "<group>"; };
 		4B6D4F641AE0A46D0084D15B /* UIImageViewExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageViewExtensionTests.swift; sourceTree = "<group>"; };
 		4B6D4F661AE0B82A0084D15B /* UIButtonExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonExtensionTests.swift; sourceTree = "<group>"; };
 		4B82DDFB1AD7701900074995 /* ImageCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCacheTests.swift; sourceTree = "<group>"; };
@@ -249,6 +251,7 @@
 				D1ED2D461AD2D09F00CFC3EB /* Supporting Files */,
 				4BBA04BD1AD77F7E00A5CF82 /* KingfisherTests-Bridging-Header.h */,
 				4BBA04C31AD7986100A5CF82 /* KingfisherTestHelper.swift */,
+				4B5083371BD88C3E00AEA807 /* KingfisherManagerTests.swift */,
 			);
 			path = KingfisherTests;
 			sourceTree = "<group>";
@@ -498,6 +501,7 @@
 				4B82DDFC1AD7701900074995 /* ImageCacheTests.swift in Sources */,
 				4BBA04C21AD795C500A5CF82 /* ImageDownloaderTests.swift in Sources */,
 				4B6D4F651AE0A46D0084D15B /* UIImageViewExtensionTests.swift in Sources */,
+				4B5083381BD88C3E00AEA807 /* KingfisherManagerTests.swift in Sources */,
 				4BBA04C41AD7986100A5CF82 /* KingfisherTestHelper.swift in Sources */,
 				4B6D4F671AE0B82A0084D15B /* UIButtonExtensionTests.swift in Sources */,
 			);

--- a/Kingfisher/Info.plist
+++ b/Kingfisher/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>277</string>
+	<string>279</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Kingfisher/Info.plist
+++ b/Kingfisher/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>283</string>
+	<string>286</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Kingfisher/Info.plist
+++ b/Kingfisher/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>267</string>
+	<string>277</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Kingfisher/Info.plist
+++ b/Kingfisher/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>279</string>
+	<string>280</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Kingfisher/KingfisherManager.swift
+++ b/Kingfisher/KingfisherManager.swift
@@ -118,38 +118,6 @@ public class KingfisherManager {
         progressBlock: DownloadProgressBlock?,
         completionHandler: CompletionHandler?) -> RetrieveImageTask
     {
-        func parseOptionsInfo(optionsInfo: KingfisherOptionsInfo?) -> (Options, ImageCache, ImageDownloader) {
-            var options = KingfisherManager.DefaultOptions
-            var targetCache = self.cache
-            var targetDownloader = self.downloader
-            
-            guard let optionsInfo = optionsInfo else {
-                return (options, targetCache, targetDownloader)
-            }
-            
-            if let optionsItem = optionsInfo.kf_findFirstMatch(.Options(.None)), case .Options(let optionsInOptionsInfo) = optionsItem {
-                
-                let queue = optionsInOptionsInfo.contains(KingfisherOptions.BackgroundCallback) ? dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) : KingfisherManager.DefaultOptions.queue
-                let scale = optionsInOptionsInfo.contains(KingfisherOptions.ScreenScale) ? UIScreen.mainScreen().scale : KingfisherManager.DefaultOptions.scale
-                
-                options = (forceRefresh: optionsInOptionsInfo.contains(KingfisherOptions.ForceRefresh),
-                    lowPriority: optionsInOptionsInfo.contains(KingfisherOptions.LowPriority),
-                    cacheMemoryOnly: optionsInOptionsInfo.contains(KingfisherOptions.CacheMemoryOnly),
-                    shouldDecode: optionsInOptionsInfo.contains(KingfisherOptions.BackgroundDecode),
-                    queue: queue, scale: scale)
-            }
-            
-            if let optionsItem = optionsInfo.kf_findFirstMatch(.TargetCache(self.cache)), case .TargetCache(let cache) = optionsItem {
-                targetCache = cache
-            }
-            
-            if let optionsItem = optionsInfo.kf_findFirstMatch(.Downloader(self.downloader)), case .Downloader(let downloader) = optionsItem {
-                targetDownloader = downloader
-            }
-            
-            return (options, targetCache, targetDownloader)
-        }
-        
         let task = RetrieveImageTask()
         
         // There is a bug in Swift compiler which prevents to write `let (options, targetCache) = parseOptionsInfo(optionsInfo)`
@@ -245,6 +213,38 @@ public class KingfisherManager {
             
             completionHandler?(image: image, error: error, cacheType: .None, imageURL: URL)
         }
+    }
+    
+    func parseOptionsInfo(optionsInfo: KingfisherOptionsInfo?) -> (Options, ImageCache, ImageDownloader) {
+        var options = KingfisherManager.DefaultOptions
+        var targetCache = self.cache
+        var targetDownloader = self.downloader
+        
+        guard let optionsInfo = optionsInfo else {
+            return (options, targetCache, targetDownloader)
+        }
+        
+        if let optionsItem = optionsInfo.kf_findFirstMatch(.Options(.None)), case .Options(let optionsInOptionsInfo) = optionsItem {
+            
+            let queue = optionsInOptionsInfo.contains(KingfisherOptions.BackgroundCallback) ? dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) : KingfisherManager.DefaultOptions.queue
+            let scale = optionsInOptionsInfo.contains(KingfisherOptions.ScreenScale) ? UIScreen.mainScreen().scale : KingfisherManager.DefaultOptions.scale
+            
+            options = (forceRefresh: optionsInOptionsInfo.contains(KingfisherOptions.ForceRefresh),
+                lowPriority: optionsInOptionsInfo.contains(KingfisherOptions.LowPriority),
+                cacheMemoryOnly: optionsInOptionsInfo.contains(KingfisherOptions.CacheMemoryOnly),
+                shouldDecode: optionsInOptionsInfo.contains(KingfisherOptions.BackgroundDecode),
+                queue: queue, scale: scale)
+        }
+        
+        if let optionsItem = optionsInfo.kf_findFirstMatch(.TargetCache(self.cache)), case .TargetCache(let cache) = optionsItem {
+            targetCache = cache
+        }
+        
+        if let optionsItem = optionsInfo.kf_findFirstMatch(.Downloader(self.downloader)), case .Downloader(let downloader) = optionsItem {
+            targetDownloader = downloader
+        }
+        
+        return (options, targetCache, targetDownloader)
     }
 }
 

--- a/Kingfisher/KingfisherOptionsInfo.swift
+++ b/Kingfisher/KingfisherOptionsInfo.swift
@@ -27,21 +27,43 @@
 import Foundation
 
 /**
-*	KingfisherOptionsInfo is a typealias for [KingfisherOptionsInfoKey: Any]. You can use the key-value pairs to control some behaviors of Kingfisher.
+*	KingfisherOptionsInfo is a typealias for [KingfisherOptionsInfoItem]. You can use the enum of option item with value to control some behaviors of Kingfisher.
 */
-public typealias KingfisherOptionsInfo = [KingfisherOptionsInfoKey: Any]
+public typealias KingfisherOptionsInfo = [KingfisherOptionsInfoItem]
 
 /**
-Key for KingfisherOptionsInfo
+Item could be added into KingfisherOptionsInfo
 
-- Options:     Key for options. The value for this key should be a KingfisherOptions.
-- TargetCache: Key for target cache. The value for this key should be an ImageCache object.Kingfisher will use this cache when handling the related operation, including trying to retrieve the cached images and store the downloaded image to it.
-- Downloader:  Key for downloader to use. The value for this key should be an ImageDownloader object. Kingfisher will use this downloader to download the images.
-- Transition:  Key for animation transition when using UIImageView.
+- Options:     Item for options. The value of this item should be a KingfisherOptions.
+- TargetCache: Item for target cache. The value of this item should be an ImageCache object. Kingfisher will use this cache when handling the related operation, including trying to retrieve the cached images and store the downloaded image to it.
+- Downloader:  Item for downloader to use. The value of this item should be an ImageDownloader object. Kingfisher will use this downloader to download the images.
+- Transition:  Item for animation transition when using UIImageView.
 */
-public enum KingfisherOptionsInfoKey {
-    case Options
-    case TargetCache
-    case Downloader
-    case Transition
+public enum KingfisherOptionsInfoItem {
+    case Options(KingfisherOptions)
+    case TargetCache(ImageCache)
+    case Downloader(ImageDownloader)
+    case Transition(ImageTransition)
+}
+
+func ==(a: KingfisherOptionsInfoItem, b: KingfisherOptionsInfoItem) -> Bool {
+    switch (a, b) {
+    case (.Options(_), .Options(_)): return true
+    case (.TargetCache(_), .TargetCache(_)): return true
+    case (.Downloader(_), .Downloader(_)): return true
+    case (.Transition(_), .Transition(_)): return true
+    default: return false
+    }
+}
+
+extension CollectionType where Generator.Element == KingfisherOptionsInfoItem {
+    func kf_findFirstMatch(target: Generator.Element) -> Generator.Element? {
+        
+        let index = indexOf {
+            e in
+            return e == target
+        }
+        
+        return (index != nil) ? self[index!] : nil
+    }
 }

--- a/Kingfisher/UIButton+Kingfisher.swift
+++ b/Kingfisher/UIButton+Kingfisher.swift
@@ -535,7 +535,7 @@ public extension UIButton {
                       placeholderImage: UIImage?,
                                options: KingfisherOptions) -> RetrieveImageTask
     {
-        return kf_setImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options: options], progressBlock: nil, completionHandler: nil)
+        return kf_setImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options(options)], progressBlock: nil, completionHandler: nil)
     }
     
     @available(*, deprecated=1.2, message="Use -kf_setImageWithURL:forState:placeholderImage:optionsInfo:completionHandler: instead.")
@@ -545,7 +545,7 @@ public extension UIButton {
                                options: KingfisherOptions,
                      completionHandler: CompletionHandler?) -> RetrieveImageTask
     {
-        return kf_setImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options: options], progressBlock: nil, completionHandler: completionHandler)
+        return kf_setImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options(options)], progressBlock: nil, completionHandler: completionHandler)
     }
     
     @available(*, deprecated=1.2, message="Use -kf_setImageWithURL:forState:placeholderImage:optionsInfo:progressBlock:completionHandler: instead.")
@@ -556,7 +556,7 @@ public extension UIButton {
                          progressBlock: DownloadProgressBlock?,
                      completionHandler: CompletionHandler?) -> RetrieveImageTask
     {
-        return kf_setImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options: options], progressBlock: progressBlock, completionHandler: completionHandler)
+        return kf_setImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options(options)], progressBlock: progressBlock, completionHandler: completionHandler)
     }
     
     @available(*, deprecated=1.2, message="Use -kf_setBackgroundImageWithURL:forState:placeholderImage:optionsInfo: instead.")
@@ -565,7 +565,7 @@ public extension UIButton {
                                 placeholderImage: UIImage?,
                                          options: KingfisherOptions) -> RetrieveImageTask
     {
-        return kf_setBackgroundImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options: options], progressBlock: nil, completionHandler: nil)
+        return kf_setBackgroundImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options(options)], progressBlock: nil, completionHandler: nil)
     }
     
     @available(*, deprecated=1.2, message="Use -kf_setBackgroundImageWithURL:forState:placeholderImage:optionsInfo:completionHandler: instead.")
@@ -575,7 +575,7 @@ public extension UIButton {
                                          options: KingfisherOptions,
                                completionHandler: CompletionHandler?) -> RetrieveImageTask
     {
-        return kf_setBackgroundImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options: options], progressBlock: nil, completionHandler: completionHandler)
+        return kf_setBackgroundImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options(options)], progressBlock: nil, completionHandler: completionHandler)
     }
     
     
@@ -587,7 +587,7 @@ public extension UIButton {
                                    progressBlock: DownloadProgressBlock?,
                                completionHandler: CompletionHandler?) -> RetrieveImageTask
     {
-        return kf_setBackgroundImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options: options], progressBlock: progressBlock, completionHandler: completionHandler)
+        return kf_setBackgroundImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: [.Options(options)], progressBlock: progressBlock, completionHandler: completionHandler)
     }
 }
 

--- a/Kingfisher/UIImageView+Kingfisher.swift
+++ b/Kingfisher/UIImageView+Kingfisher.swift
@@ -198,7 +198,10 @@ public extension UIImageView {
                 
                 dispatch_async_safely_main_queue {
                     if let sSelf = self where imageURL == sSelf.kf_webURL && image != nil {
-                        if let transition = optionsInfo?[.Transition] as? ImageTransition {
+                        
+                        if let transitionItem = optionsInfo?.kf_findFirstMatch(.Transition(.None)),
+                            case .Transition(let transition) = transitionItem {
+                            
                             UIView.transitionWithView(sSelf, duration: 0.0, options: [], animations: { () -> Void in
                                 indicator?.stopAnimating()
                                 }, completion: { (finished) -> Void in
@@ -321,7 +324,7 @@ public extension UIImageView {
                       placeholderImage: UIImage?,
                                options: KingfisherOptions) -> RetrieveImageTask
     {
-        return kf_setImageWithURL(URL, placeholderImage: placeholderImage, optionsInfo: [.Options: options], progressBlock: nil, completionHandler: nil)
+        return kf_setImageWithURL(URL, placeholderImage: placeholderImage, optionsInfo: [.Options(options)], progressBlock: nil, completionHandler: nil)
     }
     
     @available(*, deprecated=1.2, message="Use -kf_setImageWithURL:placeholderImage:optionsInfo:completionHandler: instead.")
@@ -330,7 +333,7 @@ public extension UIImageView {
                                options: KingfisherOptions,
                      completionHandler: CompletionHandler?) -> RetrieveImageTask
     {
-        return kf_setImageWithURL(URL, placeholderImage: placeholderImage, optionsInfo: [.Options: options], progressBlock: nil, completionHandler: completionHandler)
+        return kf_setImageWithURL(URL, placeholderImage: placeholderImage, optionsInfo: [.Options(options)], progressBlock: nil, completionHandler: completionHandler)
     }
     
     @available(*, deprecated=1.2, message="Use -kf_setImageWithURL:placeholderImage:optionsInfo:progressBlock:completionHandler: instead.")
@@ -340,7 +343,7 @@ public extension UIImageView {
                          progressBlock: DownloadProgressBlock?,
                      completionHandler: CompletionHandler?) -> RetrieveImageTask
     {
-        return kf_setImageWithURL(URL, placeholderImage: placeholderImage, optionsInfo: [.Options: options], progressBlock: progressBlock, completionHandler: completionHandler)
+        return kf_setImageWithURL(URL, placeholderImage: placeholderImage, optionsInfo: [.Options(options)], progressBlock: progressBlock, completionHandler: completionHandler)
     }
     
 }

--- a/KingfisherTests/ImageCacheTests.swift
+++ b/KingfisherTests/ImageCacheTests.swift
@@ -211,7 +211,9 @@ class ImageCacheTests: XCTestCase {
         format = testImagePNGData.kf_imageFormat
         XCTAssertEqual(format, ImageFormat.PNG)
         
-        format = NSData(bytes: [1,2,3,4,5,6,7,8], length: 8) .kf_imageFormat
+        let raw: [UInt8] = [1,2,3,4,5,6,7,8]
+        
+        format = NSData(bytes: raw, length: 8).kf_imageFormat
         XCTAssertEqual(format, ImageFormat.Unknown)
     }
 

--- a/KingfisherTests/KingfisherManagerTests.swift
+++ b/KingfisherTests/KingfisherManagerTests.swift
@@ -1,0 +1,42 @@
+//
+//  KingfisherManagerTests.swift
+//  Kingfisher
+//
+//  Created by WANG WEI on 2015/10/22.
+//  Copyright © 2015年 Wei Wang. All rights reserved.
+//
+
+import XCTest
+@testable import Kingfisher
+
+class KingfisherManagerTests: XCTestCase {
+    
+    var manager: KingfisherManager!
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+        manager = KingfisherManager()
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        manager = nil
+        super.tearDown()
+    }
+    
+    func testParseNilOptions() {
+        let optionsInfo: KingfisherOptionsInfo? = nil
+        let result = manager.parseOptionsInfo(optionsInfo)
+        
+        XCTAssertEqual(result.0.forceRefresh, KingfisherManager.DefaultOptions.forceRefresh)
+        XCTAssertEqual(result.0.lowPriority, KingfisherManager.DefaultOptions.lowPriority)
+        XCTAssertEqual(result.0.cacheMemoryOnly, KingfisherManager.DefaultOptions.cacheMemoryOnly)
+        XCTAssertEqual(result.0.shouldDecode, KingfisherManager.DefaultOptions.shouldDecode)
+        XCTAssertEqual(result.0.scale, KingfisherManager.DefaultOptions.scale)
+        
+        XCTAssertTrue(result.1 === manager.cache)
+        XCTAssertEqual(result.2, manager.downloader)
+    }
+    
+}

--- a/KingfisherTests/KingfisherManagerTests.swift
+++ b/KingfisherTests/KingfisherManagerTests.swift
@@ -39,4 +39,39 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertEqual(result.2, manager.downloader)
     }
     
+    func testParseSingleOptions() {
+        let cache = ImageCache(name: "KingfisherManagerTests")
+        let optionsInfo: KingfisherOptionsInfo = [.Options(.ForceRefresh), .TargetCache(cache)]
+        let result = manager.parseOptionsInfo(optionsInfo)
+        
+        XCTAssertEqual(result.0.forceRefresh, true)
+        XCTAssertEqual(result.0.lowPriority, KingfisherManager.DefaultOptions.lowPriority)
+        XCTAssertEqual(result.0.cacheMemoryOnly, KingfisherManager.DefaultOptions.cacheMemoryOnly)
+        XCTAssertEqual(result.0.shouldDecode, KingfisherManager.DefaultOptions.shouldDecode)
+        XCTAssertEqual(result.0.scale, KingfisherManager.DefaultOptions.scale)
+        
+        XCTAssertTrue(result.1 === cache)
+        XCTAssertTrue(result.1 !== manager.cache)
+        XCTAssertEqual(result.2, manager.downloader)
+    }
+    
+    func testParseMultipleOptions() {
+        let cache = ImageCache(name: "KingfisherManagerTests")
+        let downloader = ImageDownloader(name: "KingfisherManagerTests")
+        let optionsInfo: KingfisherOptionsInfo = [.Options([.ForceRefresh, .CacheMemoryOnly]),
+                                                  .TargetCache(cache),
+                                                  .Downloader(downloader)]
+        let result = manager.parseOptionsInfo(optionsInfo)
+        
+        XCTAssertEqual(result.0.forceRefresh, true)
+        XCTAssertEqual(result.0.lowPriority, KingfisherManager.DefaultOptions.lowPriority)
+        XCTAssertEqual(result.0.cacheMemoryOnly, true)
+        XCTAssertEqual(result.0.shouldDecode, KingfisherManager.DefaultOptions.shouldDecode)
+        XCTAssertEqual(result.0.scale, KingfisherManager.DefaultOptions.scale)
+        
+        XCTAssertTrue(result.1 === cache)
+        XCTAssertFalse(result.1 === manager.cache)
+        XCTAssertEqual(result.2, downloader)
+        XCTAssertNotEqual(result.2, manager.downloader)
+    }
 }

--- a/KingfisherTests/UIImageViewExtensionTests.swift
+++ b/KingfisherTests/UIImageViewExtensionTests.swift
@@ -273,7 +273,7 @@ class UIImageViewExtensionTests: XCTestCase {
         stubRequest("GET", URLString).andReturn(200).withBody(testImageData)
         let URL = NSURL(string: URLString)!
         
-        imageView.kf_setImageWithURL(URL, placeholderImage: nil, optionsInfo: [.TargetCache: cache1], progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf_setImageWithURL(URL, placeholderImage: nil, optionsInfo: [.TargetCache(cache1)], progressBlock: { (receivedSize, totalSize) -> () in
             
         }) { (image, error, cacheType, imageURL) -> () in
             
@@ -281,7 +281,7 @@ class UIImageViewExtensionTests: XCTestCase {
             XCTAssertFalse(cache2.isImageCachedForKey(URLString).cached, "This image should not be cached in cache2.")
             XCTAssertFalse(KingfisherManager.sharedManager.cache.isImageCachedForKey(URLString).cached, "This image should not be cached in default cache.")
             
-            self.imageView.kf_setImageWithURL(URL, placeholderImage: nil, optionsInfo: [.TargetCache: cache2], progressBlock: { (receivedSize, totalSize) -> () in
+            self.imageView.kf_setImageWithURL(URL, placeholderImage: nil, optionsInfo: [.TargetCache(cache2)], progressBlock: { (receivedSize, totalSize) -> () in
                 
             }, completionHandler: { (image, error, cacheType, imageURL) -> () in
                 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Kingfisher will search in cache (both memory and disk) first with the URL, if no
 ```swift
 imageView.kf_setImageWithURL(NSURL(string: "your_image_url")!,
                          placeholderImage: nil,
-                              optionsInfo: [.Options: KingfisherOptions.ForceRefresh])
+                              optionsInfo: [.Options(KingfisherOptions.ForceRefresh))
 ```
 
 There are also other options to control the cache level, downloading priority, etc. Take some other examples:
@@ -171,7 +171,7 @@ let myCache = ImageCache(name: "my_cache")
 
 imageView.kf_setImageWithURL(NSURL(string: "your_image_url")!,
                          placeholderImage: nil,
-                              optionsInfo: [.TargetCache: myCache])
+                              optionsInfo: [.TargetCache(myCache))
 ```
 
 This is useful if you want to use a specified cache for some reasons.
@@ -181,7 +181,7 @@ And if you need to fade in the image to image view during 1 second:
 ```
 imageView.kf_setImageWithURL(NSURL(string: "your_image_url")!,
                          placeholderImage: nil,
-                              optionsInfo: [.Transition: ImageTransition.Fade(1)])
+                              optionsInfo: [.Transition(ImageTransition.Fade(1)))
 ```
 
 For more information about options, please see the `KingfisherOptionsInfo` in the [documentation](http://cocoadocs.org/docsets/Kingfisher/index.html).


### PR DESCRIPTION
This p-r fixed the #123, by introducing a type-safe way to use `KingfisherOptionsInfo`.

It will break current code if you are using options. But it is fairly easy to fix it. Just change your original code

```swift
let optionsInfos: KingfisherOptionsInfo = 
[
    .Options: [KingfisherOptions.CacheMemoryOnly, KingfisherOptions.ForceRefresh], 
    .Transition: ImageTransition.Fade(1)
]
```

to something like this:

```swift
let optionsInfos: KingfisherOptionsInfo = 
[
    .Options([KingfisherOptions.CacheMemoryOnly, KingfisherOptions.ForceRefresh]), 
    .Transition(ImageTransition.Fade(1))
]
```