### PR TITLE
Support caching original images on a different cache

### DIFF
--- a/Sources/KingfisherManager.swift
+++ b/Sources/KingfisherManager.swift
@@ -171,7 +171,7 @@ public class KingfisherManager {
                                       cacheSerializer: options.cacheSerializer,
                                       toDisk: !options.cacheMemoryOnly,
                                       completionHandler: nil)
-                    if options.cacheOriginalImage {
+                    if options.cacheOriginalImage && options.processor != DefaultImageProcessor.default {
                         let originalCache = options.originalCache
                         let defaultProcessor = DefaultImageProcessor.default
                         if let originalImage = defaultProcessor.process(item: .data(originalData), options: options) {
@@ -183,7 +183,6 @@ public class KingfisherManager {
                                               toDisk: !options.cacheMemoryOnly,
                                               completionHandler: nil)
                         }
-                        
                     }
                 }
 

--- a/Sources/KingfisherManager.swift
+++ b/Sources/KingfisherManager.swift
@@ -172,9 +172,10 @@ public class KingfisherManager {
                                       toDisk: !options.cacheMemoryOnly,
                                       completionHandler: nil)
                     if options.cacheOriginalImage {
+                        let originalCache = options.originalCache
                         let defaultProcessor = DefaultImageProcessor.default
                         if let originaliImage = defaultProcessor.process(item: .data(originalData), options: options) {
-                            targetCache.store(originaliImage,
+                            originalCache.store(originaliImage,
                                               original: originalData,
                                               forKey: key,
                                               processorIdentifier: defaultProcessor.identifier,
@@ -238,8 +239,9 @@ public class KingfisherManager {
             
             // If processor is not the default one, we have a chance to check whether
             // the original image is already in cache.
+            let originalCache = options.originalCache
             let optionsWithoutProcessor = options.removeAllMatchesIgnoringAssociatedValue(.processor(processor))
-            targetCache.retrieveImage(forKey: key, options: optionsWithoutProcessor) { image, cacheType in
+            originalCache.retrieveImage(forKey: key, options: optionsWithoutProcessor) { image, cacheType in
                 // If we found the original image, there is no need to download it again.
                 // We could just apply processor to it now.
                 guard let image = image else {

--- a/Sources/KingfisherManager.swift
+++ b/Sources/KingfisherManager.swift
@@ -174,8 +174,8 @@ public class KingfisherManager {
                     if options.cacheOriginalImage {
                         let originalCache = options.originalCache
                         let defaultProcessor = DefaultImageProcessor.default
-                        if let originaliImage = defaultProcessor.process(item: .data(originalData), options: options) {
-                            originalCache.store(originaliImage,
+                        if let originalImage = defaultProcessor.process(item: .data(originalData), options: options) {
+                            originalCache.store(originalImage,
                                               original: originalData,
                                               forKey: key,
                                               processorIdentifier: defaultProcessor.identifier,

--- a/Sources/KingfisherOptionsInfo.swift
+++ b/Sources/KingfisherOptionsInfo.swift
@@ -46,6 +46,11 @@ public enum KingfisherOptionsInfoItem {
     /// the downloaded image to it.
     case targetCache(ImageCache)
     
+    /// Cache for storing and retrieving original image.
+    /// Preferred prior to targetCache for storing and retrieving original images if specified.
+    /// Only used if a non-default image processor is involved.
+    case originalCache(ImageCache)
+    
     /// The associated value of this member should be an ImageDownloader object. Kingfisher will use this
     /// downloader to download the images.
     case downloader(ImageDownloader)
@@ -138,6 +143,7 @@ infix operator <== : ItemComparisonPrecedence
 func <== (lhs: KingfisherOptionsInfoItem, rhs: KingfisherOptionsInfoItem) -> Bool {
     switch (lhs, rhs) {
     case (.targetCache(_), .targetCache(_)): return true
+    case (.originalCache(_), .originalCache(_)): return true
     case (.downloader(_), .downloader(_)): return true
     case (.transition(_), .transition(_)): return true
     case (.downloadPriority(_), .downloadPriority(_)): return true
@@ -179,6 +185,16 @@ public extension Collection where Iterator.Element == KingfisherOptionsInfoItem 
             return cache
         }
         return ImageCache.default
+    }
+    
+    /// The original `ImageCache` which is used.
+    public var originalCache: ImageCache {
+        if let item = lastMatchIgnoringAssociatedValue(.originalCache(.default)),
+            case .originalCache(let cache) = item
+        {
+            return cache
+        }
+        return targetCache
     }
     
     /// The `ImageDownloader` which is specified.


### PR DESCRIPTION
Hey hey 👋,

Here at Zeplin, we needed a way to cache the original images on a different cache (rather than the target cache) when using a custom image processor. For example, we are fetching images with a custom thumbnail image processor, and we want to store these thumbnails on a 'thumbnail' cache, and store the originals on a 'snapshots' cache. 

To accomplish this, we wrote a `originalCache` to `KingfisherOptionsInfoItem` on our fork. `originalCache` is basically used for storing and retrieving original images if paired with a non-default image processor. It defaults to `targetCache` to make it an optional item.

I've also included a typo fix and an optimization to prevent double caching if `cacheOriginalImage` is selected when used with the default image processor.

Thought this may be a good addition to the main repo. I wasn't able to write or run any tests because of the missing `Kingfisher-TestImages` folder. 