### PR TITLE
move queue dispatch code into ImageDownloader

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -276,10 +276,11 @@ extension ImageCache {
         }
         
         var block: RetrieveImageDiskTask?
+        let options = options ?? KingfisherEmptyOptionsInfo
+        
         if let image = self.retrieveImageInMemoryCacheForKey(key) {
-            
             //Found image in memory cache.
-            if let options = options where options.backgroundDecode {
+            if options.backgroundDecode {
                 dispatch_async(self.processQueue, { () -> Void in
                     let result = image.kf_decodedImage(scale: options.scaleFactor)
                     dispatch_async(options.callbackDispatchQueue, { () -> Void in
@@ -287,13 +288,14 @@ extension ImageCache {
                     })
                 })
             } else {
-                completionHandler(image, .Memory)
+                dispatch_async(options.callbackDispatchQueue, { () -> Void in
+                    completionHandler(image, .Memory)
+                })
             }
         } else {
             var sSelf: ImageCache! = self
             block = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS) {
                 // Begin to load image from disk
-                let options = options ?? KingfisherEmptyOptionsInfo
                 if let image = sSelf.retrieveImageInDiskCacheForKey(key, scale: options.scaleFactor) {
                     if options.backgroundDecode {
                         dispatch_async(sSelf.processQueue, { () -> Void in

--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -199,32 +199,27 @@ extension ImageView {
         let task = KingfisherManager.sharedManager.retrieveImageWithResource(resource, optionsInfo: optionsInfo,
             progressBlock: { receivedSize, totalSize in
                 if let progressBlock = progressBlock {
-                    dispatch_async(dispatch_get_main_queue(), { () -> Void in
-                        progressBlock(receivedSize: receivedSize, totalSize: totalSize)
-                        
-                    })
+                    progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 }
             },
             completionHandler: {[weak self] image, error, cacheType, imageURL in
                 
-                dispatch_async_safely_main_queue {
-                    
-                    guard let sSelf = self where imageURL == sSelf.kf_webURL else {
-                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
-                        return
-                    }
-                    
-                    sSelf.kf_setImageTask(nil)
-                    
-                    guard let image = image else {
-                        indicator?.kf_stopAnimating()
-                        completionHandler?(image: nil, error: error, cacheType: cacheType, imageURL: imageURL)
-                        return
-                    }
-
-
-                    if let transitionItem = optionsInfo?.kf_firstMatchIgnoringAssociatedValue(.Transition(.None)),
-                        case .Transition(let transition) = transitionItem where cacheType == .None {
+                guard let sSelf = self where imageURL == sSelf.kf_webURL else {
+                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                    return
+                }
+                
+                sSelf.kf_setImageTask(nil)
+                
+                guard let image = image else {
+                    indicator?.kf_stopAnimating()
+                    completionHandler?(image: nil, error: error, cacheType: cacheType, imageURL: imageURL)
+                    return
+                }
+                
+                
+                if let transitionItem = optionsInfo?.kf_firstMatchIgnoringAssociatedValue(.Transition(.None)),
+                    case .Transition(let transition) = transitionItem where cacheType == .None {
 #if !os(OSX)
                             UIView.transitionWithView(sSelf, duration: 0.0, options: [],
                                 animations: {
@@ -239,14 +234,13 @@ extension ImageView {
                                         completion: { finished in
                                             transition.completion?(finished)
                                             completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
-                                        })
-                                })
+                                    })
+                            })
 #endif
-                    } else {
-                        indicator?.kf_stopAnimating()
-                        sSelf.image = image
-                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
-                    }
+                } else {
+                    indicator?.kf_stopAnimating()
+                    sSelf.image = image
+                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                 }
             })
         

--- a/Sources/UIButton+Kingfisher.swift
+++ b/Sources/UIButton+Kingfisher.swift
@@ -200,23 +200,19 @@ extension UIButton {
         let task = KingfisherManager.sharedManager.retrieveImageWithResource(resource, optionsInfo: optionsInfo,
             progressBlock: { receivedSize, totalSize in
                 if let progressBlock = progressBlock {
-                    dispatch_async(dispatch_get_main_queue(), { () -> Void in
-                        progressBlock(receivedSize: receivedSize, totalSize: totalSize)
-                    })
+                    progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 }
             },
             completionHandler: {[weak self] image, error, cacheType, imageURL in
                 
-                dispatch_async_safely_main_queue {
-                    if let sSelf = self {
-                        
-                        sSelf.kf_setImageTask(nil)
-                        
-                        if imageURL == sSelf.kf_webURLForState(state) && image != nil {
-                            sSelf.setImage(image, forState: state)
-                        }
-                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                if let sSelf = self {
+                    
+                    sSelf.kf_setImageTask(nil)
+                    
+                    if imageURL == sSelf.kf_webURLForState(state) && image != nil {
+                        sSelf.setImage(image, forState: state)
                     }
+                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                 }
             })
         
@@ -465,23 +461,19 @@ extension UIButton {
         let task = KingfisherManager.sharedManager.retrieveImageWithResource(resource, optionsInfo: optionsInfo,
             progressBlock: { receivedSize, totalSize in
                 if let progressBlock = progressBlock {
-                    dispatch_async(dispatch_get_main_queue(), { () -> Void in
-                        progressBlock(receivedSize: receivedSize, totalSize: totalSize)
-                    })
+                    progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 }
             },
             completionHandler: { [weak self] image, error, cacheType, imageURL in
-                dispatch_async_safely_main_queue {
+                
+                if let sSelf = self {
                     
-                    if let sSelf = self {
-                        
-                        sSelf.kf_setBackgroundImageTask(nil)
-                        
-                        if imageURL == sSelf.kf_backgroundWebURLForState(state) && image != nil {
-                            sSelf.setBackgroundImage(image, forState: state)
-                        }
-                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                    sSelf.kf_setBackgroundImageTask(nil)
+                    
+                    if imageURL == sSelf.kf_backgroundWebURLForState(state) && image != nil {
+                        sSelf.setBackgroundImage(image, forState: state)
                     }
+                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                 }
             })
         


### PR DESCRIPTION
实现的效果仍然是当不显式指定 callbackQueue 时 completionHandler 在 main queue 上调用，显示指定 callbackQueue 则在指定 queue 上运行，无论何时 progressBlock 都在 main queue 上调用

原本在 ImageDownloader 里 session object 的 delegateQueue 是 main queue，所以可能是这个原因导致了会出现在 main queue 调用 `dispatch_async(dispatch_get_main_queue(), ...) `  的情况，例如最终调用 completionHandler 的是函数
`private func callbackWithImage(image: Image?, error: NSError?, imageURL: NSURL, originalData: NSData?) {}`

这个函数在原本的实现中有可能在 processQueue 上被调用
（函数 `processImageForTask` 的实现），
也有可能在 main queue 上被调用
（`URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError error: NSError?)` 的实现）

在 main queue 上被调用，在 handler 里又包含 `dispatch_async(dispatch_get_main_queue(), ...) ` 就会导致 reload 时出现闪动。

新的实现将 session object 的 delegateQueue 改为自定义的 operation queue 所有的 delegate method 都在这个 queue 上运行，需要调用 progressBlock 或 completionHandler 的时候运用 `dispatch_async(options.callbackDispatchQueue, ...)` 发送到默认的 main queue 或者指定的 callbackQueue 上去，这样应该可以杜绝出现在 main queue 调用 `dispatch_async(dispatch_get_main_queue(), ...) `  的情况。

这一点没法完全通过测试来证明，还需要喵神 review 看看是否是这样