### PR TITLE
Turn off codeCoverageEnabled for all schemes

### DIFF
--- a/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher-macOS.xcscheme
+++ b/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher-macOS.xcscheme
@@ -27,7 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher-tvOS.xcscheme
+++ b/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher-tvOS.xcscheme
@@ -27,7 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher.xcscheme
+++ b/Kingfisher.xcodeproj/xcshareddata/xcschemes/Kingfisher.xcscheme
@@ -27,7 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
iTunes Connect no longer accepts builds with codeCoverageEnabled option turned on, returning this error (in email):

> Invalid Bundle - Disallowed LLVM instrumentation. Do not submit apps with LLVM profiling instrumentation or coverage collection enabled. Turn off LLVM profiling or code coverage, rebuild your app and resubmit the app.
>
>Once these issues have been corrected, you can then redeliver the corrected binary.


This Pull Request turns off codeCoverageEnabled for all schemes.