### PR TITLE
Remove gem install xcpretty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ env:
     - TEST_TYPE=iOS
     - TEST_TYPE=OSX
     - TEST_TYPE=tvOS
-before_install:
-- |
-    gem install xcpretty -N --no-ri --no-rdoc
 
 script:
 - |


### PR DESCRIPTION
According to https://github.com/travis-ci/travis-ci/issues/2168, xcpretty is now preinstalled on macOS VMs.