### PR TITLE
Replace println() with print()

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,10 @@ imageView.kf_setImageWithURL(NSURL(string: "your_image_url")!,
                          placeholderImage: nil,
                               optionsInfo: nil,
                             progressBlock: { (receivedSize, totalSize) -> () in
-                                println("Download Progress: \(receivedSize)/\(totalSize)")
+                                print("Download Progress: \(receivedSize)/\(totalSize)")
                             },
                         completionHandler: { (image, error, imageURL) -> () in
-                            println("Downloaded and set!")
+                            print("Downloaded and set!")
                         }
 )
 ```
@@ -259,7 +259,7 @@ cache.maxCachePeriodInSecond = 60 * 60 * 24 * 3
 
 // Get the disk size taken by the cache.
 cache.calculateDiskCacheSizeWithCompletionHandler { (size) -> () in
-    println("disk size in bytes: \(size)")
+    print("disk size in bytes: \(size)")
 }
 ```
 


### PR DESCRIPTION
println() has been renamed print() in Swift 2.0