### PR TITLE
Removed Implicit Unwrapping of CacheType

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -243,7 +243,7 @@ extension ImageCache {
     
     - returns: The retrieving task.
     */
-    public func retrieveImageForKey(key: String, options: KingfisherOptionsInfo?, completionHandler: ((Image?, CacheType!) -> ())?) -> RetrieveImageDiskTask? {
+    public func retrieveImageForKey(key: String, options: KingfisherOptionsInfo?, completionHandler: ((Image?, CacheType) -> ())?) -> RetrieveImageDiskTask? {
         // No completion handler. Not start working and early return.
         guard let completionHandler = completionHandler else {
             return nil
@@ -281,7 +281,7 @@ extension ImageCache {
                 } else {
                     // No image found from either memory or disk
                     dispatch_async_safely_to_queue(options.callbackDispatchQueue, { () -> Void in
-                        completionHandler(nil, nil)
+                        completionHandler(nil, .None)
                         sSelf = nil
                     })
                 }

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -164,7 +164,8 @@ class ImageCacheTests: XCTestCase {
         
         cache.retrieveImageForKey(URLString, options: nil, completionHandler: { (image, type) -> () in
             XCTAssertNil(image, "Should not be cached yet")
-            XCTAssertEqual(type, nil)
+            
+            XCTAssertEqual(type, CacheType.None)
 
             self.cache.storeImage(testImage, forKey: URLString, toDisk: true) { () -> () in
                 self.cache.retrieveImageForKey(URLString, options: nil, completionHandler: { (image, type) -> () in


### PR DESCRIPTION
First of all thank you for your fantastic Library!
We notified some crashes in production cause by the fact that the cache type was implicitly unwrapped and if was `nil` if the image is not cached 