### PR TITLE
Remove duplicated APIs

### DIFF
--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -40,138 +40,35 @@ public typealias IndicatorView = UIActivityIndicatorView
 *	Set image to use from web.
 */
 extension ImageView {
-    
-    /**
-    Set an image with a resource.
-    It will ask for Kingfisher's manager to get the image for the `cacheKey` property in `resource`.
-    The memory and disk will be searched first. If the manager does not find it, it will try to download the image at the `resource.downloadURL` and store it with `resource.cacheKey` for next use.
-    
-    - parameter resource: Resource object contains information such as `cacheKey` and `downloadURL`.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithResource(resource: Resource) -> RetrieveImageTask
-    {
-        return kf_setImageWithResource(resource, placeholderImage: nil, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
-    
-    /**
-    Set an image with a URL.
-    It will ask for Kingfisher's manager to get the image for the URL.
-    The memory and disk will be searched first with `URL.absoluteString` as the cache key. If the manager does not find it, it will try to download the image at this URL and store the image with `URL.absoluteString` as cache key for next use.
-    
-    If you need to specify the key other than `URL.absoluteString`, please use resource version of these APIs with `resource.cacheKey` set to what you want.
-    
-    - parameter URL: The URL of image.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithURL(URL: NSURL) -> RetrieveImageTask
-    {
-        return kf_setImageWithURL(URL, placeholderImage: nil, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
 
     /**
-    Set an image with a resource and a placeholder image.
-    
-    - parameter resource:         Resource object contains information such as `cacheKey` and `downloadURL`.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithResource(resource: Resource,
-                                placeholderImage: Image?) -> RetrieveImageTask
-    {
-        return kf_setImageWithResource(resource, placeholderImage: placeholderImage, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
-    
-    /**
-    Set an image with a URL and a placeholder image.
-    
-    - parameter URL:              The URL of image.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithURL(URL: NSURL,
-                      placeholderImage: Image?) -> RetrieveImageTask
-    {
-        return kf_setImageWithURL(URL, placeholderImage: placeholderImage, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
-    
-    /**
-    Set an image with a resource, a placaholder image and options.
-    
-    - parameter resource:         Resource object contains information such as `cacheKey` and `downloadURL`.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:      A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithResource(resource: Resource,
-                                placeholderImage: Image?,
-                                     optionsInfo: KingfisherOptionsInfo?) -> RetrieveImageTask
-    {
-        return kf_setImageWithResource(resource, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: nil)
-    }
-    
-    /**
-    Set an image with a URL, a placaholder image and options.
-    
-    - parameter URL:              The URL of image.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:      A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithURL(URL: NSURL,
-                      placeholderImage: Image?,
-                           optionsInfo: KingfisherOptionsInfo?) -> RetrieveImageTask
-    {
-        return kf_setImageWithURL(URL, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: nil)
-    }
-    
-    /**
-    Set an image with a resource, a placeholder image, options and completion handler.
-    
-    - parameter resource:          Resource object contains information such as `cacheKey` and `downloadURL`.
-    - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    - parameter completionHandler: Called when the image retrieved and set.
-    
-    - returns: A task represents the retrieving process.
+     Set an image with a URL, a placeholder image, options, progress handler and completion handler.
      
-    - note: `completionHandler` will be invoked in main thread.
-     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
-    */
-    public func kf_setImageWithResource(resource: Resource,
-                                placeholderImage: Image?,
-                                     optionsInfo: KingfisherOptionsInfo?,
-                               completionHandler: CompletionHandler?) -> RetrieveImageTask
-    {
-        return kf_setImageWithResource(resource, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: completionHandler)
-    }
-    
-    /**
-    Set an image with a URL, a placeholder image, options and completion handler.
-    
-    - parameter URL:               The URL of image.
-    - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    - parameter completionHandler: Called when the image retrieved and set.
-    
-    - returns: A task represents the retrieving process.
+     - parameter URL:               The URL of image.
+     - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
+     - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
+     - parameter progressBlock:     Called when the image downloading progress gets updated.
+     - parameter completionHandler: Called when the image retrieved and set.
      
-    - note: `completionHandler` will be invoked in main thread.
+     - returns: A task represents the retrieving process.
+     
+     - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread.
      The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
-    */
+     */
+    
     public func kf_setImageWithURL(URL: NSURL,
-                      placeholderImage: Image?,
-                           optionsInfo: KingfisherOptionsInfo?,
-                     completionHandler: CompletionHandler?) -> RetrieveImageTask
+                                   placeholderImage: Image?,
+                                   optionsInfo: KingfisherOptionsInfo?,
+                                   progressBlock: DownloadProgressBlock?,
+                                   completionHandler: CompletionHandler?) -> RetrieveImageTask
     {
-        return kf_setImageWithURL(URL, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: completionHandler)
+        return kf_setImageWithResource(Resource(downloadURL: URL),
+                                       placeholderImage: placeholderImage,
+                                       optionsInfo: optionsInfo,
+                                       progressBlock: progressBlock,
+                                       completionHandler: completionHandler)
     }
