### PR TITLE
一点提高可读性的修改

### DIFF
--- a/Kingfisher/KingfisherManager.swift
+++ b/Kingfisher/KingfisherManager.swift
@@ -135,28 +135,15 @@ public class KingfisherManager {
                 targetCache: targetCache,
                 downloader: downloader)
         } else {
-            let diskTaskCompletionHandler: CompletionHandler = { (image, error, cacheType, imageURL) -> () in
-                // Break retain cycle created inside diskTask closure below
-                task.diskRetrieveTask = nil
-                completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
-            }
-            let diskTask = targetCache.retrieveImageForKey(resource.cacheKey, options: options, completionHandler: { (image, cacheType) -> () in
-                if image != nil {
-                    diskTaskCompletionHandler(image: image, error: nil, cacheType:cacheType, imageURL: resource.downloadURL)
-                } else {
-                    self.downloadAndCacheImageWithURL(resource.downloadURL,
-                        forKey: resource.cacheKey,
-                        retrieveImageTask: task,
-                        progressBlock: progressBlock,
-                        completionHandler: diskTaskCompletionHandler,
-                        options: options,
-                        targetCache: targetCache,
-                        downloader: downloader)
-                }
-            })
-            task.diskRetrieveTask = diskTask
+            tryToRetrieveImageFromCacheForKey(resource.cacheKey,
+                withURL: resource.downloadURL,
+                retrieveImageTask: task,
+                progressBlock: progressBlock,
+                completionHandler: completionHandler,
+                options: options,
+                targetCache: targetCache,
+                downloader: downloader)
         }
-        
         return task
     }
 
@@ -214,6 +201,40 @@ public class KingfisherManager {
             completionHandler?(image: image, error: error, cacheType: .None, imageURL: URL)
         }
     }
+    
+    func tryToRetrieveImageFromCacheForKey(key: String,
+        withURL URL: NSURL,
+        retrieveImageTask: RetrieveImageTask,
+        progressBlock: DownloadProgressBlock?,
+        completionHandler: CompletionHandler?,
+        options: Options,
+        targetCache: ImageCache,
+        downloader: ImageDownloader)
+    {
+        let diskTaskCompletionHandler: CompletionHandler = { (image, error, cacheType, imageURL) -> () in
+            // Break retain cycle created inside diskTask closure below
+            retrieveImageTask.diskRetrieveTask = nil
+            completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+        }
+        let diskTask = targetCache.retrieveImageForKey(key, options: options,
+            completionHandler: { image, cacheType in
+                if image != nil {
+                    diskTaskCompletionHandler(image: image, error: nil, cacheType:cacheType, imageURL: URL)
+                } else {
+                    self.downloadAndCacheImageWithURL(URL,
+                        forKey: key,
+                        retrieveImageTask: retrieveImageTask,
+                        progressBlock: progressBlock,
+                        completionHandler: diskTaskCompletionHandler,
+                        options: options,
+                        targetCache: targetCache,
+                        downloader: downloader)
+                }
+            }
+        )
+        retrieveImageTask.diskRetrieveTask = diskTask
+    }
+
     
     func parseOptionsInfo(optionsInfo: KingfisherOptionsInfo?) -> (Options, ImageCache, ImageDownloader) {
         var options = KingfisherManager.DefaultOptions

--- a/Kingfisher/KingfisherOptionsInfo.swift
+++ b/Kingfisher/KingfisherOptionsInfo.swift
@@ -37,7 +37,7 @@ Item could be added into KingfisherOptionsInfo
 - Options:     Item for options. The value of this item should be a KingfisherOptions.
 - TargetCache: Item for target cache. The value of this item should be an ImageCache object. Kingfisher will use this cache when handling the related operation, including trying to retrieve the cached images and store the downloaded image to it.
 - Downloader:  Item for downloader to use. The value of this item should be an ImageDownloader object. Kingfisher will use this downloader to download the images.
-- Transition:  Item for animation transition when using UIImageView.
+- Transition:  Item for animation transition when using UIImageView. Kingfisher will use the `ImageTransition` of this enum to animate the image in if it is downloaded from web. The transition will not happen when the image is retrieved from either memory or disk cache.
 */
 public enum KingfisherOptionsInfoItem {
     case Options(KingfisherOptions)
@@ -46,7 +46,12 @@ public enum KingfisherOptionsInfoItem {
     case Transition(ImageTransition)
 }
 
-func ==(a: KingfisherOptionsInfoItem, b: KingfisherOptionsInfoItem) -> Bool {
+infix operator <== {
+    associativity none
+    precedence 160
+}
+
+func <== (a: KingfisherOptionsInfoItem, b: KingfisherOptionsInfoItem) -> Bool {
     switch (a, b) {
     case (.Options(_), .Options(_)): return true
     case (.TargetCache(_), .TargetCache(_)): return true
@@ -61,7 +66,7 @@ extension CollectionType where Generator.Element == KingfisherOptionsInfoItem {
         
         let index = indexOf {
             e in
-            return e == target
+            return e <== target
         }
         
         return (index != nil) ? self[index!] : nil


### PR DESCRIPTION
将重载操作符'=='改为自定义操作符'<=='，等号有点不符合直觉，我第一次读的时候看到optionsItem = optionsInfo.kf_findFirstMatch(.Options(.None))，然后去看了kf_findFirstMatch的定义，总感觉这个optionsItem就该是.Options(.None)，怎么能匹配到别的.Options……直到无意间瞟到上面重载等号的代码……

将从缓存中取图片的过程提取为tryToRetrieveImageFromCacheForKey函数，这样在retrieveImageWithResource中判断options.forceRefresh是否为true，是就调用downloadAndCacheImageWithURL，否则调用tryToRetrieveImageFromCacheForKey。看上去对称一些，意图更清晰。

一点无关紧要的小建议^ ^