### PR TITLE
Avoid variable name min length rule violation by SwiftLint

### DIFF
--- a/Sources/AnimatedImageView.swift
+++ b/Sources/AnimatedImageView.swift
@@ -370,6 +370,6 @@ extension Array {
     }
 }
 
-func pure<T>(a: T) -> [T] {
-    return [a]
+private func pure<T>(value: T) -> [T] {
+    return [value]
 }


### PR DESCRIPTION
I replaced `type` with `value`. Thank you for pointing it out.

This PR is related to https://github.com/onevcat/Kingfisher/pull/312.