+    
     
     /**
     Set an image with a URL, a placeholder image, options, progress handler and completion handler.
@@ -257,34 +154,6 @@ extension ImageView {
         kf_setImageTask(task)
         
         return task
-    }
-    
-    /**
-    Set an image with a URL, a placeholder image, options, progress handler and completion handler.
-    
-    - parameter URL:               The URL of image.
-    - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    - parameter progressBlock:     Called when the image downloading progress gets updated.
-    - parameter completionHandler: Called when the image retrieved and set.
-    
-    - returns: A task represents the retrieving process.
-
-    - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread.
-     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
-    */
-    
-    public func kf_setImageWithURL(URL: NSURL,
-                      placeholderImage: Image?,
-                           optionsInfo: KingfisherOptionsInfo?,
-                         progressBlock: DownloadProgressBlock?,
-                     completionHandler: CompletionHandler?) -> RetrieveImageTask
-    {
-        return kf_setImageWithResource(Resource(downloadURL: URL),
-                            placeholderImage: placeholderImage,
-                                 optionsInfo: optionsInfo,
-                               progressBlock: progressBlock,
-                           completionHandler: completionHandler)
     }
 }
 

--- a/Sources/UIButton+Kingfisher.swift
+++ b/Sources/UIButton+Kingfisher.swift
@@ -32,155 +32,36 @@ import UIKit
 *	Set image to use from web for a specified state.
 */
 extension UIButton {
-
     /**
-    Set an image to use for a specified state with a resource.
-    It will ask for Kingfisher's manager to get the image for the `cacheKey` property in `resource` and then set it for a button state.
-    The memory and disk will be searched first. If the manager does not find it, it will try to download the image at the `resource.downloadURL` and store it with `resource.cacheKey` for next use.
-    
-    - parameter resource: Resource object contains information such as `cacheKey` and `downloadURL`.
-    - parameter state:    The state that uses the specified image.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithResource(resource: Resource,
-                                  forState state: UIControlState) -> RetrieveImageTask
-    {
-        return kf_setImageWithResource(resource, forState: state, placeholderImage: nil, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
-    
-    /**
-    Set an image to use for a specified state with a URL.
-    It will ask for Kingfisher's manager to get the image for the URL and then set it for a button state.
-    The memory and disk will be searched first with `URL.absoluteString` as the cache key. If the manager does not find it, it will try to download the image at this URL and store the image with `URL.absoluteString` as cache key for next use.
-    
-    If you need to specify the key other than `URL.absoluteString`, please use resource version of these APIs with `resource.cacheKey` set to what you want.
-    
-    - parameter URL:   The URL of image for specified state.
-    - parameter state: The state that uses the specified image.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithURL(URL: NSURL,
-                        forState state: UIControlState) -> RetrieveImageTask
-    {
-        return kf_setImageWithURL(URL, forState: state, placeholderImage: nil, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
-
-    /**
-    Set an image to use for a specified state with a resource and a placeholder image.
-    
-    - parameter resource:         Resource object contains information such as `cacheKey` and `downloadURL`.
-    - parameter state:            The state that uses the specified image.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithResource(resource: Resource,
-                                  forState state: UIControlState,
-                                placeholderImage: UIImage?) -> RetrieveImageTask
-    {
-        return kf_setImageWithResource(resource, forState: state, placeholderImage: placeholderImage, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
-    
-    /**
-    Set an image to use for a specified state with a URL and a placeholder image.
-    
-    - parameter URL:              The URL of image for specified state.
-    - parameter state:            The state that uses the specified image.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithURL(URL: NSURL,
-                        forState state: UIControlState,
-                      placeholderImage: UIImage?) -> RetrieveImageTask
-    {
-        return kf_setImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
-
-    /**
-    Set an image to use for a specified state with a resource, a placeholder image and options.
-    
-    - parameter resource:         Resource object contains information such as `cacheKey` and `downloadURL`.
-    - parameter state:            The state that uses the specified image.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:      A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithResource(resource: Resource,
-                                  forState state: UIControlState,
-                                placeholderImage: UIImage?,
-                                     optionsInfo: KingfisherOptionsInfo?) -> RetrieveImageTask
-    {
-        return kf_setImageWithResource(resource, forState: state, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: nil)
-    }
-    
-    /**
-    Set an image to use for a specified state with a URL, a placeholder image and options.
-    
-    - parameter URL:              The URL of image for specified state.
-    - parameter state:            The state that uses the specified image.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:      A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setImageWithURL(URL: NSURL,
-                        forState state: UIControlState,
-                      placeholderImage: UIImage?,
-                           optionsInfo: KingfisherOptionsInfo?) -> RetrieveImageTask
-    {
-        return kf_setImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: nil)
-    }
-
-    /**
-    Set an image to use for a specified state with a resource, a placeholder image, options and completion handler.
-    
-    - parameter resource:          Resource object contains information such as `cacheKey` and `downloadURL`.
-    - parameter state:             The state that uses the specified image.
-    - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    - parameter completionHandler: Called when the image retrieved and set.
-    
-    - returns: A task represents the retrieving process.
+     Set an image to use for a specified state with a URL, a placeholder image, options, progress handler and completion handler.
      
-    - note: `completionHandler` will be invoked in main thread.
-     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
-    */
-    public func kf_setImageWithResource(resource: Resource,
-                                  forState state: UIControlState,
-                                placeholderImage: UIImage?,
-                                     optionsInfo: KingfisherOptionsInfo?,
-                               completionHandler: CompletionHandler?) -> RetrieveImageTask
-    {
-        return kf_setImageWithResource(resource, forState: state, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: completionHandler)
-    }
-    
-    /**
-    Set an image to use for a specified state with a URL, a placeholder image, options and completion handler.
-    
-    - parameter URL:               The URL of image for specified state.
-    - parameter state:             The state that uses the specified image.
-    - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    - parameter completionHandler: Called when the image retrieved and set.
-    
-    - returns: A task represents the retrieving process.
+     - parameter URL:               The URL of image for specified state.
+     - parameter state:             The state that uses the specified image.
+     - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
+     - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
+     - parameter progressBlock:     Called when the image downloading progress gets updated.
+     - parameter completionHandler: Called when the image retrieved and set.
      
-    - note: `completionHandler` will be invoked in main thread.
+     - returns: A task represents the retrieving process.
+     
+     - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread.
      The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
-    */
+     */
     public func kf_setImageWithURL(URL: NSURL,
-                        forState state: UIControlState,
-                      placeholderImage: UIImage?,
-                           optionsInfo: KingfisherOptionsInfo?,
-                     completionHandler: CompletionHandler?) -> RetrieveImageTask
+                                   forState state: UIControlState,
+                                            placeholderImage: UIImage?,
+                                            optionsInfo: KingfisherOptionsInfo?,
+                                            progressBlock: DownloadProgressBlock?,
+                                            completionHandler: CompletionHandler?) -> RetrieveImageTask
     {
-        return kf_setImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: completionHandler)
+        return kf_setImageWithResource(Resource(downloadURL: URL),
+                                       forState: state,
+                                       placeholderImage: placeholderImage,
+                                       optionsInfo: optionsInfo,
+                                       progressBlock: progressBlock,
+                                       completionHandler: completionHandler)
     }
