### PR TITLE
Fix preload animated image and improve performance

### DIFF
--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -74,7 +74,7 @@ extension Kingfisher where Base: ImageView {
         
         setWebURL(resource.downloadURL)
 
-        if shouldPreloadAllGIF() {
+        if base.shouldPreloadAllGIF() {
             options.append(.preloadAllGIFData)
         }
         
@@ -137,10 +137,6 @@ extension Kingfisher where Base: ImageView {
      */
     public func cancelDownloadTask() {
         imageTask?.downloadTask?.cancel()
-    }
-    
-    func shouldPreloadAllGIF() -> Bool {
-        return true
     }
 }
 
@@ -285,6 +281,8 @@ extension ImageView {
     fileprivate func kf_setImageTask(_ task: RetrieveImageTask?) { kf.setImageTask(task) }
     @available(*, deprecated, message: "Extensions directly on image views are deprecated.", renamed: "kf.setWebURL")
     fileprivate func kf_setWebURL(_ url: URL) { kf.setWebURL(url) }
-    @available(*, deprecated, message: "Extensions directly on image views are deprecated.", renamed: "kf.shouldPreloadAllGIF")
-    func shouldPreloadAllGIF() -> Bool { return kf.shouldPreloadAllGIF() }
+}
+
+extension ImageView {
+    func shouldPreloadAllGIF() -> Bool { return true }
 }


### PR DESCRIPTION
Prepare and preload animated frames asynchronously can improve performance apparently.

While there are more than 25 visible GIFs on screen, FPS is raised from 30 to ≈60.