### PR TITLE
Disable gather coverage data in scheme test action

### DIFF
--- a/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher-macOS.xcscheme
+++ b/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher-macOS.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher-tvOS.xcscheme
+++ b/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher-tvOS.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher.xcscheme
+++ b/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher.xcscheme
@@ -26,8 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
As discussed in #752, disable "Gather coverage data" in the test action of all schemes in order to resolve issues with Kingfisher being used in Xcode 9 apps when using Carthage to compile the framework.