### PR TITLE
Application object Unretained Value

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -645,7 +645,7 @@ extension UIApplication {
     public static func kf_sharedApplication() -> UIApplication? {
         let selector = NSSelectorFromString("sharedApplication")
         guard respondsToSelector(selector) else { return nil }
-        return performSelector(selector).takeRetainedValue() as? UIApplication
+        return performSelector(selector).takeUnretainedValue() as? UIApplication
     }
 }
 #endif


### PR DESCRIPTION
Fix a crash when switching app to background and foreground multiple times, due to an over-releasing of application object.