### PR TITLE
Update to Swift 3 Xcode 8b4

### DIFF
--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -800,6 +800,14 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					0431672F00E625C6DD8D07F4F91103A6 = {
+						LastSwiftMigration = 0800;
+					};
+					921D07FCE35724A5EEF6DD5A4E6F5BC3 = {
+						LastSwiftMigration = 0800;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1004,6 +1012,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1164,6 +1173,7 @@
 				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -1181,6 +1191,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -1240,6 +1251,7 @@
 				PUBLIC_HEADERS_FOLDER_PATH = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};

--- a/Sources/AnimatedImageView.swift
+++ b/Sources/AnimatedImageView.swift
@@ -107,17 +107,17 @@ public class AnimatedImageView: UIImageView {
         }
     }
     
-    override public func isAnimating() -> Bool {
+    override public var isAnimating: Bool {
         if displayLinkInitialized {
             return !displayLink.isPaused
         } else {
-            return super.isAnimating()
+            return super.isAnimating
         }
     }
     
     /// Starts the animation.
     override public func startAnimating() {
-        if self.isAnimating() {
+        if self.isAnimating {
             return
         } else {
             displayLink.isPaused = false
@@ -169,7 +169,7 @@ public class AnimatedImageView: UIImageView {
     
     private func didMove() {
         if autoPlayAnimatedImage && animator != nil {
-            if let _ = superview, _ = window {
+            if let _ = superview, let _ = window {
                 startAnimating()
             } else {
                 stopAnimating()
@@ -248,8 +248,8 @@ class Animator {
         frameCount = CGImageSourceGetCount(imageSource)
         
         if let properties = CGImageSourceCopyProperties(imageSource, nil),
-            gifInfo = (properties as NSDictionary)[kCGImagePropertyGIFDictionary as String] as? NSDictionary,
-            loopCount = gifInfo[kCGImagePropertyGIFLoopCount as String] as? Int {
+            let gifInfo = (properties as NSDictionary)[kCGImagePropertyGIFDictionary as String] as? NSDictionary,
+            let loopCount = gifInfo[kCGImagePropertyGIFLoopCount as String] as? Int {
             self.loopCount = loopCount
         }
         
@@ -296,7 +296,7 @@ class Animator {
      */
     func updateCurrentFrame(_ duration: CFTimeInterval) -> Bool {
         timeSinceLastFrameChange += min(maxTimeStep, duration)
-        guard let frameDuration = animatedFrames[safe: currentFrameIndex]?.duration where frameDuration <= timeSinceLastFrameChange else {
+        guard let frameDuration = animatedFrames[safe: currentFrameIndex]?.duration, frameDuration <= timeSinceLastFrameChange else {
             return false
         }
         

--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -125,7 +125,7 @@ extension Image {
         return nil
     }
 #else
-    static func kf_imageWithCGImage(cgImage: CGImage, scale: CGFloat, refImage: Image?) -> Image {
+    static func kf_imageWithCGImage(_ cgImage: CGImage, scale: CGFloat, refImage: Image?) -> Image {
         if let refImage = refImage {
             return Image(cgImage: cgImage, scale: scale, orientation: refImage.imageOrientation)
         } else {
@@ -248,15 +248,15 @@ extension Image {
                 } else {
                     // Animated GIF
                     guard let properties = CGImageSourceCopyPropertiesAtIndex(imageSource, i, nil),
-                        gifInfo = (properties as NSDictionary)[kCGImagePropertyGIFDictionary as String] as? NSDictionary,
-                        frameDuration = (gifInfo[kCGImagePropertyGIFDelayTime as String] as? NSNumber) else
+                        let gifInfo = (properties as NSDictionary)[kCGImagePropertyGIFDictionary as String] as? NSDictionary,
+                        let frameDuration = (gifInfo[kCGImagePropertyGIFDelayTime as String] as? NSNumber) else
                     {
                         return nil
                     }
                     gifDuration += frameDuration.doubleValue
                 }
                 
-                images.append(Image.kf_imageWithCGImage(cgImage: imageRef, scale: scale, refImage: nil))
+                images.append(Image.kf_imageWithCGImage(imageRef, scale: scale, refImage: nil))
             }
             
             return (images, gifDuration)
@@ -348,7 +348,7 @@ extension Image {
             let rect = CGRect(x: 0, y: 0, width: (imageRef?.width)!, height: (imageRef?.height)!)
             context.draw(in: rect, image: imageRef!)
             let decompressedImageRef = context.makeImage()
-            return Image.kf_imageWithCGImage(cgImage: decompressedImageRef!, scale: scale, refImage: self)
+            return Image.kf_imageWithCGImage(decompressedImageRef!, scale: scale, refImage: self)
         } else {
             return nil
         }

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -73,7 +73,7 @@ public enum CacheType {
 public class ImageCache {
 
     //Memory
-    private let memoryCache = Cache<NSString, AnyObject>()
+    private let memoryCache = NSCache<NSString, AnyObject>()
     
     /// The largest cache cost of memory cache. The total cost is pixel count of all cached images in memory.
     public var maxMemoryCost: UInt = 0 {
@@ -123,8 +123,8 @@ public class ImageCache {
         let dstPath = path ?? NSSearchPathForDirectoriesInDomains(.cachesDirectory, FileManager.SearchPathDomainMask.userDomainMask, true).first!
         diskCachePath = (dstPath as NSString).appendingPathComponent(cacheName)
         
-        ioQueue = DispatchQueue(label: ioQueueName + name, attributes: DispatchQueueAttributes.serial)
-        processQueue = DispatchQueue(label: processQueueName + name, attributes: DispatchQueueAttributes.concurrent)
+        ioQueue = DispatchQueue(label: ioQueueName + name)
+        processQueue = DispatchQueue(label: processQueueName + name, attributes: [.concurrent])
         
         ioQueue.sync(execute: { () -> Void in
             self.fileManager = FileManager()
@@ -392,7 +392,7 @@ extension ImageCache {
                     resourceValue1, resourceValue2 -> Bool in
                     
                     if let date1 = resourceValue1[URLResourceKey.contentModificationDateKey] as? Date,
-                           date2 = resourceValue2[URLResourceKey.contentModificationDateKey] as? Date {
+                           let date2 = resourceValue2[URLResourceKey.contentModificationDateKey] as? Date {
                         return date1.compare(date2) == .orderedAscending
                     }
                     // Not valid date information. This should not happen. Just in case.
@@ -423,7 +423,7 @@ extension ImageCache {
                 
                 if URLsToDelete.count != 0 {
                     let cleanedHashes = URLsToDelete.map({ (url) -> String in
-                        return url.lastPathComponent!
+                        return url.lastPathComponent
                     })
                     
                     NotificationCenter.default.post(name: KingfisherDidCleanDiskCacheNotification, object: self, userInfo: [KingfisherDiskCacheCleanedHashKey: cleanedHashes])
@@ -444,11 +444,8 @@ extension ImageCache {
         var URLsToDelete = [URL]()
         var diskCacheSize: UInt = 0
         
-        let resourceKeysString = resourceKeys.map { (key) -> String in
-            return key.rawValue
-        }
-        if let fileEnumerator = self.fileManager.enumerator(at: diskCacheURL, includingPropertiesForKeys: resourceKeysString, options: FileManager.DirectoryEnumerationOptions.skipsHiddenFiles, errorHandler: nil),
-            urls = fileEnumerator.allObjects as? [URL] {
+        if let fileEnumerator = self.fileManager.enumerator(at: diskCacheURL, includingPropertiesForKeys: resourceKeys, options: FileManager.DirectoryEnumerationOptions.skipsHiddenFiles, errorHandler: nil),
+            let urls = fileEnumerator.allObjects as? [URL] {
                 for fileURL in urls {
                     
                     do {

--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -123,7 +123,7 @@ extension ImageView {
             completionHandler: {[weak self] image, error, cacheType, imageURL in
                 
                 dispatch_async_safely_to_main_queue {
-                    guard let sSelf = self where imageURL == sSelf.kf_webURL else {
+                    guard let sSelf = self, imageURL == sSelf.kf_webURL else {
                         return
                     }
                     
@@ -136,7 +136,7 @@ extension ImageView {
                     }
                     
                     if let transitionItem = options.kf_firstMatchIgnoringAssociatedValue(.transition(.none)),
-                        case .transition(let transition) = transitionItem where ( options.forceTransition || cacheType == .none) {
+                        case .transition(let transition) = transitionItem, ( options.forceTransition || cacheType == .none) {
                             #if !os(OSX)
                                 UIView.transition(with: sSelf, duration: 0.0, options: [],
                                     animations: {

--- a/Sources/KingfisherManager.swift
+++ b/Sources/KingfisherManager.swift
@@ -123,7 +123,7 @@ public class KingfisherManager {
     {
         let task = RetrieveImageTask()
 
-        if let optionsInfo = optionsInfo where optionsInfo.forceRefresh {
+        if let optionsInfo = optionsInfo, optionsInfo.forceRefresh {
             _ = downloadAndCacheImageWithURL(resource.downloadURL as URL,
                 forKey: resource.cacheKey,
                 retrieveImageTask: task,
@@ -183,7 +183,7 @@ public class KingfisherManager {
             completionHandler: { image, error, imageURL, originalData in
 
                 let targetCache = options?.targetCache ?? self.cache
-                if let error = error where error.code == KingfisherError.notModified.rawValue {
+                if let error = error, error.code == KingfisherError.notModified.rawValue {
                     // Not modified. Try to find the image from cache.
                     // (The image should be in cache. It should be guaranteed by the framework users.)
                     targetCache.retrieveImageForKey(key, options: options, completionHandler: { (cacheImage, cacheType) -> () in
@@ -193,7 +193,7 @@ public class KingfisherManager {
                     return
                 }
                 
-                if let image = image, originalData = originalData {
+                if let image = image, let originalData = originalData {
                     targetCache.storeImage(image, originalData: originalData, forKey: key, toDisk: !(options?.cacheMemoryOnly ?? false), completionHandler: nil)
                 }
 

--- a/Sources/Resource.swift
+++ b/Sources/Resource.swift
@@ -49,6 +49,6 @@ public struct Resource {
      */
     public init(downloadURL: URL, cacheKey: String? = nil) {
         self.downloadURL = downloadURL
-        self.cacheKey = cacheKey ?? downloadURL.absoluteString!
+        self.cacheKey = cacheKey ?? downloadURL.absoluteString
     }
 }

--- a/Sources/String+MD5.swift
+++ b/Sources/String+MD5.swift
@@ -43,7 +43,7 @@ extension String {
 func arrayOfBytes<T>(_ value: T, length: Int? = nil) -> [UInt8] {
     let totalBytes = length ?? (sizeofValue(value) * 8)
     
-    let valuePointer = UnsafeMutablePointer<T>(allocatingCapacity: 1)
+    let valuePointer = UnsafeMutablePointer<T>.allocate(capacity: 1)
     valuePointer.pointee = value
     
     let bytesPointer = UnsafeMutablePointer<UInt8>(valuePointer)
@@ -53,7 +53,7 @@ func arrayOfBytes<T>(_ value: T, length: Int? = nil) -> [UInt8] {
     }
     
     valuePointer.deinitialize()
-    valuePointer.deallocateCapacity(1)
+    valuePointer.deallocate(capacity: 1)
     
     return bytes
 }

--- a/Sources/UIButton+Kingfisher.swift
+++ b/Sources/UIButton+Kingfisher.swift
@@ -102,7 +102,7 @@ extension UIButton {
             },
             completionHandler: {[weak self] image, error, cacheType, imageURL in
                 dispatch_async_safely_to_main_queue {
-                    guard let sSelf = self where imageURL == sSelf.kf_webURLForState(state) else {
+                    guard let sSelf = self, imageURL == sSelf.kf_webURLForState(state) else {
                         return
                     }
                     
@@ -241,7 +241,7 @@ extension UIButton {
             },
             completionHandler: { [weak self] image, error, cacheType, imageURL in
                 dispatch_async_safely_to_main_queue {
-                    guard let sSelf = self where imageURL == sSelf.kf_backgroundWebURLForState(state) else {
+                    guard let sSelf = self, imageURL == sSelf.kf_backgroundWebURLForState(state) else {
                         return
                     }
                     

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -73,7 +73,7 @@ class ImageCacheTests: XCTestCase {
     
     func testClearDiskCache() {
         
-        let expectation = self.expectation(withDescription: "wait for clearing disk cache")
+        let expectation = self.expectation(description: "wait for clearing disk cache")
         let key = testKeys[0]
         
         cache.storeImage(testImage, originalData: testImageData, forKey: key, toDisk: true) { () -> () in
@@ -88,11 +88,11 @@ class ImageCacheTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        waitForExpectations(withTimeout: 10, handler:nil)
+        waitForExpectations(timeout: 10, handler:nil)
     }
     
     func testClearMemoryCache() {
-        let expectation = self.expectation(withDescription: "wait for retrieving image")
+        let expectation = self.expectation(description: "wait for retrieving image")
         
         cache.storeImage(testImage, originalData: testImageData, forKey: testKeys[0], toDisk: true) { () -> () in
             self.cache.clearMemoryCache()
@@ -103,11 +103,11 @@ class ImageCacheTests: XCTestCase {
             })
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testNoImageFound() {
-        let expectation = self.expectation(withDescription: "wait for retrieving image")
+        let expectation = self.expectation(description: "wait for retrieving image")
         
         cache.clearDiskCacheWithCompletionHandler { () -> () in
             self.cache.retrieveImageForKey(testKeys[0], options: nil, completionHandler: { (image, type) -> () in
@@ -117,11 +117,11 @@ class ImageCacheTests: XCTestCase {
             return
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testStoreImageInMemory() {
-        let expectation = self.expectation(withDescription: "wait for retrieving image")
+        let expectation = self.expectation(description: "wait for retrieving image")
         
         cache.storeImage(testImage, forKey: testKeys[0], toDisk: false) { () -> () in
             self.cache.retrieveImageForKey(testKeys[0], options: nil, completionHandler: { (image, type) -> () in
@@ -131,11 +131,11 @@ class ImageCacheTests: XCTestCase {
             return
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testStoreMultipleImages() {
-        let expectation = self.expectation(withDescription: "wait for writing image")
+        let expectation = self.expectation(description: "wait for writing image")
         
         storeMultipleImages { () -> () in
             let diskCachePath = self.cache.diskCachePath
@@ -150,11 +150,11 @@ class ImageCacheTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCachedFileExists() {
-        let expectation = self.expectation(withDescription: "cache does contain image")
+        let expectation = self.expectation(description: "cache does contain image")
         
         let URLString = testKeys[0]
         let URL = Foundation.URL(string: URLString)!
@@ -189,7 +189,7 @@ class ImageCacheTests: XCTestCase {
             }
         })
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCachedFileDoesNotExist() {
@@ -215,7 +215,7 @@ class ImageCacheTests: XCTestCase {
     }
 
     func testIsImageCachedForKey() {
-        let expectation = self.expectation(withDescription: "wait for caching image")
+        let expectation = self.expectation(description: "wait for caching image")
         
         XCTAssert(self.cache.isImageCachedForKey(testKeys[0]).cached == false, "This image should not be cached yet.")
         self.cache.storeImage(testImage, originalData: testImageData, forKey: testKeys[0], toDisk: true) { () -> () in
@@ -223,12 +223,12 @@ class ImageCacheTests: XCTestCase {
             expectation.fulfill()
         }
 
-        self.waitForExpectations(withTimeout: 5, handler: nil)
+        self.waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testRetrievingImagePerformance() {
 
-        let expectation = self.expectation(withDescription: "wait for retrieving image")
+        let expectation = self.expectation(description: "wait for retrieving image")
         self.cache.storeImage(testImage, originalData: testImageData, forKey: testKeys[0], toDisk: true) { () -> () in
             self.measure({ () -> Void in
                 for _ in 1 ..< 1000 {
@@ -238,11 +238,11 @@ class ImageCacheTests: XCTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectations(withTimeout: 20, handler: nil)
+        self.waitForExpectations(timeout: 20, handler: nil)
     }
     
     func testCleanDiskCacheNotification() {
-        let expectation = self.expectation(withDescription: "wait for retrieving image")
+        let expectation = self.expectation(description: "wait for retrieving image")
         
         cache.storeImage(testImage, originalData: testImageData, forKey: testKeys[0], toDisk: true) { () -> () in
 
@@ -267,7 +267,7 @@ class ImageCacheTests: XCTestCase {
             self.cache.cleanExpiredDiskCache()
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     // MARK: - Helper

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -56,7 +56,7 @@ class ImageDownloaderTests: XCTestCase {
     }
     
     func testDownloadAnImage() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
@@ -69,11 +69,11 @@ class ImageDownloaderTests: XCTestCase {
             XCTAssert(image != nil, "Download should be able to finished for URL: \(imageURL)")
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testDownloadMultipleImages() {
-        let expectation = self.expectation(withDescription: "wait for all downloading finish")
+        let expectation = self.expectation(description: "wait for all downloading finish")
         
         let group = DispatchGroup()
         
@@ -94,11 +94,11 @@ class ImageDownloaderTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testDownloadAnImageWithMultipleCallback() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let group = DispatchGroup()
         let URLString = testKeys[0]
@@ -119,11 +119,11 @@ class ImageDownloaderTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testDownloadWithModifyingRequest() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
 
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
@@ -141,11 +141,11 @@ class ImageDownloaderTests: XCTestCase {
             XCTAssertEqual(imageURL!, URL(string: URLString)!, "The returned imageURL should be the replaced one")
             expectation.fulfill()
         }
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testServerNotModifiedResponse() {
-        let expectation = self.expectation(withDescription: "wait for server response 304")
+        let expectation = self.expectation(description: "wait for server response 304")
         
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(304)
@@ -157,7 +157,7 @@ class ImageDownloaderTests: XCTestCase {
             XCTAssertEqual(error!.code, KingfisherError.notModified.rawValue, "The error should be NotModified.")
             expectation.fulfill()
         }
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     // Since we could not receive one challage, no test for trusted hosts currently.
@@ -169,7 +169,7 @@ class ImageDownloaderTests: XCTestCase {
         
         let URL = Foundation.URL(string: "https://testssl-expire.disig.sk/Expired.png")!
         
-        let expectation = self.expectation(withDescription: "wait for download from an invalid ssl site.")
+        let expectation = self.expectation(description: "wait for download from an invalid ssl site.")
         
         downloader.downloadImageWithURL(URL, progressBlock: nil, completionHandler: { (image, error, imageURL, data) -> () in
             XCTAssertNotNil(error, "Error should not be nil")
@@ -178,14 +178,14 @@ class ImageDownloaderTests: XCTestCase {
             LSNocilla.sharedInstance().start()
         })
         
-        waitForExpectations(withTimeout: 20) { (error) in
+        waitForExpectations(timeout: 20) { (error) in
             XCTAssertNil(error, "\(error)")
             LSNocilla.sharedInstance().start()
         }
     }
     
     func testDownloadResultErrorAndRetry() {
-        let expectation = self.expectation(withDescription: "wait for downloading error")
+        let expectation = self.expectation(description: "wait for downloading error")
         
         let URLString = testKeys[0]
         stubRequest("GET", URLString).andFailWithError(NSError(domain: "stubError", code: -1, userInfo: nil))
@@ -204,22 +204,24 @@ class ImageDownloaderTests: XCTestCase {
             })
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
-    
-    func testDownloadEmptyURL() {
-        let expectation = self.expectation(withDescription: "wait for downloading error")
-        
-        downloader.downloadImageWithURL(URL(string: "")!, progressBlock: { (receivedSize, totalSize) -> () in
-            XCTFail("The progress block should not be called.")
-            }) { (image, error, imageURL, originalData) -> () in
-                XCTAssertNotNil(error, "An error should happen for empty URL")
-                XCTAssertEqual(error!.code, KingfisherError.invalidURL.rawValue)
-                expectation.fulfill()
-        }
-        waitForExpectations(withTimeout: 5, handler: nil)
-    }
-    
+
+    // FIXME: The test below must be removed or revised, since `URL(string: "")` will always return `nil` in Swift 3
+    //
+    //    func testDownloadEmptyURL() {
+    //        let expectation = self.expectation(description: "wait for downloading error")
+    //
+    //        downloader.downloadImageWithURL(URL(string: "")!, progressBlock: { (receivedSize, totalSize) -> () in
+    //            XCTFail("The progress block should not be called.")
+    //            }) { (image, error, imageURL, originalData) -> () in
+    //                XCTAssertNotNil(error, "An error should happen for empty URL")
+    //                XCTAssertEqual(error!.code, KingfisherError.invalidURL.rawValue)
+    //                expectation.fulfill()
+    //        }
+    //        waitForExpectations(timeout: 5, handler: nil)
+    //    }
+
     func testDownloadTaskProperty() {
         let task = downloader.downloadImageWithURL(URL(string: "1234")!, progressBlock: { (receivedSize, totalSize) -> () in
 
@@ -233,7 +235,7 @@ class ImageDownloaderTests: XCTestCase {
     
     func testCancelDownloadTask() {
         
-        let expectation = self.expectation(withDescription: "wait for downloading")
+        let expectation = self.expectation(description: "wait for downloading")
         
         let URLString = testKeys[0]
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
@@ -255,17 +257,18 @@ class ImageDownloaderTests: XCTestCase {
         downloadTask!.cancel()
         _ = stub!.go()
         
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.09)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.09)) / Double(NSEC_PER_SEC)) { () -> Void in
             expectation.fulfill()
             XCTAssert(progressBlockIsCalled == false, "ProgressBlock should not be called since it is canceled.")
             XCTAssert(completionBlockIsCalled == true, "CompletionBlock should be called with error.")
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
-    
-    func testDownloadTaskNil() {
-        let downloadTask = downloader.downloadImageWithURL(URL(string: "")!, progressBlock: nil, completionHandler: nil)
-        XCTAssertNil(downloadTask)
-    }
+
+    // FIXME: Revise or remove this test. `URL(string: "")` will always return `nil`.
+    //    func testDownloadTaskNil() {
+    //        let downloadTask = downloader.downloadImageWithURL(URL(string: "")!, progressBlock: nil, completionHandler: nil)
+    //        XCTAssertNil(downloadTask)
+    //    }
 }

--- a/Tests/KingfisherTests/ImagePrefetcherTests.swift
+++ b/Tests/KingfisherTests/ImagePrefetcherTests.swift
@@ -58,7 +58,7 @@ class ImagePrefetcherTests: XCTestCase {
     }
 
     func testPrefetchingImages() {
-        let expectation = self.expectation(withDescription: "wait for prefetching images")
+        let expectation = self.expectation(description: "wait for prefetching images")
         
         var urls = [URL]()
         for URLString in testKeys {
@@ -76,17 +76,17 @@ class ImagePrefetcherTests: XCTestCase {
                 XCTAssertEqual(completedResources.count, urls.count, "All resources prefetching should be completed.")
                 XCTAssertEqual(progressCalledCount, urls.count, "Progress should be called the same time of download count.")
                 for url in urls {
-                    XCTAssertTrue(KingfisherManager.sharedManager.cache.isImageCachedForKey(url.absoluteString!).cached)
+                    XCTAssertTrue(KingfisherManager.sharedManager.cache.isImageCachedForKey(url.absoluteString).cached)
                 }
         }
         
         prefetcher.start()
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCancelPrefetching() {
-        let expectation = self.expectation(withDescription: "wait for prefetching images")
+        let expectation = self.expectation(description: "wait for prefetching images")
         
         var urls = [URL]()
         var responses = [LSStubResponseDSL!]()
@@ -112,16 +112,15 @@ class ImagePrefetcherTests: XCTestCase {
         prefetcher.stop()
         
         let delayTime = DispatchTime.now() + Double(Int64(0.1 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
-        DispatchQueue.main.after(when: delayTime) {
+        DispatchQueue.main.asyncAfter(deadline: delayTime) {
             responses.forEach { _ = $0!.go() }
         }
-
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
 
     func testPrefetcherCouldSkipCachedImages() {
-        let expectation = self.expectation(withDescription: "wait for prefetching images")
+        let expectation = self.expectation(description: "wait for prefetching images")
         KingfisherManager.sharedManager.cache.storeImage(Image(), forKey: testKeys[0])
         
         var urls = [URL]()
@@ -143,11 +142,11 @@ class ImagePrefetcherTests: XCTestCase {
         
         prefetcher.start()
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testPrefetcherForceRefreshDownloadImages() {
-        let expectation = self.expectation(withDescription: "wait for prefetching images")
+        let expectation = self.expectation(description: "wait for prefetching images")
         
         // Store an image in cache.
         KingfisherManager.sharedManager.cache.storeImage(Image(), forKey: testKeys[0])
@@ -171,11 +170,11 @@ class ImagePrefetcherTests: XCTestCase {
         
         prefetcher.start()
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testPrefetchWithWrongInitParameters() {
-        let expectation = self.expectation(withDescription: "wait for prefetching images")
+        let expectation = self.expectation(description: "wait for prefetching images")
         let prefetcher = ImagePrefetcher(urls: [], optionsInfo: nil, progressBlock: nil) { (skippedResources, failedResources, completedResources) -> () in
             expectation.fulfill()
             
@@ -185,6 +184,6 @@ class ImagePrefetcherTests: XCTestCase {
         }
         
         prefetcher.start()
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 }

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -60,7 +60,7 @@ class ImageViewExtensionTests: XCTestCase {
     }
 
     func testImageDownloadForImageView() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
@@ -84,17 +84,17 @@ class ImageViewExtensionTests: XCTestCase {
             XCTAssertTrue(Thread.isMainThread)
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testImageDownloadCompletionHandlerRunningOnMainQueue() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
         let URL = Foundation.URL(string: URLString)!
         
-        let customQueue = DispatchQueue(label: "com.kingfisher.testQueue", attributes: DispatchQueueAttributes.serial)
+        let customQueue = DispatchQueue(label: "com.kingfisher.testQueue")
         imageView.kf_setImageWithURL(URL, placeholderImage: nil, optionsInfo: [.callbackDispatchQueue(customQueue)], progressBlock: { (receivedSize, totalSize) -> () in
             XCTAssertTrue(Thread.isMainThread)
         }) { (image, error, cacheType, imageURL) -> () in
@@ -102,11 +102,11 @@ class ImageViewExtensionTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testImageDownloadWithResourceForImageView() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
@@ -131,11 +131,11 @@ class ImageViewExtensionTests: XCTestCase {
                 XCTAssert(cacheType == .none, "The cache type should be none here. This image was just downloaded. But now is: \(cacheType)")
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testImageDownloadCancelForImageView() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
 
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
@@ -152,17 +152,17 @@ class ImageViewExtensionTests: XCTestCase {
 
         task.cancel()
         
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.09)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.09)) / Double(NSEC_PER_SEC)) { () -> Void in
             expectation.fulfill()
             XCTAssert(progressBlockIsCalled == false, "ProgressBlock should not be called since it is canceled.")
             XCTAssert(completionBlockIsCalled == false, "CompletionBlock should not be called since it is canceled.")
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testImageDownloadCancelForImageViewAfterRequestStarted() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
@@ -181,22 +181,22 @@ class ImageViewExtensionTests: XCTestCase {
                 completionBlockIsCalled = true
         }
         
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
             task.cancel()
             _ = stub!.go()
         }
 
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.2)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.2)) / Double(NSEC_PER_SEC)) { () -> Void in
             expectation.fulfill()
             XCTAssert(progressBlockIsCalled == false, "ProgressBlock should not be called since it is canceled.")
             XCTAssert(completionBlockIsCalled == true, "CompletionBlock should be called with error.")
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testImageDownloadCancelPartialTaskBeforeRequest() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
@@ -227,22 +227,22 @@ class ImageViewExtensionTests: XCTestCase {
         }
         
         task1.cancel()
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
             _ = stub!.go()
         }
         
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.2)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.2)) / Double(NSEC_PER_SEC)) { () -> Void in
             expectation.fulfill()
             XCTAssert(task1Completion == false, "Task 1 should be not completed since it is cancelled before downloading started.")
             XCTAssert(task2Completion == true, "Task 2 should be completed.")
             XCTAssert(task3Completion == true, "Task 3 should be completed.")
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testImageDownloadCancelPartialTaskAfterRequestStarted() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
@@ -273,23 +273,23 @@ class ImageViewExtensionTests: XCTestCase {
                 task3Completion = true
         }
         
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
             task1.cancel()
             _ = stub!.go()
         }
         
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.2)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.2)) / Double(NSEC_PER_SEC)) { () -> Void in
             expectation.fulfill()
             XCTAssert(task1Completion == true, "Task 1 should be completed since task 2 and 3 are not cancelled and they are sharing the same downloading process.")
             XCTAssert(task2Completion == true, "Task 2 should be completed.")
             XCTAssert(task3Completion == true, "Task 3 should be completed.")
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testImageDownloadCancelAllTasksAfterRequestStarted() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
@@ -323,21 +323,21 @@ class ImageViewExtensionTests: XCTestCase {
                 task3Completion = true
         }
         
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
             task1.cancel()
             task2.cancel()
             task3.cancel()
             _ = stub!.go()
         }
         
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.2)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.2)) / Double(NSEC_PER_SEC)) { () -> Void in
             expectation.fulfill()
             XCTAssert(task1Completion == true, "Task 1 should be completed with error.")
             XCTAssert(task2Completion == true, "Task 2 should be completed with error.")
             XCTAssert(task3Completion == true, "Task 3 should be completed with error.")
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testImageDownloadMultipleCaches() {
@@ -348,7 +348,7 @@ class ImageViewExtensionTests: XCTestCase {
         cache1.clearDiskCache()
         cache2.clearDiskCache()
         
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
@@ -377,7 +377,7 @@ class ImageViewExtensionTests: XCTestCase {
             
         }
         
-        waitForExpectations(withTimeout: 5, handler: { (error) -> Void in
+        waitForExpectations(timeout: 5, handler: { (error) -> Void in
             clearCaches([cache1, cache2])
         })
     }
@@ -393,7 +393,7 @@ class ImageViewExtensionTests: XCTestCase {
     func testIndicatorViewAnimating() {
         imageView.kf_showIndicatorWhenLoading = true
         
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
@@ -411,11 +411,11 @@ class ImageViewExtensionTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCacnelImageTask() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
@@ -430,16 +430,16 @@ class ImageViewExtensionTests: XCTestCase {
                 expectation.fulfill()
         }
         
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
             self.imageView.kf_cancelDownloadTask()
             _ = stub!.go()
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testDownloadForMutipleURLs() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLStrings = [testKeys[0], testKeys[1]]
         _ = stubRequest("GET", URLStrings[0]).andReturn(200)?.withBody(testImageData)
@@ -467,18 +467,18 @@ class ImageViewExtensionTests: XCTestCase {
                 XCTAssertEqual(self.imageView.image, image)
         }
         
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
             XCTAssertFalse(task1Complete, "Task 1 should not be completed since task 2 overrides it.")
             XCTAssertTrue(task2Complete, "Task 2 should be completed.")
 
             expectation.fulfill()
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testSettingNilURL() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URL: Foundation.URL? = nil
         imageView.kf_setImageWithURL(URL, placeholderImage: nil, optionsInfo: nil, progressBlock: { (receivedSize, totalSize) -> () in
@@ -492,6 +492,6 @@ class ImageViewExtensionTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 }

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -56,7 +56,7 @@ class KingfisherManagerTests: XCTestCase {
     
     func testRetrieveImage() {
         
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
         
@@ -90,11 +90,11 @@ class KingfisherManagerTests: XCTestCase {
             }
         }
 
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testRetrieveImageNotModified() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
         
@@ -127,12 +127,12 @@ class KingfisherManagerTests: XCTestCase {
             }
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testSuccessCompletionHandlerRunningOnMainQueueDefaultly() {
-        let progressExpectation = expectation(withDescription: "progressBlock running on main queue")
-        let completionExpectation = expectation(withDescription: "completionHandler running on main queue")
+        let progressExpectation = expectation(description: "progressBlock running on main queue")
+        let completionExpectation = expectation(description: "completionHandler running on main queue")
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
         
@@ -146,11 +146,11 @@ class KingfisherManagerTests: XCTestCase {
                 XCTAssertTrue(Thread.isMainThread)
                 completionExpectation.fulfill()
         })
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testErrorCompletionHandlerRunningOnMainQueueDefaultly() {
-        let expectation = self.expectation(withDescription: "running on main queue")
+        let expectation = self.expectation(description: "running on main queue")
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString)?.andReturn(404)
         
@@ -163,18 +163,18 @@ class KingfisherManagerTests: XCTestCase {
                 XCTAssertTrue(Thread.isMainThread)
                 expectation.fulfill()
         })
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testSucessCompletionHandlerRunningOnCustomQueue() {
-        let progressExpectation = expectation(withDescription: "progressBlock running on custom queue")
-        let completionExpectation = expectation(withDescription: "completionHandler running on custom queue")
+        let progressExpectation = expectation(description: "progressBlock running on custom queue")
+        let completionExpectation = expectation(description: "completionHandler running on custom queue")
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
         
         let URL = Foundation.URL(string: URLString)!
         
-        let customQueue = DispatchQueue(label: "com.kingfisher.testQueue", attributes: DispatchQueueAttributes.serial)
+        let customQueue = DispatchQueue(label: "com.kingfisher.testQueue")
         manager.retrieveImageWithURL(URL, optionsInfo: [.callbackDispatchQueue(customQueue)], progressBlock: { _, _ in
             XCTAssertTrue(Thread.isMainThread)
             progressExpectation.fulfill()
@@ -187,17 +187,17 @@ class KingfisherManagerTests: XCTestCase {
                 
                 completionExpectation.fulfill()
         })
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testErrorCompletionHandlerRunningOnCustomQueue() {
-        let expectation = self.expectation(withDescription: "running on custom queue")
+        let expectation = self.expectation(description: "running on custom queue")
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString)?.andReturn(404)
         
         let URL = Foundation.URL(string: URLString)!
         
-        let customQueue = DispatchQueue(label: "com.kingfisher.testQueue", attributes: DispatchQueueAttributes.serial)
+        let customQueue = DispatchQueue(label: "com.kingfisher.testQueue")
         manager.retrieveImageWithURL(URL, optionsInfo: [.callbackDispatchQueue(customQueue)], progressBlock: { _, _ in
             //won't be called
             }, completionHandler: { _, error, _, _ in
@@ -207,6 +207,6 @@ class KingfisherManagerTests: XCTestCase {
                 }
                 expectation.fulfill()
         })
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 }

--- a/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
+++ b/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
@@ -70,8 +70,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
 #else
         let transition = ImageTransition.fade(0.5)
 #endif
-            
-        let queue = DispatchQueue.global(attributes: DispatchQueue.GlobalAttributes.qosDefault)
+        let queue = DispatchQueue.global(qos: .default)
         
         
         let options: KingfisherOptionsInfo = [

--- a/Tests/KingfisherTests/KingfisherTestHelper.swift
+++ b/Tests/KingfisherTests/KingfisherTestHelper.swift
@@ -38,8 +38,8 @@ let testImageData = Data(base64Encoded: testImageString, options: [])
 
 let testImagePNGData = ImagePNGRepresentation(testImage)!
 let testImageJEPGData = ImageJPEGRepresentation(testImage, 1.0)!
-let testImageGIFData = try! Data(contentsOf: URL(fileURLWithPath: Bundle(for: ImageExtensionTests.self).pathForResource("dancing-banana", ofType: "gif")!))
-let testImageSingleFrameGIFData = try! Data(contentsOf: URL(fileURLWithPath: Bundle(for: ImageExtensionTests.self).pathForResource("single-frame", ofType: "gif")!))
+let testImageGIFData = try! Data(contentsOf: URL(fileURLWithPath: Bundle(for: ImageExtensionTests.self).path(forResource: "dancing-banana", ofType: "gif")!))
+let testImageSingleFrameGIFData = try! Data(contentsOf: URL(fileURLWithPath: Bundle(for: ImageExtensionTests.self).path(forResource: "single-frame", ofType: "gif")!))
 
 let testKeys = ["http://stackoverflow.com/questions/11251340/convert-image-to-base64-string-in-ios-swift", "https://onevcat.com", "http://onevcat.com/content/images/2014/May/200.jpg", "http://onevcat.com/content/images/2014/May/200.jpg?fads#kj1asf"]
 

--- a/Tests/KingfisherTests/UIButtonExtensionTests.swift
+++ b/Tests/KingfisherTests/UIButtonExtensionTests.swift
@@ -61,7 +61,7 @@ class UIButtonExtensionTests: XCTestCase {
     }
 
     func testDownloadAndSetImage() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
@@ -83,11 +83,11 @@ class UIButtonExtensionTests: XCTestCase {
             XCTAssert(self.button.kf_webURLForState(UIControlState.highlighted) == imageURL, "Web URL should equal to the downloaded url.")
             XCTAssert(cacheType == .none, "The cache type should be none here. This image was just downloaded. But now is: \(cacheType)")
         }
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testDownloadAndSetBackgroundImage() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
@@ -107,11 +107,11 @@ class UIButtonExtensionTests: XCTestCase {
                 XCTAssert(cacheType == .none, "cacheType should be .None since the image was just downloaded.")
 
         }
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCacnelImageTask() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
@@ -125,16 +125,16 @@ class UIButtonExtensionTests: XCTestCase {
 
                 expectation.fulfill()
         }
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) {
             self.button.kf_cancelImageDownloadTask()
             _ = stub!.go()
         }
 
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testCacnelBackgroundImageTask() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URLString = testKeys[0]
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
@@ -148,16 +148,16 @@ class UIButtonExtensionTests: XCTestCase {
                 
                 expectation.fulfill()
         }
-        DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(Double(NSEC_PER_SEC) * 0.1)) / Double(NSEC_PER_SEC)) { () -> Void in
             self.button.kf_cancelBackgroundImageDownloadTask()
             _ = stub!.go()
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
     
     func testSettingNilURL() {
-        let expectation = self.expectation(withDescription: "wait for downloading image")
+        let expectation = self.expectation(description: "wait for downloading image")
         
         let URL: Foundation.URL? = nil
         button.kf_setBackgroundImageWithURL(URL, forState: UIControlState(), placeholderImage: nil, optionsInfo: nil, progressBlock: { (receivedSize, totalSize) -> () in
@@ -171,6 +171,6 @@ class UIButtonExtensionTests: XCTestCase {
             expectation.fulfill()
         }
         
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 }


### PR DESCRIPTION
Addressed Xcode 8 beta 4 migration issues, updated tests and commented out two tests for you to verify if they're still valid.