### PR TITLE
Reduce Swift compile time.

### DIFF
--- a/Sources/String+MD5.swift
+++ b/Sources/String+MD5.swift
@@ -281,7 +281,11 @@ class MD5: HashProtocol {
         
         hh.forEach {
             let itemLE = $0.littleEndian
-            result += [UInt8(itemLE & 0xff), UInt8((itemLE >> 8) & 0xff), UInt8((itemLE >> 16) & 0xff), UInt8((itemLE >> 24) & 0xff)]
+            let r1 = UInt8(itemLE & 0xff)
+            let r2 = UInt8((itemLE >> 8) & 0xff)
+            let r3 = UInt8((itemLE >> 16) & 0xff)
+            let r4 = UInt8((itemLE >> 24) & 0xff)
+            result += [r1, r2, r3, r4]
         }
         return result
     }


### PR DESCRIPTION
I profiled Kingfisher’s compile time after reading this:
http://irace.me/swift-profiling

With this small change, I was able to speed up compile time dramatically.

Before:

```
2517.2ms  Kingfisher/Sources/String+MD5.swift:213:10  func calculate() -> [UInt8]
2444.7ms  Kingfisher/Sources/String+MD5.swift:282:20  (closure)
2320.0ms  Kingfisher/Sources/String+MD5.swift:213:10  func calculate() -> [UInt8]
2251.4ms  Kingfisher/Sources/String+MD5.swift:282:20  (closure)
113.8ms Kingfisher/Sources/String+MD5.swift:129:6 func toUInt32Array(_ slice: ArraySlice<UInt8>) -> Array<UInt32>
108.5ms Kingfisher/Sources/String+MD5.swift:129:6 func toUInt32Array(_ slice: ArraySlice<UInt8>) -> Array<UInt32>
47.5ms  Kingfisher/Sources/String+MD5.swift:63:6  func arrayOfBytes<T>(_ value: T, length: Int? = default) -> [UInt8]
46.4ms  Kingfisher/Sources/String+MD5.swift:63:6  func arrayOfBytes<T>(_ value: T, length: Int? = default) -> [UInt8]
39.8ms  Kingfisher/Sources/String+MD5.swift:69:86 (closure)
39.3ms  Kingfisher/Sources/String+MD5.swift:69:86 (closure)
…
```

After:

```
123.0ms Kingfisher/Sources/String+MD5.swift:213:10  func calculate() -> [UInt8]
103.6ms Kingfisher/Sources/String+MD5.swift:129:6 func toUInt32Array(_ slice: ArraySlice<UInt8>) -> Array<UInt32>
101.5ms Kingfisher/Sources/String+MD5.swift:129:6 func toUInt32Array(_ slice: ArraySlice<UInt8>) -> Array<UInt32>
73.1ms  Kingfisher/Sources/String+MD5.swift:213:10  func calculate() -> [UInt8]
45.3ms  Kingfisher/Sources/String+MD5.swift:63:6  func arrayOfBytes<T>(_ value: T, length: Int? = default) -> [UInt8]
45.2ms  Kingfisher/Sources/String+MD5.swift:63:6  func arrayOfBytes<T>(_ value: T, length: Int? = default) -> [UInt8]
39.2ms  Kingfisher/Sources/String+MD5.swift:69:86 (closure)
38.4ms  Kingfisher/Sources/String+MD5.swift:69:86 (closure)
16.1ms  Kingfisher/Sources/String+MD5.swift:157:19  mutating func next() -> ArraySlice<UInt8>?
12.2ms  Kingfisher/Sources/String+MD5.swift:39:21 get {}
…
```

