### PR TITLE
Also set the webURL to nil when resource is nil

### DIFF
--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -59,6 +59,7 @@ extension Kingfisher where Base: ImageView {
     {
         guard let resource = resource else {
             base.image = placeholder
+            setWebURL(nil)
             completionHandler?(nil, nil, .none, nil)
             return .empty
         }
@@ -155,7 +156,7 @@ extension Kingfisher where Base: ImageView {
         return objc_getAssociatedObject(base, &lastURLKey) as? URL
     }
     
-    fileprivate func setWebURL(_ url: URL) {
+    fileprivate func setWebURL(_ url: URL?) {
         objc_setAssociatedObject(base, &lastURLKey, url, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
     


### PR DESCRIPTION
Hi,
while using Kingfisher in a collection view I noticed that in some cases the image views weren't updated as expected.

This is what I'm doing:
- Dequeue a reusable cell containing an image view
- Set the image to a certain `image-url` using KF
- At some point the cell gets reused and the download KF download canceled
- Set the image to `nil` with a placeholder

What I expect at this point is for the image view to display the placeholder, what happens is that it still displays the image at `image-url`.

I looked a bit into the `setImage` method in `ImageView+Kingfisher` and noticed that the cause of this issue might be the fact that `webURL` is not updated when setImage is called with a `nil` resource thus letting the completion block of the download task update the image even if the operation was cancelled and the `setImage` called again.

Also, the same this is probably happening for `UIButton` and `NSButton` extensions but I wanted to open this PR before editing any other method.
 