### PR TITLE
Swiftlint 

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,3 +8,6 @@ disabled_rules:
   - type_body_length
   - valid_docs
   - function_parameter_count
+  - type_name
+  - force_try
+  - conditional_binding_cascade


### PR DESCRIPTION
Disables swiftlint rules that fail with swift 3.
type_name and conditional_binding_cascade are bugs/errors in swift lint