### PR TITLE
Allow images other than JPEG, PNG or GIF (.ICO, as example)

### DIFF
--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -256,14 +256,14 @@ extension Image {
             case .JPEG: image = Image(data: data)
             case .PNG: image = Image(data: data)
             case .GIF: image = Image.kf_animatedImageWithGIFData(gifData: data, scale: scale, duration: 0.0)
-            case .Unknown: image = nil
+            case .Unknown: image = Image(data: data)
             }
         #else
             switch data.kf_imageFormat {
             case .JPEG: image = Image(data: data, scale: scale)
             case .PNG: image = Image(data: data, scale: scale)
             case .GIF: image = Image.kf_animatedImageWithGIFData(gifData: data, scale: scale, duration: 0.0)
-            case .Unknown: image = nil
+            case .Unknown: image = Image(data: data, scale: scale)
             }
         #endif
         


### PR DESCRIPTION
Allow images with other formats than JPEG, PNG or GIF to be converted from downloaded image data (.ICO, as example)