-
+    
     
     /**
     Set an image to use for a specified state with a resource, a placeholder image, options, progress handler and completion handler.
@@ -228,36 +109,6 @@ extension UIButton {
         
         kf_setImageTask(task)
         return task
-    }
-    
-    /**
-    Set an image to use for a specified state with a URL, a placeholder image, options, progress handler and completion handler.
-    
-    - parameter URL:               The URL of image for specified state.
-    - parameter state:             The state that uses the specified image.
-    - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    - parameter progressBlock:     Called when the image downloading progress gets updated.
-    - parameter completionHandler: Called when the image retrieved and set.
-    
-    - returns: A task represents the retrieving process.
-     
-    - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread.
-     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
-    */
-    public func kf_setImageWithURL(URL: NSURL,
-                        forState state: UIControlState,
-                      placeholderImage: UIImage?,
-                           optionsInfo: KingfisherOptionsInfo?,
-                         progressBlock: DownloadProgressBlock?,
-                     completionHandler: CompletionHandler?) -> RetrieveImageTask
-    {
-        return kf_setImageWithResource(Resource(downloadURL: URL),
-                                forState: state,
-                        placeholderImage: placeholderImage,
-                             optionsInfo: optionsInfo,
-                           progressBlock: progressBlock,
-                       completionHandler: completionHandler)
     }
 }
 
