### PR TITLE
Make ImageDownloader non-objc

### DIFF
--- a/Sources/ImageDownloader.swift
+++ b/Sources/ImageDownloader.swift
@@ -166,7 +166,7 @@ extension AuthenticationChallengeResponsable {
 }
 
 /// `ImageDownloader` represents a downloading manager for requesting the image with a URL from server.
-open class ImageDownloader: NSObject {
+open class ImageDownloader {
     
     class ImageFetchLoad {
         var contents = [(callback: CallbackPair, options: KingfisherOptionsInfo)]()
@@ -234,9 +234,7 @@ open class ImageDownloader: NSObject {
         processQueue = DispatchQueue(label: "com.onevcat.Kingfisher.ImageDownloader.Process.\(name)", attributes: .concurrent)
         
         sessionHandler = ImageDownloaderSessionHandler()
-        
-        super.init()
-        
+
         // Provide a default implement for challenge responder.
         authenticationChallengeResponder = sessionHandler
         session = URLSession(configuration: sessionConfiguration, delegate: sessionHandler, delegateQueue: .main)

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -248,7 +248,7 @@ class ImageDownloaderTests: XCTestCase {
         }
         
         XCTAssertNotNil(task, "The task should exist.")
-        XCTAssertEqual(task!.ownerDownloader, downloader, "The owner downloader should be correct")
+        XCTAssertTrue(task!.ownerDownloader === downloader, "The owner downloader should be correct")
         XCTAssertEqual(task!.url, URL(string: "1234"), "The request URL should equal.")
     }
     


### PR DESCRIPTION
Since we do not support Objective-C now, it would be a good idea to remove `NSObject` superclass from `ImageDownloader`. This could also be a workaround for #520 