### PR TITLE
Do not decode an animated image.

### DIFF
--- a/Kingfisher/UIImage+Extension.swift
+++ b/Kingfisher/UIImage+Extension.swift
@@ -67,6 +67,10 @@ extension UIImage {
     }
     
     func kf_decodedImage(scale scale: CGFloat) -> UIImage? {
+        if images != nil {
+            return self
+        }
+
         let imageRef = self.CGImage
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.PremultipliedLast.rawValue).rawValue

--- a/Kingfisher/UIImage+Extension.swift
+++ b/Kingfisher/UIImage+Extension.swift
@@ -67,6 +67,7 @@ extension UIImage {
     }
     
     func kf_decodedImage(scale scale: CGFloat) -> UIImage? {
+        // prevent animated image (GIF) lose it's images
         if images != nil {
             return self
         }


### PR DESCRIPTION
If a GIF image has been decoded, it will lose it's images, become a static image.

请作者看看是否有必要对 images 内的图像再做 decode？