### PR TITLE
Rename methods for Swift 4 compatibility

### DIFF
--- a/Sources/Filter.swift
+++ b/Sources/Filter.swift
@@ -71,7 +71,7 @@ public struct Filter {
             let filter = CIFilter(name: "CISourceOverCompositing")!
             filter.setValue(colorImage, forKey: kCIInputImageKey)
             filter.setValue(input, forKey: kCIInputBackgroundImageKey)
-            return filter.outputImage?.cropped(to: input.extent)
+            return filter.outputImage?.cropping(to: input.extent)
         }
     }
     
@@ -85,9 +85,9 @@ public struct Filter {
                                kCIInputContrastKey: contrast,
                                kCIInputSaturationKey: saturation]
             
-            let blackAndWhite = input.applyingFilter("CIColorControls", parameters: paramsColor)
+            let blackAndWhite = input.applyingFilter("CIColorControls", withInputParameters: paramsColor)
             let paramsExposure = [kCIInputEVKey: inputEV]
-            return blackAndWhite.applyingFilter("CIExposureAdjust", parameters: paramsExposure)
+            return blackAndWhite.applyingFilter("CIExposureAdjust", withInputParameters: paramsExposure)
         }
         
     }


### PR DESCRIPTION
Hi there 👋 

When using your pod on the `swift4` branch, Xcode 9.0 / Swift 4 still gave me errors for methods that got renamed. 

Methods that got renamed:
* `.cropped(to:)` to `.cropping(to:)`
* `.applyingFilter(_, parameters:)` to `.applyingFilter(_, withInputParameters:)`

Have a nice weekend!