### PR TITLE
Apply callback queue to downloader as well

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -283,12 +283,12 @@ extension ImageCache {
             if options.backgroundDecode {
                 dispatch_async(self.processQueue, { () -> Void in
                     let result = image.kf_decodedImage(scale: options.scaleFactor)
-                    dispatch_async(options.callbackDispatchQueue, { () -> Void in
+                    dispatch_async_safely_to_queue(options.callbackDispatchQueue, { () -> Void in
                         completionHandler(result, .Memory)
                     })
                 })
             } else {
-                dispatch_async(options.callbackDispatchQueue, { () -> Void in
+                dispatch_async_safely_to_queue(options.callbackDispatchQueue, { () -> Void in
                     completionHandler(image, .Memory)
                 })
             }
@@ -302,21 +302,21 @@ extension ImageCache {
                             let result = image.kf_decodedImage(scale: options.scaleFactor)
                             sSelf.storeImage(result!, forKey: key, toDisk: false, completionHandler: nil)
 
-                            dispatch_async(options.callbackDispatchQueue, { () -> Void in
+                            dispatch_async_safely_to_queue(options.callbackDispatchQueue, { () -> Void in
                                 completionHandler(result, .Memory)
                                 sSelf = nil
                             })
                         })
                     } else {
                         sSelf.storeImage(image, forKey: key, toDisk: false, completionHandler: nil)
-                        dispatch_async(options.callbackDispatchQueue, { () -> Void in
+                        dispatch_async_safely_to_queue(options.callbackDispatchQueue, { () -> Void in
                             completionHandler(image, .Disk)
                             sSelf = nil
                         })
                     }
                 } else {
                     // No image found from either memory or disk
-                    dispatch_async(options.callbackDispatchQueue, { () -> Void in
+                    dispatch_async_safely_to_queue(options.callbackDispatchQueue, { () -> Void in
                         completionHandler(nil, nil)
                         sSelf = nil
                     })

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -276,10 +276,11 @@ extension ImageCache {
         }
         
         var block: RetrieveImageDiskTask?
+        let options = options ?? KingfisherEmptyOptionsInfo
+        
         if let image = self.retrieveImageInMemoryCacheForKey(key) {
-            
             //Found image in memory cache.
-            if let options = options where options.backgroundDecode {
+            if options.backgroundDecode {
                 dispatch_async(self.processQueue, { () -> Void in
                     let result = image.kf_decodedImage(scale: options.scaleFactor)
                     dispatch_async(options.callbackDispatchQueue, { () -> Void in
@@ -287,13 +288,14 @@ extension ImageCache {
                     })
                 })
             } else {
-                completionHandler(image, .Memory)
+                dispatch_async(options.callbackDispatchQueue, { () -> Void in
+                    completionHandler(image, .Memory)
+                })
             }
         } else {
             var sSelf: ImageCache! = self
             block = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS) {
                 // Begin to load image from disk
-                let options = options ?? KingfisherEmptyOptionsInfo
                 if let image = sSelf.retrieveImageInDiskCacheForKey(key, scale: options.scaleFactor) {
                     if options.backgroundDecode {
                         dispatch_async(sSelf.processQueue, { () -> Void in

--- a/Sources/ImageDownloader.swift
+++ b/Sources/ImageDownloader.swift
@@ -127,12 +127,11 @@ public class ImageDownloader: NSObject {
     /// Use this to set supply a configuration for the downloader. By default, NSURLSessionConfiguration.ephemeralSessionConfiguration() will be used. You could change the configuration before a downloaing task starts. A configuration without persistent storage for caches is requsted for downloader working correctly.
     public var sessionConfiguration = NSURLSessionConfiguration.ephemeralSessionConfiguration() {
         didSet {
-            session = NSURLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: sessionDelegationQueue)
+            session = NSURLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: NSOperationQueue.mainQueue())
         }
     }
     
     private var session: NSURLSession?
-    private let sessionDelegationQueue = NSOperationQueue()
     
     /// Delegate of this `ImageDownloader` object. See `ImageDownloaderDelegate` protocol for more.
     public weak var delegate: ImageDownloaderDelegate?
@@ -168,8 +167,7 @@ public class ImageDownloader: NSObject {
         
         super.init()
         
-        sessionDelegationQueue.maxConcurrentOperationCount = 1
-        session = NSURLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: sessionDelegationQueue)
+        session = NSURLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: NSOperationQueue.mainQueue())
     }
     
     func fetchLoadForKey(key: NSURL) -> ImageFetchLoad? {

--- a/Sources/ImageDownloader.swift
+++ b/Sources/ImageDownloader.swift
@@ -364,7 +364,7 @@ extension ImageDownloader: NSURLSessionDataDelegate {
             self.cleanForURL(imageURL)
             
             for callbackPair in callbackPairs {
-                dispatch_async(options.callbackDispatchQueue, { () -> Void in
+                dispatch_async_safely_to_queue(options.callbackDispatchQueue, { () -> Void in
                     callbackPair.completionHander?(image: image, error: error, imageURL: imageURL, originalData: originalData)
                 })
             }

--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -204,43 +204,44 @@ extension ImageView {
             },
             completionHandler: {[weak self] image, error, cacheType, imageURL in
                 
-                guard let sSelf = self where imageURL == sSelf.kf_webURL else {
-                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
-                    return
-                }
-                
-                sSelf.kf_setImageTask(nil)
-                
-                guard let image = image else {
-                    indicator?.kf_stopAnimating()
-                    completionHandler?(image: nil, error: error, cacheType: cacheType, imageURL: imageURL)
-                    return
-                }
-                
-                
-                if let transitionItem = optionsInfo?.kf_firstMatchIgnoringAssociatedValue(.Transition(.None)),
-                    case .Transition(let transition) = transitionItem where cacheType == .None {
-#if !os(OSX)
-                            UIView.transitionWithView(sSelf, duration: 0.0, options: [],
-                                animations: {
-                                    indicator?.kf_stopAnimating()
-                                },
-                                completion: { finished in
-                                    UIView.transitionWithView(sSelf, duration: transition.duration,
-                                        options: transition.animationOptions,
-                                        animations: {
-                                            transition.animations?(sSelf, image)
-                                        },
-                                        completion: { finished in
-                                            transition.completion?(finished)
-                                            completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
-                                    })
-                            })
-#endif
-                } else {
-                    indicator?.kf_stopAnimating()
-                    sSelf.image = image
-                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                dispatch_async_safely_to_main_queue {
+                    guard let sSelf = self where imageURL == sSelf.kf_webURL else {
+                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                        return
+                    }
+                    
+                    sSelf.kf_setImageTask(nil)
+                    
+                    guard let image = image else {
+                        indicator?.kf_stopAnimating()
+                        completionHandler?(image: nil, error: error, cacheType: cacheType, imageURL: imageURL)
+                        return
+                    }
+                    
+                    if let transitionItem = optionsInfo?.kf_firstMatchIgnoringAssociatedValue(.Transition(.None)),
+                        case .Transition(let transition) = transitionItem where cacheType == .None {
+                            #if !os(OSX)
+                                UIView.transitionWithView(sSelf, duration: 0.0, options: [],
+                                    animations: {
+                                        indicator?.kf_stopAnimating()
+                                    },
+                                    completion: { finished in
+                                        UIView.transitionWithView(sSelf, duration: transition.duration,
+                                            options: transition.animationOptions,
+                                            animations: {
+                                                transition.animations?(sSelf, image)
+                                            },
+                                            completion: { finished in
+                                                transition.completion?(finished)
+                                                completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                                        })
+                                })
+                            #endif
+                    } else {
+                        indicator?.kf_stopAnimating()
+                        sSelf.image = image
+                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                    }
                 }
             })
         

--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -199,32 +199,27 @@ extension ImageView {
         let task = KingfisherManager.sharedManager.retrieveImageWithResource(resource, optionsInfo: optionsInfo,
             progressBlock: { receivedSize, totalSize in
                 if let progressBlock = progressBlock {
-                    dispatch_async(dispatch_get_main_queue(), { () -> Void in
-                        progressBlock(receivedSize: receivedSize, totalSize: totalSize)
-                        
-                    })
+                    progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 }
             },
             completionHandler: {[weak self] image, error, cacheType, imageURL in
                 
-                dispatch_async_safely_main_queue {
-                    
-                    guard let sSelf = self where imageURL == sSelf.kf_webURL else {
-                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
-                        return
-                    }
-                    
-                    sSelf.kf_setImageTask(nil)
-                    
-                    guard let image = image else {
-                        indicator?.kf_stopAnimating()
-                        completionHandler?(image: nil, error: error, cacheType: cacheType, imageURL: imageURL)
-                        return
-                    }
-
-
-                    if let transitionItem = optionsInfo?.kf_firstMatchIgnoringAssociatedValue(.Transition(.None)),
-                        case .Transition(let transition) = transitionItem where cacheType == .None {
+                guard let sSelf = self where imageURL == sSelf.kf_webURL else {
+                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                    return
+                }
+                
+                sSelf.kf_setImageTask(nil)
+                
+                guard let image = image else {
+                    indicator?.kf_stopAnimating()
+                    completionHandler?(image: nil, error: error, cacheType: cacheType, imageURL: imageURL)
+                    return
+                }
+                
+                
+                if let transitionItem = optionsInfo?.kf_firstMatchIgnoringAssociatedValue(.Transition(.None)),
+                    case .Transition(let transition) = transitionItem where cacheType == .None {
 #if !os(OSX)
                             UIView.transitionWithView(sSelf, duration: 0.0, options: [],
                                 animations: {
@@ -239,14 +234,13 @@ extension ImageView {
                                         completion: { finished in
                                             transition.completion?(finished)
                                             completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
-                                        })
-                                })
+                                    })
+                            })
 #endif
-                    } else {
-                        indicator?.kf_stopAnimating()
-                        sSelf.image = image
-                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
-                    }
+                } else {
+                    indicator?.kf_stopAnimating()
+                    sSelf.image = image
+                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                 }
             })
         

--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -140,6 +140,9 @@ extension ImageView {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+     
+    - note: `completionHandler` will be invoked in main thread.
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     public func kf_setImageWithResource(resource: Resource,
                                 placeholderImage: Image?,
@@ -158,6 +161,9 @@ extension ImageView {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+     
+    - note: `completionHandler` will be invoked in main thread.
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     public func kf_setImageWithURL(URL: NSURL,
                       placeholderImage: Image?,
@@ -177,6 +183,9 @@ extension ImageView {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+     
+    - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread. 
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     public func kf_setImageWithResource(resource: Resource,
                                 placeholderImage: Image?,
@@ -260,6 +269,9 @@ extension ImageView {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+
+    - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread.
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     
     public func kf_setImageWithURL(URL: NSURL,

--- a/Sources/ThreadHelper.swift
+++ b/Sources/ThreadHelper.swift
@@ -30,6 +30,9 @@ func dispatch_async_safely_to_main_queue(block: ()->()) {
     dispatch_async_safely_to_queue(dispatch_get_main_queue(), block)
 }
 
+// This methd will dispatch the `block` to a specified `queue`.
+// If the `queue` is the main queue, and current thread is main thread, the block 
+// will be invoked immediately instead of being dispatched.
 func dispatch_async_safely_to_queue(queue: dispatch_queue_t, _ block: ()->()) {
     if queue === dispatch_get_main_queue() && NSThread.isMainThread() {
         block()

--- a/Sources/ThreadHelper.swift
+++ b/Sources/ThreadHelper.swift
@@ -26,11 +26,15 @@
 
 import Foundation
 
-func dispatch_async_safely_main_queue(block: ()->()) {
-    if NSThread.isMainThread() {
+func dispatch_async_safely_to_main_queue(block: ()->()) {
+    dispatch_async_safely_to_queue(dispatch_get_main_queue(), block)
+}
+
+func dispatch_async_safely_to_queue(queue: dispatch_queue_t, _ block: ()->()) {
+    if queue === dispatch_get_main_queue() && NSThread.isMainThread() {
         block()
     } else {
-        dispatch_async(dispatch_get_main_queue()) {
+        dispatch_async(queue) {
             block()
         }
     }

--- a/Sources/UIButton+Kingfisher.swift
+++ b/Sources/UIButton+Kingfisher.swift
@@ -145,6 +145,9 @@ extension UIButton {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+     
+    - note: `completionHandler` will be invoked in main thread.
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     public func kf_setImageWithResource(resource: Resource,
                                   forState state: UIControlState,
@@ -165,6 +168,9 @@ extension UIButton {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+     
+    - note: `completionHandler` will be invoked in main thread.
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     public func kf_setImageWithURL(URL: NSURL,
                         forState state: UIControlState,
@@ -187,6 +193,9 @@ extension UIButton {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+     
+    - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread.
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     public func kf_setImageWithResource(resource: Resource,
                                   forState state: UIControlState,
@@ -204,15 +213,16 @@ extension UIButton {
                 }
             },
             completionHandler: {[weak self] image, error, cacheType, imageURL in
-                
-                if let sSelf = self {
-                    
-                    sSelf.kf_setImageTask(nil)
-                    
-                    if imageURL == sSelf.kf_webURLForState(state) && image != nil {
-                        sSelf.setImage(image, forState: state)
+                dispatch_async_safely_to_main_queue {
+                    if let sSelf = self {
+                        
+                        sSelf.kf_setImageTask(nil)
+                        
+                        if imageURL == sSelf.kf_webURLForState(state) && image != nil {
+                            sSelf.setImage(image, forState: state)
+                        }
+                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                     }
-                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                 }
             })
         
@@ -231,6 +241,9 @@ extension UIButton {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+     
+    - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread.
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     public func kf_setImageWithURL(URL: NSURL,
                         forState state: UIControlState,
@@ -406,6 +419,9 @@ extension UIButton {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+     
+    - note: `completionHandler` will be invoked in main thread.
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     public func kf_setBackgroundImageWithResource(resource: Resource,
                                             forState state: UIControlState,
@@ -426,6 +442,9 @@ extension UIButton {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+     
+    - note: `completionHandler` will be invoked in main thread.
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     public func kf_setBackgroundImageWithURL(URL: NSURL,
                                   forState state: UIControlState,
@@ -448,6 +467,9 @@ extension UIButton {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+     
+    - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread.
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     public func kf_setBackgroundImageWithResource(resource: Resource,
                                             forState state: UIControlState,
@@ -465,15 +487,16 @@ extension UIButton {
                 }
             },
             completionHandler: { [weak self] image, error, cacheType, imageURL in
-                
-                if let sSelf = self {
-                    
-                    sSelf.kf_setBackgroundImageTask(nil)
-                    
-                    if imageURL == sSelf.kf_backgroundWebURLForState(state) && image != nil {
-                        sSelf.setBackgroundImage(image, forState: state)
+                dispatch_async_safely_to_main_queue {
+                    if let sSelf = self {
+                        
+                        sSelf.kf_setBackgroundImageTask(nil)
+                        
+                        if imageURL == sSelf.kf_backgroundWebURLForState(state) && image != nil {
+                            sSelf.setBackgroundImage(image, forState: state)
+                        }
+                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                     }
-                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                 }
             })
         
@@ -493,6 +516,9 @@ extension UIButton {
     - parameter completionHandler: Called when the image retrieved and set.
     
     - returns: A task represents the retrieving process.
+     
+    - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread.
+     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
     */
     public func kf_setBackgroundImageWithURL(URL: NSURL,
                                   forState state: UIControlState,

--- a/Sources/UIButton+Kingfisher.swift
+++ b/Sources/UIButton+Kingfisher.swift
@@ -200,23 +200,19 @@ extension UIButton {
         let task = KingfisherManager.sharedManager.retrieveImageWithResource(resource, optionsInfo: optionsInfo,
             progressBlock: { receivedSize, totalSize in
                 if let progressBlock = progressBlock {
-                    dispatch_async(dispatch_get_main_queue(), { () -> Void in
-                        progressBlock(receivedSize: receivedSize, totalSize: totalSize)
-                    })
+                    progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 }
             },
             completionHandler: {[weak self] image, error, cacheType, imageURL in
                 
-                dispatch_async_safely_main_queue {
-                    if let sSelf = self {
-                        
-                        sSelf.kf_setImageTask(nil)
-                        
-                        if imageURL == sSelf.kf_webURLForState(state) && image != nil {
-                            sSelf.setImage(image, forState: state)
-                        }
-                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                if let sSelf = self {
+                    
+                    sSelf.kf_setImageTask(nil)
+                    
+                    if imageURL == sSelf.kf_webURLForState(state) && image != nil {
+                        sSelf.setImage(image, forState: state)
                     }
+                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                 }
             })
         
@@ -465,23 +461,19 @@ extension UIButton {
         let task = KingfisherManager.sharedManager.retrieveImageWithResource(resource, optionsInfo: optionsInfo,
             progressBlock: { receivedSize, totalSize in
                 if let progressBlock = progressBlock {
-                    dispatch_async(dispatch_get_main_queue(), { () -> Void in
-                        progressBlock(receivedSize: receivedSize, totalSize: totalSize)
-                    })
+                    progressBlock(receivedSize: receivedSize, totalSize: totalSize)
                 }
             },
             completionHandler: { [weak self] image, error, cacheType, imageURL in
-                dispatch_async_safely_main_queue {
+                
+                if let sSelf = self {
                     
-                    if let sSelf = self {
-                        
-                        sSelf.kf_setBackgroundImageTask(nil)
-                        
-                        if imageURL == sSelf.kf_backgroundWebURLForState(state) && image != nil {
-                            sSelf.setBackgroundImage(image, forState: state)
-                        }
-                        completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
+                    sSelf.kf_setBackgroundImageTask(nil)
+                    
+                    if imageURL == sSelf.kf_backgroundWebURLForState(state) && image != nil {
+                        sSelf.setBackgroundImage(image, forState: state)
                     }
+                    completionHandler?(image: image, error: error, cacheType: cacheType, imageURL: imageURL)
                 }
             })
         

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -87,7 +87,7 @@ class ImageViewExtensionTests: XCTestCase {
         waitForExpectationsWithTimeout(5, handler: nil)
     }
     
-    func testImageDownloadCompletionHandlerRunningOnCustomQueue() {
+    func testImageDownloadCompletionHandlerRunningOnMainQueue() {
         let expectation = expectationWithDescription("wait for downloading image")
         
         let URLString = testKeys[0]
@@ -98,7 +98,7 @@ class ImageViewExtensionTests: XCTestCase {
         imageView.kf_setImageWithURL(URL, placeholderImage: nil, optionsInfo: [.CallbackDispatchQueue(customQueue)], progressBlock: { (receivedSize, totalSize) -> () in
             XCTAssertTrue(NSThread.isMainThread())
         }) { (image, error, cacheType, imageURL) -> () in
-            XCTAssertEqual(String(UTF8String: dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL))!, "com.kingfisher.testQueue")
+            XCTAssertTrue(NSThread.isMainThread(), "The image extension callback should be always in main queue.")
             expectation.fulfill()
         }
         


### PR DESCRIPTION
@dopcn

在你的基础上改动了一些：

1. `ImageView` 和 `UIButton` 的 extension 中因为涉及的是 UI 操作，所以必须是 main thread；
2. `ImageCache` 里从内存缓存中直接取的时候并不需要进行 dispatch，否则将造成刷新时的闪烁；
3. 因此调整了一下 ThreadHelper 中的内容，依然还是进行一下判定，如果已经在 main queue 的话就不再做 dispatch 了；

因为从磁盘缓存读取为了性能考虑需要放在另外的线程执行，所以在内存无缓存但磁盘有缓存时刷新的闪烁似乎是不可避免的，不过因为这种情况并不是很常见或者致命。现在并不想添加像是在主线程读取磁盘缓存的选项，所以决定暂时先维持现状这样。稍后会在 `optionsInfo` 中添加一个强制进行 transition 的标识，如果用户觉得磁盘缓存读取的闪烁不可接受的话可以用像是 fade 之类的过度来缓解。

如果没有什么其它问题的话可以应该 merge 了。