@@ -308,153 +159,37 @@ extension UIButton {
 */
 extension UIButton {
     /**
-    Set the background image to use for a specified state with a resource.
-    It will ask for Kingfisher's manager to get the image for the `cacheKey` property in `resource` and then set it for a button state.
-    The memory and disk will be searched first. If the manager does not find it, it will try to download the image at the `resource.downloadURL` and store it with `resource.cacheKey` for next use.
-    
-    - parameter resource: Resource object contains information such as `cacheKey` and `downloadURL`.
-    - parameter state:    The state that uses the specified image.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setBackgroundImageWithResource(resource: Resource,
-                                            forState state: UIControlState) -> RetrieveImageTask
-    {
-        return kf_setBackgroundImageWithResource(resource, forState: state, placeholderImage: nil, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
-    
-    /**
-    Set the background image to use for a specified state with a URL.
-    It will ask for Kingfisher's manager to get the image for the URL and then set it for a button state.
-    The memory and disk will be searched first with `URL.absoluteString` as the cache key. If the manager does not find it, it will try to download the image at this URL and store the image with `URL.absoluteString` as cache key for next use.
-    
-    If you need to specify the key other than `URL.absoluteString`, please use resource version of these APIs with `resource.cacheKey` set to what you want.
-    
-    - parameter URL:   The URL of image for specified state.
-    - parameter state: The state that uses the specified image.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setBackgroundImageWithURL(URL: NSURL,
-                                  forState state: UIControlState) -> RetrieveImageTask
-    {
-        return kf_setBackgroundImageWithURL(URL, forState: state, placeholderImage: nil, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
-
-    /**
-    Set the background image to use for a specified state with a resource and a placeholder image.
-    
-    - parameter resource:         Resource object contains information such as `cacheKey` and `downloadURL`.
-    - parameter state:            The state that uses the specified image.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setBackgroundImageWithResource(resource: Resource,
-                                            forState state: UIControlState,
-                                          placeholderImage: UIImage?) -> RetrieveImageTask
-    {
-        return kf_setBackgroundImageWithResource(resource, forState: state, placeholderImage: placeholderImage, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
-    
-    /**
-    Set the background image to use for a specified state with a URL and a placeholder image.
-    
-    - parameter URL:              The URL of image for specified state.
-    - parameter state:            The state that uses the specified image.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setBackgroundImageWithURL(URL: NSURL,
-                                  forState state: UIControlState,
-                                placeholderImage: UIImage?) -> RetrieveImageTask
-    {
-        return kf_setBackgroundImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: nil, progressBlock: nil, completionHandler: nil)
-    }
-
-    /**
-    Set the background image to use for a specified state with a resource, a placeholder image and options.
-    
-    - parameter resource:         Resource object contains information such as `cacheKey` and `downloadURL`.
-    - parameter state:            The state that uses the specified image.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:      A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setBackgroundImageWithResource(resource: Resource,
-                                            forState state: UIControlState,
-                                          placeholderImage: UIImage?,
-                                               optionsInfo: KingfisherOptionsInfo?) -> RetrieveImageTask
-    {
-        return kf_setBackgroundImageWithResource(resource, forState: state, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: nil)
-    }
-    
-    /**
-    Set the background image to use for a specified state with a URL, a placeholder image and options.
-    
-    - parameter URL:              The URL of image for specified state.
-    - parameter state:            The state that uses the specified image.
-    - parameter placeholderImage: A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:      A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    
-    - returns: A task represents the retrieving process.
-    */
-    public func kf_setBackgroundImageWithURL(URL: NSURL,
-                                  forState state: UIControlState,
-                                placeholderImage: UIImage?,
-                                     optionsInfo: KingfisherOptionsInfo?) -> RetrieveImageTask
-    {
-        return kf_setBackgroundImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: nil)
-    }
-
-    /**
-    Set the background image to use for a specified state with a resource, a placeholder image, options and completion handler.
-    
-    - parameter resource:          Resource object contains information such as `cacheKey` and `downloadURL`.
-    - parameter state:             The state that uses the specified image.
-    - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    - parameter completionHandler: Called when the image retrieved and set.
-    
-    - returns: A task represents the retrieving process.
+     Set the background image to use for a specified state with a URL,
+     a placeholder image, options progress handler and completion handler.
      
-    - note: `completionHandler` will be invoked in main thread.
-     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
-    */
-    public func kf_setBackgroundImageWithResource(resource: Resource,
-                                            forState state: UIControlState,
-                                          placeholderImage: UIImage?,
-                                               optionsInfo: KingfisherOptionsInfo?,
-                                         completionHandler: CompletionHandler?) -> RetrieveImageTask
-    {
-        return kf_setBackgroundImageWithResource(resource, forState: state, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: completionHandler)
-    }
-    
-    /**
-    Set the background image to use for a specified state with a URL, a placeholder image, options and completion handler.
-    
-    - parameter URL:               The URL of image for specified state.
-    - parameter state:             The state that uses the specified image.
-    - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    - parameter completionHandler: Called when the image retrieved and set.
-    
-    - returns: A task represents the retrieving process.
+     - parameter URL:               The URL of image for specified state.
+     - parameter state:             The state that uses the specified image.
+     - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
+     - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
+     - parameter progressBlock:     Called when the image downloading progress gets updated.
+     - parameter completionHandler: Called when the image retrieved and set.
      
-    - note: `completionHandler` will be invoked in main thread.
+     - returns: A task represents the retrieving process.
+     
+     - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread.
      The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
-    */
+     */
     public func kf_setBackgroundImageWithURL(URL: NSURL,
-                                  forState state: UIControlState,
-                                placeholderImage: UIImage?,
-                                     optionsInfo: KingfisherOptionsInfo?,
-                               completionHandler: CompletionHandler?) -> RetrieveImageTask
+                                             forState state: UIControlState,
+                                                      placeholderImage: UIImage?,
+                                                      optionsInfo: KingfisherOptionsInfo?,
+                                                      progressBlock: DownloadProgressBlock?,
+                                                      completionHandler: CompletionHandler?) -> RetrieveImageTask
     {
-        return kf_setBackgroundImageWithURL(URL, forState: state, placeholderImage: placeholderImage, optionsInfo: optionsInfo, progressBlock: nil, completionHandler: completionHandler)
+        return kf_setBackgroundImageWithResource(Resource(downloadURL: URL),
+                                                 forState: state,
+                                                 placeholderImage: placeholderImage,
+                                                 optionsInfo: optionsInfo,
+                                                 progressBlock: progressBlock,
+                                                 completionHandler: completionHandler)
     }
