### PR TITLE
Put `open` functions in extensions into class definition

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -148,10 +148,10 @@ open class ImageCache {
     deinit {
         NotificationCenter.default.removeObserver(self)
     }
-}
 
-// MARK: - Store & Remove
-extension ImageCache {
+
+    // MARK: - Store & Remove
+
     /**
     Store an image to cache. It will be saved to both memory and disk. It is an async operation.
     
@@ -243,11 +243,9 @@ extension ImageCache {
             callHandlerInMainQueue()
         }
     }
-    
-}
 
-// MARK: - Get data from cache
-extension ImageCache {
+    // MARK: - Get data from cache
+
     /**
     Get an image for a key from memory or disk.
     
@@ -357,10 +355,10 @@ extension ImageCache {
         
         return diskImage(forComputedKey: computedKey, serializer: options.cacheSerializer, options: options)
     }
-}
 
-// MARK: - Clear & Clean
-extension ImageCache {
+
+    // MARK: - Clear & Clean
+
     /**
     Clear memory cache.
     */
@@ -530,11 +528,9 @@ extension ImageCache {
         }
     }
 #endif
-}
 
 
-// MARK: - Check cache status
-extension ImageCache {
+    // MARK: - Check cache status
     
     /**
     *  Cache result for checking whether an image is cached for a key.
@@ -616,7 +612,7 @@ extension ImageCache {
         return cachePath(forComputedKey: computedKey)
     }
 
-    func cachePath(forComputedKey key: String) -> String {
+    fileprivate func cachePath(forComputedKey key: String) -> String {
         let fileName = cacheFileName(forComputedKey: key)
         return (diskCachePath as NSString).appendingPathComponent(fileName)
     }

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -612,7 +612,7 @@ open class ImageCache {
         return cachePath(forComputedKey: computedKey)
     }
 
-    fileprivate func cachePath(forComputedKey key: String) -> String {
+    open func cachePath(forComputedKey key: String) -> String {
         let fileName = cacheFileName(forComputedKey: key)
         return (diskCachePath as NSString).appendingPathComponent(fileName)
     }


### PR DESCRIPTION
Put `open` functions in extensions into class definition to be able to override `open` functions in subclasses. Before if you tried to do it you'd gotten the Swift error: `Declarations from extensions cannot be overridden yet`. 