### PR TITLE
Ignore progressBlock if imageUrl is not equal to current imageUrl.

### DIFF
--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -82,6 +82,9 @@ extension Kingfisher where Base: ImageView {
             with: resource,
             options: options,
             progressBlock: { receivedSize, totalSize in
+                guard resource.downloadURL == self.webURL else {
+                    return
+                }
                 if let progressBlock = progressBlock {
                     progressBlock(receivedSize, totalSize)
                 }

--- a/Sources/NSButton+Kingfisher.swift
+++ b/Sources/NSButton+Kingfisher.swift
@@ -69,6 +69,9 @@ extension Kingfisher where Base: NSButton {
             with: resource,
             options: options,
             progressBlock: { receivedSize, totalSize in
+                guard resource.downloadURL == self.webURL else {
+                    return
+                }
                 if let progressBlock = progressBlock {
                     progressBlock(receivedSize, totalSize)
                 }
@@ -135,6 +138,9 @@ extension Kingfisher where Base: NSButton {
             with: resource,
             options: options,
             progressBlock: { receivedSize, totalSize in
+                guard resource.downloadURL == self.alternateWebURL else {
+                    return
+                }
                 if let progressBlock = progressBlock {
                     progressBlock(receivedSize, totalSize)
                 }

--- a/Sources/UIButton+Kingfisher.swift
+++ b/Sources/UIButton+Kingfisher.swift
@@ -71,6 +71,9 @@ extension Kingfisher where Base: UIButton {
             with: resource,
             options: options,
             progressBlock: { receivedSize, totalSize in
+                guard resource.downloadURL == self.webURL(for: state) else {
+                    return
+                }
                 if let progressBlock = progressBlock {
                     progressBlock(receivedSize, totalSize)
                 }
@@ -142,6 +145,9 @@ extension Kingfisher where Base: UIButton {
             with: resource,
             options: options,
             progressBlock: { receivedSize, totalSize in
+                guard resource.downloadURL == self.backgroundWebURL(for: state) else {
+                    return
+                }
                 if let progressBlock = progressBlock {
                     progressBlock(receivedSize, totalSize)
                 }


### PR DESCRIPTION
For the case 'setImage twice for different url, and progressBlock will cross, like A1%, A50%, B20%, A100%, B60% ...'.