### PR TITLE
Added user interaction to animation

### DIFF
--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -236,7 +236,7 @@ extension ImageView {
                                     },
                                     completion: { finished in
                                         UIView.transitionWithView(sSelf, duration: transition.duration,
-                                            options: transition.animationOptions,
+                                            options: [transition.animationOptions, .AllowUserInteraction],
                                             animations: {
                                                 transition.animations?(sSelf, image)
                                             },


### PR DESCRIPTION
When using Kingfisher with any type of animation, it was just breaking user interaction and not allowing users to scroll through lists on interact with the `UIImageView`s themselves.

This was mostly due to the fact that `.AllowUserInteraction` was not an option on the `UIView.transitionWithView` call.