### PR TITLE
Fix gif frame duration calculation to match that of webkit

### DIFF
--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -238,7 +238,7 @@ extension Image {
                 
                 let unclampedDelayTime = gifInfo[kCGImagePropertyGIFUnclampedDelayTime as String]
                 let delayTime = gifInfo[kCGImagePropertyGIFDelayTime as String]
-                var duration = unclampedDelayTime ?? delayTime
+                let duration = unclampedDelayTime ?? delayTime
                 
                 guard let frameDuration = duration else { return gifDefaultFrameDuration }
                 

--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -234,16 +234,16 @@ extension Image {
         func decodeFromSource(imageSource: CGImageSource, options: NSDictionary) -> ([Image], NSTimeInterval)? {
             
             //Calculates frame duration for a gif frame out of the kCGImagePropertyGIFDictionary dictionary
-            func frameDuration(fromGifInfo gifInfo: Dictionary<String, Double>) -> Double {
+            func frameDuration(fromGifInfo gifInfo: NSDictionary) -> Double {
                 let gifDefaultFrameDuration = 0.100
                 
-                let unclampedDelayTime = gifInfo[kCGImagePropertyGIFUnclampedDelayTime as String]
-                let delayTime = gifInfo[kCGImagePropertyGIFDelayTime as String]
+                let unclampedDelayTime = gifInfo[kCGImagePropertyGIFUnclampedDelayTime as String] as? NSNumber
+                let delayTime = gifInfo[kCGImagePropertyGIFDelayTime as String] as? NSNumber
                 let duration = unclampedDelayTime ?? delayTime
                 
                 guard let frameDuration = duration else { return gifDefaultFrameDuration }
                 
-                return frameDuration > 0.011 ? frameDuration : gifDefaultFrameDuration
+                return frameDuration.doubleValue > 0.011 ? frameDuration.doubleValue : gifDefaultFrameDuration
             }
             
             let frameCount = CGImageSourceGetCount(imageSource)
@@ -261,7 +261,7 @@ extension Image {
                 } else {
                     // Animated GIF
                     guard let properties = CGImageSourceCopyPropertiesAtIndex(imageSource, i, nil),
-                        gifInfo = (properties as NSDictionary)[kCGImagePropertyGIFDictionary as String] as? Dictionary<String, Double> else
+                        gifInfo = (properties as NSDictionary)[kCGImagePropertyGIFDictionary as String] as? NSDictionary else
                     {
                         return nil
                     }

--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -233,6 +233,7 @@ extension Image {
         
         func decodeFromSource(imageSource: CGImageSource, options: NSDictionary) -> ([Image], NSTimeInterval)? {
             
+            //Calculates frame duration for a gif frame out of the kCGImagePropertyGIFDictionary dictionary
             func frameDuration(fromGifInfo gifInfo: Dictionary<String, Double>) -> Double {
                 let gifDefaultFrameDuration = 0.100
                 

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -238,7 +238,7 @@ class ImageCacheTests: XCTestCase {
             expectation.fulfill()
         }
         
-        self.waitForExpectationsWithTimeout(20, handler: nil)
+        self.waitForExpectationsWithTimeout(30, handler: nil)
     }
     
     func testCleanDiskCacheNotification() {


### PR DESCRIPTION
Fix gif frame duration calculation to match that of webkit
This bug caused wrong animation speeds for some gif when not using AnimateImage