### PR TITLE
use originalData in favour of image

### DIFF
--- a/Kingfisher/ImageCache.swift
+++ b/Kingfisher/ImageCache.swift
@@ -187,9 +187,9 @@ public extension ImageCache {
                 
                 let data: NSData?
                 switch imageFormat {
-                case .PNG: data = UIImagePNGRepresentation(image)
-                case .JPEG: data = UIImageJPEGRepresentation(image, 1.0)
-                case .GIF: data = UIImageGIFRepresentation(image)
+                case .PNG: data = originalData ?? UIImagePNGRepresentation(image)
+                case .JPEG: data = originalData ?? UIImageJPEGRepresentation(image, 1.0)
+                case .GIF: data = originalData ?? UIImageGIFRepresentation(image)
                 case .Unknown: data = originalData ?? UIImagePNGRepresentation(image.kf_normalizedImage())
                 }
                 


### PR DESCRIPTION
This is a followup pull request on #202.
If originalData is available it will be used in favour of the supplied image to store to the cache.

This will omit compressing the image in case of a JPEG.
