### PR TITLE
Fix the case: `cancelDownloadTask` just after setImage, `cancelDownloadTask` will be ignored, because downloadTask is nil.

### DIFF
--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -136,7 +136,12 @@ extension Kingfisher where Base: ImageView {
      Nothing will happen if the downloading has already finished.
      */
     public func cancelDownloadTask() {
-        imageTask?.downloadTask?.cancel()
+        if let downloadTask = imageTask?.downloadTask {
+            downloadTask.cancel()
+        }
+        else {
+            imageTask?.cancelledBeforeDownloadStarting = true
+        }
     }
 }
 

--- a/Sources/NSButton+Kingfisher.swift
+++ b/Sources/NSButton+Kingfisher.swift
@@ -95,7 +95,12 @@ extension Kingfisher where Base: NSButton {
      Nothing will happen if the downloading has already finished.
      */
     public func cancelImageDownloadTask() {
-        imageTask?.downloadTask?.cancel()
+        if let downloadTask = imageTask?.downloadTask {
+            downloadTask.cancel()
+        }
+        else {
+            imageTask?.cancelledBeforeDownloadStarting = true
+        }
     }
     
     /**
@@ -164,7 +169,12 @@ extension Kingfisher where Base: NSButton {
     /// Cancel the alternate image download task bounded to the image view if it is running. 
     /// Nothing will happen if the downloading has already finished.
     public func cancelAlternateImageDownloadTask() {
-        alternateImageTask?.downloadTask?.cancel()
+        if let downloadTask = alternateImageTask?.downloadTask {
+            downloadTask.cancel()
+        }
+        else {
+            alternateImageTask?.cancelledBeforeDownloadStarting = true
+        }
     }
 }
 

--- a/Sources/UIButton+Kingfisher.swift
+++ b/Sources/UIButton+Kingfisher.swift
@@ -99,7 +99,12 @@ extension Kingfisher where Base: UIButton {
      Nothing will happen if the downloading has already finished.
      */
     public func cancelImageDownloadTask() {
-        imageTask?.downloadTask?.cancel()
+        if let downloadTask = imageTask?.downloadTask {
+            downloadTask.cancel()
+        }
+        else {
+            imageTask?.cancelledBeforeDownloadStarting = true
+        }
     }
     
     /**
@@ -168,9 +173,13 @@ extension Kingfisher where Base: UIButton {
      Nothing will happen if the downloading has already finished.
      */
     public func cancelBackgroundImageDownloadTask() {
-        backgroundImageTask?.downloadTask?.cancel()
+        if let downloadTask = backgroundImageTask?.downloadTask {
+            downloadTask.cancel()
+        }
+        else {
+            backgroundImageTask?.cancelledBeforeDownloadStarting = true
+        }
     }
-
 }
 
 // MARK: - Associated Object


### PR DESCRIPTION
Fix the case: `cancelDownloadTask` just after setImage, `cancelDownloadTask` will be ignored, because downloadTask is nil.

提交之后才发现，喵大已经拉分支在优化这一块了。
年前在看代码的时候发现一些关于 cancel 方面有一些优化的余地，先提一个。