-
+    
+    
     /**
     Set the background image to use for a specified state with a resource,
     a placeholder image, options progress handler and completion handler.
@@ -502,37 +237,6 @@ extension UIButton {
         
         kf_setBackgroundImageTask(task)
         return task
-    }
-    
-    /**
-    Set the background image to use for a specified state with a URL,
-    a placeholder image, options progress handler and completion handler.
-    
-    - parameter URL:               The URL of image for specified state.
-    - parameter state:             The state that uses the specified image.
-    - parameter placeholderImage:  A placeholder image when retrieving the image at URL.
-    - parameter optionsInfo:       A dictionary could control some behaviors. See `KingfisherOptionsInfo` for more.
-    - parameter progressBlock:     Called when the image downloading progress gets updated.
-    - parameter completionHandler: Called when the image retrieved and set.
-    
-    - returns: A task represents the retrieving process.
-     
-    - note: Both the `progressBlock` and `completionHandler` will be invoked in main thread.
-     The `CallbackDispatchQueue` specified in `optionsInfo` will not be used in callbacks of this method.
-    */
-    public func kf_setBackgroundImageWithURL(URL: NSURL,
-                                  forState state: UIControlState,
-                                placeholderImage: UIImage?,
-                                     optionsInfo: KingfisherOptionsInfo?,
-                                   progressBlock: DownloadProgressBlock?,
-                               completionHandler: CompletionHandler?) -> RetrieveImageTask
-    {
-        return kf_setBackgroundImageWithResource(Resource(downloadURL: URL),
-                                        forState: state,
-                                placeholderImage: placeholderImage,
-                                     optionsInfo: optionsInfo,
-                                   progressBlock: progressBlock,
-                               completionHandler: completionHandler)
     }
 }
 


### PR DESCRIPTION
Since Xcode autocompletion improves for Swift 2.2.