### PR TITLE
Fix compile error Swift4 in Xcode9.0

### DIFF
--- a/Sources/Filter.swift
+++ b/Sources/Filter.swift
@@ -71,7 +71,7 @@ public struct Filter {
             let filter = CIFilter(name: "CISourceOverCompositing")!
             filter.setValue(colorImage, forKey: kCIInputImageKey)
             filter.setValue(input, forKey: kCIInputBackgroundImageKey)
-            return filter.outputImage?.cropped(to: input.extent)
+            return filter.outputImage?.cropping(to: input.extent)
         }
     }
     
@@ -85,9 +85,9 @@ public struct Filter {
                                kCIInputContrastKey: contrast,
                                kCIInputSaturationKey: saturation]
             
-            let blackAndWhite = input.applyingFilter("CIColorControls", parameters: paramsColor)
+            let blackAndWhite = input.applyingFilter("CIColorControls", withInputParameters: paramsColor)
             let paramsExposure = [kCIInputEVKey: inputEV]
-            return blackAndWhite.applyingFilter("CIExposureAdjust", parameters: paramsExposure)
+            return blackAndWhite.applyingFilter("CIExposureAdjust", withInputParameters: paramsExposure)
         }
         
     }


### PR DESCRIPTION
In my Xcode 9.0 beta 2, I was occurred compile error in Filter.swift.
Then, I fix it to compile be success.

I love Kingfisher ❤️ 

Best regards.