### PR TITLE
fixed typo in documentation

### DIFF
--- a/Sources/ThreadHelper.swift
+++ b/Sources/ThreadHelper.swift
@@ -30,7 +30,7 @@ func dispatch_async_safely_to_main_queue(block: ()->()) {
     dispatch_async_safely_to_queue(dispatch_get_main_queue(), block)
 }
 
-// This methd will dispatch the `block` to a specified `queue`.
+// This method will dispatch the `block` to a specified `queue`.
 // If the `queue` is the main queue, and current thread is main thread, the block 
 // will be invoked immediately instead of being dispatched.
 func dispatch_async_safely_to_queue(queue: dispatch_queue_t, _ block: ()->()) {


### PR DESCRIPTION
Thanks for this resource! 

Changed "methd" to "method" in ThreadHelper.swift