### PR TITLE
Disable background decoding for images from the in memory cache.

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -279,18 +279,8 @@ extension ImageCache {
         let options = options ?? KingfisherEmptyOptionsInfo
         
         if let image = self.retrieveImageInMemoryCacheForKey(key) {
-            //Found image in memory cache.
-            if options.backgroundDecode {
-                dispatch_async(self.processQueue, { () -> Void in
-                    let result = image.kf_decodedImage(scale: options.scaleFactor)
-                    dispatch_async_safely_to_queue(options.callbackDispatchQueue, { () -> Void in
-                        completionHandler(result, .Memory)
-                    })
-                })
-            } else {
-                dispatch_async_safely_to_queue(options.callbackDispatchQueue, { () -> Void in
-                    completionHandler(image, .Memory)
-                })
+            dispatch_async_safely_to_queue(options.callbackDispatchQueue) { () -> Void in
+                completionHandler(image, .Memory)
             }
         } else {
             var sSelf: ImageCache! = self

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -152,7 +152,21 @@ class ImageCacheTests: XCTestCase {
         
         waitForExpectationsWithTimeout(5, handler: nil)
     }
-    
+
+    func testCachedImageIsFetchedSyncronouslyFromTheMemoryCache() {
+        cache.storeImage(testImage, forKey: testKeys[0], toDisk: false) { () -> () in
+            // do nothing
+        }
+
+        var foundImage: Image?
+
+        cache.retrieveImageForKey(testKeys[0], options: [.BackgroundDecode]) { (image, type) -> () in
+            foundImage = image
+        }
+
+        XCTAssertEqual(testImage, foundImage, "should have found the image immediately")
+    }
+
     func testIsImageCachedForKey() {
         let expectation = self.expectationWithDescription("wait for caching image")
         


### PR DESCRIPTION
- this improves the performance of image loading for in-memory cached
  images.

We observe a flicker when returing to an image view that renders
multiple images using `kf_setImageWithResource`.  We traced through the
calls and found a place where Kingfisher attempts to re-decode an image
that has already been decoded and stored in the in memory cache.

We think that it is safe to pull out an image from the in memory cache and not
attempt to decode again.