### PR TITLE
Make cachePathForKey public [resolves #255]

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -604,6 +604,18 @@ extension ImageCache {
             })
         })
     }
+    
+    /**
+    Get the cache path for the key.
+    It is useful for projects with UIWebView or anyone that needs access to the local file path
+    
+    i.e. <img src='key'>
+    */
+    public func cachePathForKey(key: String) -> String {
+        let fileName = cacheFileNameForKey(key)
+        return (diskCachePath as NSString).stringByAppendingPathComponent(fileName)
+    }
+
 }
 
 // MARK: - Internal Helper
@@ -620,11 +632,6 @@ extension ImageCache {
     func diskImageDataForKey(key: String) -> NSData? {
         let filePath = cachePathForKey(key)
         return NSData(contentsOfFile: filePath)
-    }
-    
-    func cachePathForKey(key: String) -> String {
-        let fileName = cacheFileNameForKey(key)
-        return (diskCachePath as NSString).stringByAppendingPathComponent(fileName)
     }
     
     func cacheFileNameForKey(key: String) -> String {


### PR DESCRIPTION
Understandably, the method was private; however, this commit solves the problem of anyone that requires access to the actual file path of the cached image. This is especially useful for projects that are building iOS apps that are showing content with `UIWebView`s and lacks access to Internet connection.

Ref: #255