### PR TITLE
Feature gif first image

### DIFF
--- a/Demo/Kingfisher-macOS-Demo/ViewController.swift
+++ b/Demo/Kingfisher-macOS-Demo/ViewController.swift
@@ -66,6 +66,8 @@ extension ViewController: NSCollectionViewDataSource {
                                                     print("\(indexPath.item + 1): Finished")
                                                     })
         
+        // Set imageView's `animates` to true if you are loading a GIF.
+        // item.imageView?.animates = true
         return item
     }
 }

--- a/Sources/CacheSerializer.swift
+++ b/Sources/CacheSerializer.swift
@@ -77,9 +77,11 @@ public struct DefaultCacheSerializer: CacheSerializer {
     }
     
     public func image(with data: Data, options: KingfisherOptionsInfo?) -> Image? {
-        let scale = (options ?? KingfisherEmptyOptionsInfo).scaleFactor
-        let preloadAllGIFData = (options ?? KingfisherEmptyOptionsInfo).preloadAllGIFData
-        
-        return Kingfisher<Image>.image(data: data, scale: scale, preloadAllGIFData: preloadAllGIFData)
+        let options = options ?? KingfisherEmptyOptionsInfo
+        return Kingfisher<Image>.image(
+            data: data,
+            scale: options.scaleFactor,
+            preloadAllGIFData: options.preloadAllGIFData,
+            onlyFirstFrame: options.onlyLoadFirstFrame)
     }
 }

--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -94,15 +94,15 @@ extension Kingfisher where Base: Image {
     }
     
     var scale: CGFloat {
-    return base.scale
+        return base.scale
     }
     
     var images: [Image]? {
-    return base.images
+        return base.images
     }
     
     var duration: TimeInterval {
-    return base.duration
+        return base.duration
     }
     
     fileprivate(set) var imageSource: ImageSource? {

--- a/Sources/ImageProcessor.swift
+++ b/Sources/ImageProcessor.swift
@@ -116,7 +116,11 @@ public struct DefaultImageProcessor: ImageProcessor {
         case .image(let image):
             return image
         case .data(let data):
-            return Kingfisher<Image>.image(data: data, scale: options.scaleFactor, preloadAllGIFData: options.preloadAllGIFData)
+            return Kingfisher<Image>.image(
+                data: data,
+                scale: options.scaleFactor,
+                preloadAllGIFData: options.preloadAllGIFData,
+                onlyFirstFrame: options.onlyLoadFirstFrame)
         }
     }
 }

--- a/Sources/KingfisherOptionsInfo.swift
+++ b/Sources/KingfisherOptionsInfo.swift
@@ -113,6 +113,12 @@ public enum KingfisherOptionsInfoItem {
     /// By setting this option, the placeholder image parameter of imageview extension method
     /// will be ignored and the current image will be kept while loading or downloading the new image.
     case keepCurrentImageWhileLoading
+    
+    /// If set, Kingfisher will only load the first frame from a GIF file as a single image.
+    /// Loading a lot of GIFs may take too much memory. It will be useful when you want to display a 
+    /// static preview of the first frame from a GIF image.
+    /// This option will be ignored if the target image is not GIF.
+    case onlyLoadFirstFrame
 }
 
 precedencegroup ItemComparisonPrecedence {
@@ -141,6 +147,7 @@ func <== (lhs: KingfisherOptionsInfoItem, rhs: KingfisherOptionsInfoItem) -> Boo
     case (.processor(_), .processor(_)): return true
     case (.cacheSerializer(_), .cacheSerializer(_)): return true
     case (.keepCurrentImageWhileLoading, .keepCurrentImageWhileLoading): return true
+    case (.onlyLoadFirstFrame, .onlyLoadFirstFrame): return true
     default: return false
     }
 }
@@ -281,5 +288,9 @@ public extension Collection where Iterator.Element == KingfisherOptionsInfoItem 
     /// Or the placeholder will be used while downloading.
     public var keepCurrentImageWhileLoading: Bool {
         return contains { $0 <== .keepCurrentImageWhileLoading }
+    }
+    
+    public var onlyLoadFirstFrame: Bool {
+        return contains { $0 <== .onlyLoadFirstFrame }
     }
 }

--- a/Tests/KingfisherTests/ImageExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageExtensionTests.swift
@@ -105,4 +105,14 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertEqual(image.kf.duration, image.kf.duration)
         XCTAssertEqual(image.kf.images!.count, image.kf.images!.count)
     }
+    
+    func testLoadOnlyFirstFrame() {
+        let image = Kingfisher<Image>.animated(with: testImageGIFData,
+                                               scale: 1.0,
+                                               duration: 0.0,
+                                               preloadAll: true,
+                                               onlyFirstFrame: true)!
+        XCTAssertNotNil(image, "The image should be initiated.")
+        XCTAssertNil(image.kf.images, "The image should be nil")
+    }
 }

--- a/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
+++ b/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
@@ -59,6 +59,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertEqual(options.callbackDispatchQueue.label, DispatchQueue.main.label)
         XCTAssertEqual(options.scaleFactor, 1.0)
         XCTAssertFalse(options.keepCurrentImageWhileLoading)
+        XCTAssertFalse(options.onlyLoadFirstFrame)
     }
     
 
@@ -89,7 +90,8 @@ class KingfisherOptionsInfoTests: XCTestCase {
             KingfisherOptionsInfoItem.scaleFactor(2.0),
             .requestModifier(testModifier),
             .processor(processor),
-            .keepCurrentImageWhileLoading
+            .keepCurrentImageWhileLoading,
+            .onlyLoadFirstFrame
         ]
         
         XCTAssertTrue(options.targetCache === cache)
@@ -113,6 +115,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertTrue(options.modifier is TestModifier)
         XCTAssertEqual(options.processor.identifier, processor.identifier)
         XCTAssertTrue(options.keepCurrentImageWhileLoading)
+        XCTAssertTrue(options.onlyLoadFirstFrame)
     }
 }
 


### PR DESCRIPTION
This pull-request implements the feature of only loading the first frame of a GIF file.

It could help to save memory when loading a list (table view) of GIF file. Originally, all the GIFs will be loaded and animated. However, it is not a good idea to do so, since it will eat quite a lot of memory. Instead, we may want to load and decode the first frame of a GIF file as a preview or thumbnail. Then user could be navigated to a detail view will full, animating GIF image.