### PR TITLE
Fix name min length violation by SwiftLint

### DIFF
--- a/Sources/AnimatedImageView.swift
+++ b/Sources/AnimatedImageView.swift
@@ -370,6 +370,6 @@ extension Array {
     }
 }
 
-func pure<T>(a: T) -> [T] {
-    return [a]
+private func pure<T>(type: T) -> [T] {
+    return [type]
 }


### PR DESCRIPTION
Fix the following error by SwiftLint and set the `pure` function's scope private.

`error: Variable Name Min Length Rule Violation: Variable name should be 2 characters or more: currently 1 characters (variable_name_min_length)`

If you'd like to allow the violation, please add `- variable_name_min_length` in `.swiftlint.yml` as a disabled_rules.