### PR TITLE
Ignore progressBlock if imageUrl is not equal to current imageUrl.

### DIFF
--- a/Demo/Kingfisher-Demo/ViewController.swift
+++ b/Demo/Kingfisher-Demo/ViewController.swift
@@ -71,7 +71,7 @@ extension ViewController {
         _ = (cell as! CollectionViewCell).cellImageView.kf.setImage(with: url,
                                            placeholder: nil,
                                            options: [.transition(ImageTransition.fade(1))],
-                                           progressBlock: { receivedSize, totalSize in
+                                           progressBlock: { receivedSize, totalSize, imageURL in
                                             print("\(indexPath.row + 1): \(receivedSize)/\(totalSize)")
             },
                                            completionHandler: { image, error, cacheType, imageURL in

--- a/Sources/ImageDownloader.swift
+++ b/Sources/ImageDownloader.swift
@@ -406,7 +406,7 @@ class ImageDownloaderSessionHandler: NSObject, URLSessionDataDelegate, Authentic
             if let expectedLength = dataTask.response?.expectedContentLength {
                 for content in fetchLoad.contents {
                     DispatchQueue.main.async {
-                        content.callback.progressBlock?(Int64(fetchLoad.responseData.length), expectedLength)
+                        content.callback.progressBlock?(Int64(fetchLoad.responseData.length), expectedLength, dataTask.originalRequest?.url)
                     }
                 }
             }

--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -81,9 +81,12 @@ extension Kingfisher where Base: ImageView {
         let task = KingfisherManager.shared.retrieveImage(
             with: resource,
             options: options,
-            progressBlock: { receivedSize, totalSize in
+            progressBlock: { receivedSize, totalSize, imageURL in
+                guard imageURL == self.webURL else {
+                    return
+                }
                 if let progressBlock = progressBlock {
-                    progressBlock(receivedSize, totalSize)
+                    progressBlock(receivedSize, totalSize, imageURL)
                 }
             },
             completionHandler: {[weak base] image, error, cacheType, imageURL in

--- a/Sources/KingfisherManager.swift
+++ b/Sources/KingfisherManager.swift
@@ -30,7 +30,7 @@ import AppKit
 import UIKit
 #endif
 
-public typealias DownloadProgressBlock = ((_ receivedSize: Int64, _ totalSize: Int64) -> ())
+public typealias DownloadProgressBlock = ((_ receivedSize: Int64, _ totalSize: Int64, _ imageURL: URL?) -> ())
 public typealias CompletionHandler = ((_ image: Image?, _ error: NSError?, _ cacheType: CacheType, _ imageURL: URL?) -> ())
 
 /// RetrieveImageTask represents a task of image retrieving process.
@@ -141,8 +141,8 @@ public class KingfisherManager {
         let options = options ?? KingfisherEmptyOptionsInfo
         let downloader = options.downloader
         return downloader.downloadImage(with: url, retrieveImageTask: retrieveImageTask, options: options,
-            progressBlock: { receivedSize, totalSize in
-                progressBlock?(receivedSize, totalSize)
+            progressBlock: { receivedSize, totalSize, imageURL in
+                progressBlock?(receivedSize, totalSize, imageURL)
             },
             completionHandler: { image, error, imageURL, originalData in
 

--- a/Sources/NSButton+Kingfisher.swift
+++ b/Sources/NSButton+Kingfisher.swift
@@ -69,6 +69,9 @@ extension Kingfisher where Base: NSButton {
             with: resource,
             options: options,
             progressBlock: { receivedSize, totalSize in
+                guard imageURL == self.webURL else {
+                    return
+                }
                 if let progressBlock = progressBlock {
                     progressBlock(receivedSize, totalSize)
                 }
@@ -135,6 +138,9 @@ extension Kingfisher where Base: NSButton {
             with: resource,
             options: options,
             progressBlock: { receivedSize, totalSize in
+                guard imageURL == self.alternateWebURL else {
+                    return
+                }
                 if let progressBlock = progressBlock {
                     progressBlock(receivedSize, totalSize)
                 }

--- a/Sources/UIButton+Kingfisher.swift
+++ b/Sources/UIButton+Kingfisher.swift
@@ -70,9 +70,12 @@ extension Kingfisher where Base: UIButton {
         let task = KingfisherManager.shared.retrieveImage(
             with: resource,
             options: options,
-            progressBlock: { receivedSize, totalSize in
+            progressBlock: { receivedSize, totalSize, imageURL in
+                guard imageURL == self.webURL(for: state) else {
+                    return
+                }
                 if let progressBlock = progressBlock {
-                    progressBlock(receivedSize, totalSize)
+                    progressBlock(receivedSize, totalSize, imageURL)
                 }
             },
             completionHandler: {[weak base] image, error, cacheType, imageURL in
@@ -141,9 +144,12 @@ extension Kingfisher where Base: UIButton {
         let task = KingfisherManager.shared.retrieveImage(
             with: resource,
             options: options,
-            progressBlock: { receivedSize, totalSize in
+            progressBlock: { receivedSize, totalSize, imageURL in
+                guard imageURL == self.webURL(for: state) else {
+                    return
+                }
                 if let progressBlock = progressBlock {
-                    progressBlock(receivedSize, totalSize)
+                    progressBlock(receivedSize, totalSize, imageURL)
                 }
             },
             completionHandler: { [weak base] image, error, cacheType, imageURL in


### PR DESCRIPTION
For the case 'setImage twice for different url, and progressBlock will cross, like A1%, A50%, B20%, A100%, B60% ...'.