### PR TITLE
queue management is moved into manager

### DIFF
--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -199,16 +199,11 @@ extension ImageView {
         let task = KingfisherManager.sharedManager.retrieveImageWithResource(resource, optionsInfo: optionsInfo,
             progressBlock: { receivedSize, totalSize in
                 if let progressBlock = progressBlock {
-                    dispatch_async(dispatch_get_main_queue(), { () -> Void in
-                        progressBlock(receivedSize: receivedSize, totalSize: totalSize)
-                        
-                    })
+                    progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 }
             },
             completionHandler: {[weak self] image, error, cacheType, imageURL in
                 
-                dispatch_async_safely_main_queue {
-                    
                     guard let sSelf = self where imageURL == sSelf.kf_webURL else {
                         completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                         return
@@ -247,7 +242,6 @@ extension ImageView {
                         sSelf.image = image
                         completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                     }
-                }
             })
         
         kf_setImageTask(task)

--- a/Sources/KingfisherManager.swift
+++ b/Sources/KingfisherManager.swift
@@ -86,6 +86,9 @@ public class KingfisherManager {
     /// Downloader used by this manager
     public var downloader: ImageDownloader
     
+    /// The dispatch queue for `completionBlock`. If `NULL` (default), the main queue is used.
+    public var completionQueue: dispatch_queue_t?
+    
     /**
     Default init method
     
@@ -169,7 +172,9 @@ public class KingfisherManager {
         let downloader = options?.downloader ?? self.downloader
         downloader.downloadImageWithURL(URL, retrieveImageTask: retrieveImageTask, options: options,
             progressBlock: { receivedSize, totalSize in
-                progressBlock?(receivedSize: receivedSize, totalSize: totalSize)
+                dispatch_async(dispatch_get_main_queue(), { () -> Void in
+                    progressBlock?(receivedSize: receivedSize, totalSize: totalSize)
+                })
             },
             completionHandler: { image, error, imageURL, originalData in
 
@@ -177,9 +182,10 @@ public class KingfisherManager {
                 if let error = error where error.code == KingfisherError.NotModified.rawValue {
                     // Not modified. Try to find the image from cache.
                     // (The image should be in cache. It should be guaranteed by the framework users.)
-                    targetCache.retrieveImageForKey(key, options: options, completionHandler: { (cacheImage, cacheType) -> () in
-                        completionHandler?(image: cacheImage, error: nil, cacheType: cacheType, imageURL: URL)
-                        
+                    targetCache.retrieveImageForKey(key, options: options, completionHandler: { [unowned self] (cacheImage, cacheType) -> () in
+                        dispatch_async_safely_queue(self.completionQueue, block: { () -> () in
+                            completionHandler?(image: cacheImage, error: nil, cacheType: cacheType, imageURL: URL)
+                        })
                     })
                     return
                 }
@@ -188,7 +194,9 @@ public class KingfisherManager {
                     targetCache.storeImage(image, originalData: originalData, forKey: key, toDisk: !(options?.cacheMemoryOnly ?? false), completionHandler: nil)
                 }
                 
-                completionHandler?(image: image, error: error, cacheType: .None, imageURL: URL)
+                dispatch_async_safely_queue(self.completionQueue, block: { () -> () in
+                    completionHandler?(image: image, error: error, cacheType: .None, imageURL: URL)
+                })
             })
     }
     
@@ -202,7 +210,9 @@ public class KingfisherManager {
         let diskTaskCompletionHandler: CompletionHandler = { (image, error, cacheType, imageURL) -> () in
             // Break retain cycle created inside diskTask closure below
             retrieveImageTask.diskRetrieveTask = nil
-            completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+            dispatch_async_safely_queue(self.completionQueue, block: { () -> () in
+                completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+            })
         }
         
         let targetCache = options?.targetCache ?? cache

--- a/Sources/KingfisherOptionsInfo.swift
+++ b/Sources/KingfisherOptionsInfo.swift
@@ -47,7 +47,7 @@ Items could be added into KingfisherOptionsInfo.
 - ForceRefresh: If set, `Kingfisher` will ignore the cache and try to fire a download task for the resource.
 - CacheMemoryOnly: If set, `Kingfisher` will only cache the value in memory but not in disk.
 - BackgroundDecode: Decode the image in background thread before using.
-- CallbackDispatchQueue: The associated value of this member will be used as the target queue of dispatch callbacks when retrieving images from cache. If not set, `Kingfisher` will use main quese for callbacks.
+- CallbackDispatchQueue: The associated value of this member will be used as the target queue of dispatch callbacks when retrieving images. If not set, `Kingfisher` will use main quese for callbacks.
 - ScaleFactor: The associated value of this member will be used as the scale factor when converting retrieved data to an image.
 */
 public enum KingfisherOptionsInfoItem {
@@ -140,13 +140,13 @@ extension CollectionType where Generator.Element == KingfisherOptionsInfoItem {
         return contains{ $0 <== .BackgroundDecode }
     }
     
-    var callbackDispatchQueue: dispatch_queue_t {
+    var callbackDispatchQueue: dispatch_queue_t? {
         if let item = kf_firstMatchIgnoringAssociatedValue(.CallbackDispatchQueue(nil)),
             case .CallbackDispatchQueue(let queue) = item
         {
-            return queue ?? dispatch_get_main_queue()
+            return queue
         }
-        return dispatch_get_main_queue()
+        return nil
     }
     
     var scaleFactor: CGFloat {

--- a/Sources/ThreadHelper.swift
+++ b/Sources/ThreadHelper.swift
@@ -26,7 +26,7 @@
 
 import Foundation
 
-func dispatch_async_safely_queue(queue: dispatch_queue_t?, block: ()->()) {
+func dispatch_async_safely(queue: dispatch_queue_t?, block: ()->()) {
     if let queue = queue {
         dispatch_async(queue, { () -> Void in
             block()

--- a/Sources/ThreadHelper.swift
+++ b/Sources/ThreadHelper.swift
@@ -26,8 +26,12 @@
 
 import Foundation
 
-func dispatch_async_safely_main_queue(block: ()->()) {
-    if NSThread.isMainThread() {
+func dispatch_async_safely_queue(queue: dispatch_queue_t?, block: ()->()) {
+    if let queue = queue {
+        dispatch_async(queue, { () -> Void in
+            block()
+        })
+    } else if NSThread.isMainThread() {
         block()
     } else {
         dispatch_async(dispatch_get_main_queue()) {

--- a/Sources/UIButton+Kingfisher.swift
+++ b/Sources/UIButton+Kingfisher.swift
@@ -200,23 +200,19 @@ extension UIButton {
         let task = KingfisherManager.sharedManager.retrieveImageWithResource(resource, optionsInfo: optionsInfo,
             progressBlock: { receivedSize, totalSize in
                 if let progressBlock = progressBlock {
-                    dispatch_async(dispatch_get_main_queue(), { () -> Void in
-                        progressBlock(receivedSize: receivedSize, totalSize: totalSize)
-                    })
+                    progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 }
             },
             completionHandler: {[weak self] image, error, cacheType, imageURL in
                 
-                dispatch_async_safely_main_queue {
-                    if let sSelf = self {
-                        
-                        sSelf.kf_setImageTask(nil)
-                        
-                        if imageURL == sSelf.kf_webURLForState(state) && image != nil {
-                            sSelf.setImage(image, forState: state)
-                        }
-                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                if let sSelf = self {
+                    
+                    sSelf.kf_setImageTask(nil)
+                    
+                    if imageURL == sSelf.kf_webURLForState(state) && image != nil {
+                        sSelf.setImage(image, forState: state)
                     }
+                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                 }
             })
         
@@ -465,23 +461,19 @@ extension UIButton {
         let task = KingfisherManager.sharedManager.retrieveImageWithResource(resource, optionsInfo: optionsInfo,
             progressBlock: { receivedSize, totalSize in
                 if let progressBlock = progressBlock {
-                    dispatch_async(dispatch_get_main_queue(), { () -> Void in
-                        progressBlock(receivedSize: receivedSize, totalSize: totalSize)
-                    })
+                    progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 }
             },
             completionHandler: { [weak self] image, error, cacheType, imageURL in
-                dispatch_async_safely_main_queue {
+                
+                if let sSelf = self {
                     
-                    if let sSelf = self {
-                        
-                        sSelf.kf_setBackgroundImageTask(nil)
-                        
-                        if imageURL == sSelf.kf_backgroundWebURLForState(state) && image != nil {
-                            sSelf.setBackgroundImage(image, forState: state)
-                        }
-                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                    sSelf.kf_setBackgroundImageTask(nil)
+                    
+                    if imageURL == sSelf.kf_backgroundWebURLForState(state) && image != nil {
+                        sSelf.setBackgroundImage(image, forState: state)
                     }
+                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                 }
             })
         

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -147,14 +147,14 @@ class KingfisherManagerTests: XCTestCase {
     }
     
     func testRunningOnCustomQueue() {
-        manager.completionQueue = dispatch_queue_create("com.kingfisher.testQueue", DISPATCH_QUEUE_CONCURRENT)
         let expectation = expectationWithDescription("running on custom queue")
         let URLString = testKeys[0]
         stubRequest("GET", URLString).andReturn(200).withBody(testImageData)
         
         let URL = NSURL(string: URLString)!
         
-        manager.retrieveImageWithURL(URL, optionsInfo: nil, progressBlock: { _, _ in
+        let customQueue = dispatch_queue_create("com.kingfisher.testQueue", DISPATCH_QUEUE_SERIAL)
+        manager.retrieveImageWithURL(URL, optionsInfo: [.CallbackDispatchQueue(customQueue)], progressBlock: { _, _ in
             XCTAssertTrue(NSThread.isMainThread())
             }, completionHandler: { _, _, _, _ in
                 XCTAssertEqual(String(UTF8String: dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL))!, "com.kingfisher.testQueue")


### PR DESCRIPTION
从我自己的使用角度出发，我觉得图片下载的 progress block 和 completion block 在绝大多数情况下都是涉及到 UIKit 中的类的操作，也就是应该在主线程上运行。所以这个 PR 尝试采取类似 AFNetworking 中 manager 的 queue 处理方式，将图片下载完成后的回调默认在主线程上运行，当要在非主线程运行时需要显示地为 manager 的 property completionQueue 赋值。