### PR TITLE
Cancel donwloading when status code is invalid

### DIFF
--- a/Sources/ImageDownloader.swift
+++ b/Sources/ImageDownloader.swift
@@ -85,6 +85,7 @@ The error code.
 public enum KingfisherError: Int {
     case BadData = 10000
     case NotModified = 10001
+    case InvalidStatusCode = 10002
     case InvalidURL = 20000
 }
 
@@ -364,6 +365,12 @@ class ImageDownloaderSessionHandler: NSObject, NSURLSessionDataDelegate, Authent
     This method is exposed since the compiler requests. Do not call it.
     */
     internal func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveResponse response: NSURLResponse, completionHandler: (NSURLSessionResponseDisposition) -> Void) {
+        
+        // If server response is not 200 or 201, inform the callback handler with InvalidStatusCode error.
+        // InvalidStatusCode error has status code and localized description in userInfo.
+        if let statusCode = (response as? NSHTTPURLResponse)?.statusCode, let URL = dataTask.originalRequest?.URL where statusCode != 200 && statusCode != 201 {
+            callbackWithImage(nil, error: NSError(domain: KingfisherErrorDomain, code: KingfisherError.InvalidStatusCode.rawValue, userInfo: ["statusCode": statusCode, "localizedStringForStatusCode": NSHTTPURLResponse.localizedStringForStatusCode(statusCode)]), imageURL: URL, originalData: nil)
+        }
         
         completionHandler(NSURLSessionResponseDisposition.Allow)
     }

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -160,6 +160,23 @@ class ImageDownloaderTests: XCTestCase {
         waitForExpectationsWithTimeout(5, handler: nil)
     }
     
+    func testServerInvalidStatusCode() {
+        let expectation = expectationWithDescription("wait for response which has invalid status code")
+        
+        let URLString = testKeys[0]
+        stubRequest("GET", URLString).andReturn(404).withBody(testImageData)
+        
+        downloader.downloadImageWithURL(NSURL(string: URLString)!, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+            
+        }) { (image, error, imageURL, data) -> () in
+            XCTAssertNotNil(error, "There should be an error since server returning 404")
+            XCTAssertEqual(error!.code, KingfisherError.InvalidStatusCode.rawValue, "The error should be InvalidStatusCode.")
+            XCTAssertEqual(error!.userInfo["statusCode"]! as? Int, 404, "The error should be InvalidStatusCode.")
+            expectation.fulfill()
+        }
+        waitForExpectationsWithTimeout(5, handler: nil)
+    }
+    
     // Since we could not receive one challage, no test for trusted hosts currently.
     // See http://stackoverflow.com/questions/27065372/why-is-a-https-nsurlsession-connection-only-challenged-once-per-domain for more.
     func testSSLCertificateValidation() {


### PR DESCRIPTION
This is mentioned at #245 

This change will make kingfisher to avoid to cache image when server respond with invalid status code like 404.
When status code is not 200 or 201, callback handler include error which has status code and localized description.

Thank you for your great library.