### PR TITLE
Fix a serious bug: Haven't cancel previous request when new request runs.

### DIFF
--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -57,6 +57,7 @@ extension Kingfisher where Base: ImageView {
                          progressBlock: DownloadProgressBlock? = nil,
                          completionHandler: CompletionHandler? = nil) -> RetrieveImageTask
     {
+        cancelDownloadTask()
         guard let resource = resource else {
             base.image = placeholder
             completionHandler?(nil, nil, .none, nil)

--- a/Sources/NSButton+Kingfisher.swift
+++ b/Sources/NSButton+Kingfisher.swift
@@ -53,6 +53,7 @@ extension Kingfisher where Base: NSButton {
                          progressBlock: DownloadProgressBlock? = nil,
                          completionHandler: CompletionHandler? = nil) -> RetrieveImageTask
     {
+        cancelImageDownloadTask()
         guard let resource = resource else {
             base.image = placeholder
             completionHandler?(nil, nil, .none, nil)
@@ -119,6 +120,7 @@ extension Kingfisher where Base: NSButton {
                                   progressBlock: DownloadProgressBlock? = nil,
                                   completionHandler: CompletionHandler? = nil) -> RetrieveImageTask
     {
+        cancelAlternateImageDownloadTask()
         guard let resource = resource else {
             base.alternateImage = placeholder
             completionHandler?(nil, nil, .none, nil)

--- a/Sources/UIButton+Kingfisher.swift
+++ b/Sources/UIButton+Kingfisher.swift
@@ -55,6 +55,7 @@ extension Kingfisher where Base: UIButton {
                          progressBlock: DownloadProgressBlock? = nil,
                          completionHandler: CompletionHandler? = nil) -> RetrieveImageTask
     {
+        cancelImageDownloadTask()
         guard let resource = resource else {
             base.setImage(placeholder, for: state)
             completionHandler?(nil, nil, .none, nil)
@@ -126,6 +127,7 @@ extension Kingfisher where Base: UIButton {
                                    progressBlock: DownloadProgressBlock? = nil,
                                    completionHandler: CompletionHandler? = nil) -> RetrieveImageTask
     {
+        cancelBackgroundImageDownloadTask()
         guard let resource = resource else {
             base.setBackgroundImage(placeholder, for: state)
             completionHandler?(nil, nil, .none, nil)


### PR DESCRIPTION
Fix a serious bug: Haven't cancel previous request when new request runs, which leads to "Request A, then B, if A is bigger, it will show B, finally B";
Case below:
    let imageView = UIImageView.init(frame: view.bounds)
    view.addSubview(imageView)
    imageView.set(url: "http://pic1.win4000.com/wallpaper/2/4fcec0bf0fb7f.jpg")
    imageView.set(url: "http://tva2.sinaimg.cn/crop.0.0.750.750.180/615e2f0fjw8f44ixckuogj20ku0ku0t1.jpg")