### PR TITLE
Fix possible invalid redeclaration error

### DIFF
--- a/Sources/AnimatedImageView.swift
+++ b/Sources/AnimatedImageView.swift
@@ -363,7 +363,7 @@ extension Kingfisher where Base: CGImageSource {
 }
 
 extension Array {
-    subscript(safe index: Int) -> Element? {
+    fileprivate subscript(safe index: Int) -> Element? {
         return indices ~= index ? self[index] : nil
     }
 }


### PR DESCRIPTION
- Array extension in `AnimatedImageView.swift` uses default access level for `subscript(safe:)` method
- This is a common Array extension method to make, and using this current access control level can lead to `Invalid Redeclaration of function` errors in Xcode

Steps to reproduce:
1) Create a new, empty Swift project, and import the Kingfisher library
2) Add the same Array extension in `AppDelegate.swift`

- Note: this error will occur regardless of the access control level of any duplicate extension (so even a `fileprivate subscript(safe:)` elsewhere will trigger the error)
