### PR TITLE
make closure return type  -> () modify to -> Void. Void is more accurate than () in return.

### DIFF
--- a/Demo/Kingfisher-watchOS-Demo Extension/InterfaceController.swift
+++ b/Demo/Kingfisher-watchOS-Demo Extension/InterfaceController.swift
@@ -47,7 +47,7 @@ class InterfaceController: WKInterfaceController {
     
     func refreshImage() {
         let url = URL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher/master/images/kingfisher-\(currentIndex! + 1).jpg")!
-        _ = KingfisherManager.shared.retrieveImage(with: url, options: nil, progressBlock: nil) { (image, error, cacheType, imageURL) -> () in
+        _ = KingfisherManager.shared.retrieveImage(with: url, options: nil, progressBlock: nil) { (image, error, cacheType, imageURL) -> Void in
             self.interfaceImage.setImage(image)
         }
     }

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -281,7 +281,7 @@ open class ImageCache {
     @discardableResult
     open func retrieveImage(forKey key: String,
                                options: KingfisherOptionsInfo?,
-                     completionHandler: ((Image?, CacheType) -> ())?) -> RetrieveImageDiskTask?
+                     completionHandler: ((Image?, CacheType) -> Void)?) -> RetrieveImageDiskTask?
     {
         // No completion handler. Not start working and early return.
         guard let completionHandler = completionHandler else {
@@ -600,7 +600,7 @@ open class ImageCache {
     
     - parameter completionHandler: Called with the calculated size when finishes.
     */
-    open func calculateDiskCacheSize(completion handler: @escaping ((_ size: UInt) -> ())) {
+    open func calculateDiskCacheSize(completion handler: @escaping ((_ size: UInt) -> Void)) {
         ioQueue.async {
             let (_, diskCacheSize, _) = self.travelCachedFiles(onlyForCacheSize: true)
             DispatchQueue.main.async {

--- a/Sources/ImageDownloader.swift
+++ b/Sources/ImageDownloader.swift
@@ -34,7 +34,7 @@ import UIKit
 public typealias ImageDownloaderProgressBlock = DownloadProgressBlock
 
 /// Completion block of downloader.
-public typealias ImageDownloaderCompletionHandler = ((_ image: Image?, _ error: NSError?, _ url: URL?, _ originalData: Data?) -> ())
+public typealias ImageDownloaderCompletionHandler = ((_ image: Image?, _ error: NSError?, _ url: URL?, _ originalData: Data?) -> Void)
 
 /// Download task.
 public struct RetrieveImageDownloadTask {

--- a/Sources/ImagePrefetcher.swift
+++ b/Sources/ImagePrefetcher.swift
@@ -37,14 +37,14 @@
 /// - `skippedResources`: An array of resources that are already cached before the prefetching starting.
 /// - `failedResources`: An array of resources that fail to be downloaded. It could because of being cancelled while downloading, encountered an error when downloading or the download not being started at all.
 /// - `completedResources`: An array of resources that are downloaded and cached successfully.
-public typealias PrefetcherProgressBlock = ((_ skippedResources: [Resource], _ failedResources: [Resource], _ completedResources: [Resource]) -> ())
+public typealias PrefetcherProgressBlock = ((_ skippedResources: [Resource], _ failedResources: [Resource], _ completedResources: [Resource]) -> Void)
 
 /// Completion block of prefetcher.
 ///
 /// - `skippedResources`: An array of resources that are already cached before the prefetching starting.
 /// - `failedResources`: An array of resources that fail to be downloaded. It could because of being cancelled while downloading, encountered an error when downloading or the download not being started at all.
 /// - `completedResources`: An array of resources that are downloaded and cached successfully.
-public typealias PrefetcherCompletionHandler = ((_ skippedResources: [Resource], _ failedResources: [Resource], _ completedResources: [Resource]) -> ())
+public typealias PrefetcherCompletionHandler = ((_ skippedResources: [Resource], _ failedResources: [Resource], _ completedResources: [Resource]) -> Void)
 
 /// `ImagePrefetcher` represents a downloading manager for requesting many images via URLs, then caching them.
 /// This is useful when you know a list of image resources and want to download them before showing.
@@ -189,7 +189,7 @@ public class ImagePrefetcher {
     
     func downloadAndCache(_ resource: Resource) {
 
-        let downloadTaskCompletionHandler: CompletionHandler = { (image, error, _, _) -> () in
+        let downloadTaskCompletionHandler: CompletionHandler = { (image, error, _, _) -> Void in
             self.tasks.removeValue(forKey: resource.downloadURL)
             if let _ = error {
                 self.failedResources.append(resource)

--- a/Sources/KingfisherManager.swift
+++ b/Sources/KingfisherManager.swift
@@ -30,8 +30,8 @@ import AppKit
 import UIKit
 #endif
 
-public typealias DownloadProgressBlock = ((_ receivedSize: Int64, _ totalSize: Int64) -> ())
-public typealias CompletionHandler = ((_ image: Image?, _ error: NSError?, _ cacheType: CacheType, _ imageURL: URL?) -> ())
+public typealias DownloadProgressBlock = ((_ receivedSize: Int64, _ totalSize: Int64) -> Void)
+public typealias CompletionHandler = ((_ image: Image?, _ error: NSError?, _ cacheType: CacheType, _ imageURL: URL?) -> Void)
 
 /// RetrieveImageTask represents a task of image retrieving process.
 /// It contains an async task of getting image from disk and from network.
@@ -157,7 +157,7 @@ public class KingfisherManager {
                 if let error = error, error.code == KingfisherError.notModified.rawValue {
                     // Not modified. Try to find the image from cache.
                     // (The image should be in cache. It should be guaranteed by the framework users.)
-                    targetCache.retrieveImage(forKey: key, options: options, completionHandler: { (cacheImage, cacheType) -> () in
+                    targetCache.retrieveImage(forKey: key, options: options, completionHandler: { (cacheImage, cacheType) -> Void in
                         completionHandler?(cacheImage, nil, cacheType, url)
                     })
                     return
@@ -199,7 +199,7 @@ public class KingfisherManager {
                                         options: KingfisherOptionsInfo)
     {
 
-        let diskTaskCompletionHandler: CompletionHandler = { (image, error, cacheType, imageURL) -> () in
+        let diskTaskCompletionHandler: CompletionHandler = { (image, error, cacheType, imageURL) -> Void in
             completionHandler?(image, error, cacheType, imageURL)
         }
         

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -94,9 +94,9 @@ class ImageCacheTests: XCTestCase {
     func testClearMemoryCache() {
         let expectation = self.expectation(description: "wait for retrieving image")
         
-        cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) { () -> () in
+        cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) { () -> Void in
             self.cache.clearMemoryCache()
-            self.cache.retrieveImage(forKey: testKeys[0], options: nil, completionHandler: { (image, type) -> () in
+            self.cache.retrieveImage(forKey: testKeys[0], options: nil, completionHandler: { (image, type) -> Void in
                 XCTAssert(image != nil && type == .disk, "Should be cached in disk. But \(type)")
 
                 expectation.fulfill()
@@ -110,7 +110,7 @@ class ImageCacheTests: XCTestCase {
         let expectation = self.expectation(description: "wait for retrieving image")
         
         cache.clearDiskCache {
-            self.cache.retrieveImage(forKey: testKeys[0], options: nil, completionHandler: { (image, type) -> () in
+            self.cache.retrieveImage(forKey: testKeys[0], options: nil, completionHandler: { (image, type) -> Void in
                 XCTAssert(image == nil, "Should not be cached in memory yet")
                 expectation.fulfill()
             })
@@ -123,8 +123,8 @@ class ImageCacheTests: XCTestCase {
     func testStoreImageInMemory() {
         let expectation = self.expectation(description: "wait for retrieving image")
         
-        cache.store(testImage, forKey: testKeys[0], toDisk: false) { () -> () in
-            self.cache.retrieveImage(forKey: testKeys[0], options: nil, completionHandler: { (image, type) -> () in
+        cache.store(testImage, forKey: testKeys[0], toDisk: false) { () -> Void in
+            self.cache.retrieveImage(forKey: testKeys[0], options: nil, completionHandler: { (image, type) -> Void in
                 XCTAssert(image != nil && type == .memory, "Should be cached in memory.")
                 expectation.fulfill()
             })
@@ -137,7 +137,7 @@ class ImageCacheTests: XCTestCase {
     func testStoreMultipleImages() {
         let expectation = self.expectation(description: "wait for writing image")
         
-        storeMultipleImages { () -> () in
+        storeMultipleImages { () -> Void in
             let diskCachePath = self.cache.diskCachePath
             let files: [String]?
             do {
@@ -162,13 +162,13 @@ class ImageCacheTests: XCTestCase {
         let exists = cache.imageCachedType(forKey: url.cacheKey).cached
         XCTAssertFalse(exists)
         
-        cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> () in
+        cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
             XCTAssertNil(image, "Should not be cached yet")
             
             XCTAssertEqual(type, .none)
 
-            self.cache.store(testImage, forKey: URLString, toDisk: true) { () -> () in
-                self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> () in
+            self.cache.store(testImage, forKey: URLString, toDisk: true) { () -> Void in
+                self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
                     XCTAssertNotNil(image, "Should be cached (memory or disk)")
                     XCTAssertEqual(type, .memory)
 
@@ -176,7 +176,7 @@ class ImageCacheTests: XCTestCase {
                     XCTAssertTrue(exists, "Image should exist in the cache (memory or disk)")
 
                     self.cache.clearMemoryCache()
-                    self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> () in
+                    self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
                         XCTAssertNotNil(image, "Should be cached (disk)")
                         XCTAssertEqual(type, CacheType.disk)
                         
@@ -210,13 +210,13 @@ class ImageCacheTests: XCTestCase {
         let exists = cache.imageCachedType(forKey: url.cacheKey).cached
         XCTAssertFalse(exists)
         
-        cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> () in
+        cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
             XCTAssertNil(image, "Should not be cached yet")
             
             XCTAssertEqual(type, .none)
             
-            self.cache.store(testImage, forKey: URLString, toDisk: true) { () -> () in
-                self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> () in
+            self.cache.store(testImage, forKey: URLString, toDisk: true) { () -> Void in
+                self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
                     XCTAssertNotNil(image, "Should be cached (memory or disk)")
                     XCTAssertEqual(type, .memory)
                     
@@ -224,7 +224,7 @@ class ImageCacheTests: XCTestCase {
                     XCTAssertTrue(exists, "Image should exist in the cache (memory or disk)")
                     
                     self.cache.clearMemoryCache()
-                    self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> () in
+                    self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
                         XCTAssertNotNil(image, "Should be cached (disk)")
                         XCTAssertEqual(type, CacheType.disk)
                         
@@ -246,13 +246,13 @@ class ImageCacheTests: XCTestCase {
 
   
     func testCachedImageIsFetchedSyncronouslyFromTheMemoryCache() {
-        cache.store(testImage, forKey: testKeys[0], toDisk: false) { () -> () in
+        cache.store(testImage, forKey: testKeys[0], toDisk: false) { () -> Void in
             // do nothing
         }
 
         var foundImage: Image?
 
-        cache.retrieveImage(forKey: testKeys[0], options: [.backgroundDecode]) { (image, type) -> () in
+        cache.retrieveImage(forKey: testKeys[0], options: [.backgroundDecode]) { (image, type) -> Void in
             foundImage = image
         }
 
@@ -263,7 +263,7 @@ class ImageCacheTests: XCTestCase {
         let expectation = self.expectation(description: "wait for caching image")
         
         XCTAssert(self.cache.imageCachedType(forKey: testKeys[0]).cached == false, "This image should not be cached yet.")
-        self.cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) { () -> () in
+        self.cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) { () -> Void in
             XCTAssert(self.cache.imageCachedType(forKey: testKeys[0]).cached == true, "This image should be already cached.")
             expectation.fulfill()
         }
@@ -274,7 +274,7 @@ class ImageCacheTests: XCTestCase {
     func testRetrievingImagePerformance() {
 
         let expectation = self.expectation(description: "wait for retrieving image")
-        self.cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) { () -> () in
+        self.cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) { () -> Void in
             self.measure({ () -> Void in
                 for _ in 1 ..< 200 {
                     _ = self.cache.retrieveImageInDiskCache(forKey: testKeys[0])
@@ -289,7 +289,7 @@ class ImageCacheTests: XCTestCase {
     func testCleanDiskCacheNotification() {
         let expectation = self.expectation(description: "wait for retrieving image")
         
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) { () -> () in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) { () -> Void in
 
             self.observer = NotificationCenter.default.addObserver(forName: .KingfisherDidCleanDiskCache, object: self.cache, queue: OperationQueue.main, using: { (noti) -> Void in
 
@@ -321,9 +321,9 @@ class ImageCacheTests: XCTestCase {
         let expectation = self.expectation(description: "wait for retrieving image")
         let p = RoundCornerImageProcessor(cornerRadius: 40)
         
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) { () -> () in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) { () -> Void in
             
-            self.cache.retrieveImage(forKey: testKeys[0], options: [.processor(p)], completionHandler: { (image, type) -> () in
+            self.cache.retrieveImage(forKey: testKeys[0], options: [.processor(p)], completionHandler: { (image, type) -> Void in
                 
                 XCTAssert(image == nil, "The image with prosossor should not be cached yet.")
                 
@@ -338,9 +338,9 @@ class ImageCacheTests: XCTestCase {
         let expectation = self.expectation(description: "wait for retrieving image")
         let p = RoundCornerImageProcessor(cornerRadius: 40)
         
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], processorIdentifier: p.identifier,toDisk: true) { () -> () in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], processorIdentifier: p.identifier,toDisk: true) { () -> Void in
             
-            self.cache.retrieveImage(forKey: testKeys[0], options: [.processor(p)], completionHandler: { (image, type) -> () in
+            self.cache.retrieveImage(forKey: testKeys[0], options: [.processor(p)], completionHandler: { (image, type) -> Void in
                 
                 XCTAssert(image != nil, "The image with prosossor should already be cached.")
                 
@@ -401,19 +401,19 @@ class ImageCacheTests: XCTestCase {
         let group = DispatchGroup()
         
         group.enter()
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) { () -> () in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) { () -> Void in
             group.leave()
         }
         group.enter()
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[1], toDisk: true) { () -> () in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[1], toDisk: true) { () -> Void in
             group.leave()
         }
         group.enter()
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[2], toDisk: true) { () -> () in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[2], toDisk: true) { () -> Void in
             group.leave()
         }
         group.enter()
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[3], toDisk: true) { () -> () in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[3], toDisk: true) { () -> Void in
             group.leave()
         }
         

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -64,9 +64,9 @@ class ImageDownloaderTests: XCTestCase {
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
 
         let url = URL(string: URLString)!
-        downloader.downloadImage(with: url, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        downloader.downloadImage(with: url, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             return
-        }) { (image, error, imageURL, data) -> () in
+        }) { (image, error, imageURL, data) -> Void in
             expectation.fulfill()
             XCTAssert(image != nil, "Download should be able to finished for URL: \(String(describing: imageURL))")
         }
@@ -83,9 +83,9 @@ class ImageDownloaderTests: XCTestCase {
             if let url = URL(string: URLString) {
                 group.enter()
                 _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
-                downloader.downloadImage(with: url, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+                downloader.downloadImage(with: url, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
                     
-                }, completionHandler: { (image, error, imageURL, data) -> () in
+                }, completionHandler: { (image, error, imageURL, data) -> Void in
                     XCTAssert(image != nil, "Download should be able to finished for URL: \(String(describing: imageURL)).")
                     group.leave()
                 })
@@ -105,9 +105,9 @@ class ImageDownloaderTests: XCTestCase {
 
         for _ in 0...5 {
             group.enter()
-            downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+            downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
                 
-                }) { (image, error, imageURL, data) -> () in
+                }) { (image, error, imageURL, data) -> Void in
                     XCTAssert(image != nil, "Download should be able to finished for URL: \(String(describing: imageURL)).")
                     group.leave()
                     
@@ -127,9 +127,9 @@ class ImageDownloaderTests: XCTestCase {
         modifier.url = URL(string: URLString)
         
         let someURL = URL(string: "some_strange_url")!
-        downloader.downloadImage(with: someURL, options: [.requestModifier(modifier)], progressBlock: { (receivedSize, totalSize) -> () in
+        downloader.downloadImage(with: someURL, options: [.requestModifier(modifier)], progressBlock: { (receivedSize, totalSize) -> Void in
             
-        }) { (image, error, imageURL, data) -> () in
+        }) { (image, error, imageURL, data) -> Void in
             XCTAssert(image != nil, "Download should be able to finished for URL: \(String(describing: imageURL)).")
             XCTAssertEqual(imageURL!, URL(string: URLString)!, "The returned imageURL should be the replaced one")
             expectation.fulfill()
@@ -143,9 +143,9 @@ class ImageDownloaderTests: XCTestCase {
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(304)
         
-        downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
-        }) { (image, error, imageURL, data) -> () in
+        }) { (image, error, imageURL, data) -> Void in
             XCTAssertNotNil(error, "There should be an error since server returning 304 and no image downloaded.")
             XCTAssertEqual(error!.code, KingfisherError.notModified.rawValue, "The error should be NotModified.")
             expectation.fulfill()
@@ -159,9 +159,9 @@ class ImageDownloaderTests: XCTestCase {
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(404)?.withBody(testImageData)
         
-        downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
-        }) { (image, error, imageURL, data) -> () in
+        }) { (image, error, imageURL, data) -> Void in
             XCTAssertNotNil(error, "There should be an error since server returning 404")
             XCTAssertEqual(error!.code, KingfisherError.invalidStatusCode.rawValue, "The error should be InvalidStatusCode.")
             XCTAssertEqual(error!.userInfo["statusCode"]! as? Int, 404, "The error should be InvalidStatusCode.")
@@ -181,7 +181,7 @@ class ImageDownloaderTests: XCTestCase {
         
         let expectation = self.expectation(description: "wait for download from an invalid ssl site.")
         
-        downloader.downloadImage(with: url, progressBlock: nil, completionHandler: { (image, error, imageURL, data) -> () in
+        downloader.downloadImage(with: url, progressBlock: nil, completionHandler: { (image, error, imageURL, data) -> Void in
             XCTAssertNotNil(error, "Error should not be nil")
             XCTAssert(error?.code == NSURLErrorServerCertificateUntrusted || error?.code == NSURLErrorSecureConnectionFailed, "Error should be NSURLErrorServerCertificateUntrusted, but \(String(describing: error))")
             expectation.fulfill()
@@ -202,14 +202,14 @@ class ImageDownloaderTests: XCTestCase {
         stubRequest("GET", URLString).andFailWithError(NSError(domain: "stubError", code: -1, userInfo: nil))
         let url = URL(string: URLString)!
         
-        downloader.downloadImage(with: url, progressBlock: nil) { (image, error, imageURL, data) -> () in
+        downloader.downloadImage(with: url, progressBlock: nil) { (image, error, imageURL, data) -> Void in
             XCTAssertNotNil(error, "Should return with an error")
             
             LSNocilla.sharedInstance().clearStubs()
             _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
             
             // Retry the download
-            self.downloader.downloadImage(with: url, progressBlock: nil, completionHandler: { (image, error, imageURL, data) -> () in
+            self.downloader.downloadImage(with: url, progressBlock: nil, completionHandler: { (image, error, imageURL, data) -> Void in
                 XCTAssertNil(error, "Download should be finished without error")
                 expectation.fulfill()
             })
@@ -224,9 +224,9 @@ class ImageDownloaderTests: XCTestCase {
         modifier.url = nil
         
         let url = URL(string: "http://onevcat.com")
-        downloader.downloadImage(with: url!, options: [.requestModifier(modifier)], progressBlock: { (receivedSize, totalSize) -> () in
+        downloader.downloadImage(with: url!, options: [.requestModifier(modifier)], progressBlock: { (receivedSize, totalSize) -> Void in
             XCTFail("The progress block should not be called.")
-            }) { (image, error, imageURL, originalData) -> () in
+            }) { (image, error, imageURL, originalData) -> Void in
                 XCTAssertNotNil(error, "An error should happen for empty URL")
                 XCTAssertEqual(error!.code, KingfisherError.invalidURL.rawValue)
                 self.downloader.delegate = nil
@@ -236,9 +236,9 @@ class ImageDownloaderTests: XCTestCase {
     }
     
     func testDownloadTaskProperty() {
-        let task = downloader.downloadImage(with: URL(string: "1234")!, progressBlock: { (receivedSize, totalSize) -> () in
+        let task = downloader.downloadImage(with: URL(string: "1234")!, progressBlock: { (receivedSize, totalSize) -> Void in
 
-            }) { (image, error, imageURL, originalData) -> () in
+            }) { (image, error, imageURL, originalData) -> Void in
         }
         
         XCTAssertNotNil(task, "The task should exist.")
@@ -256,9 +256,9 @@ class ImageDownloaderTests: XCTestCase {
         
         var progressBlockIsCalled = false
         
-        let downloadTask = downloader.downloadImage(with: url, progressBlock: { (receivedSize, totalSize) -> () in
+        let downloadTask = downloader.downloadImage(with: url, progressBlock: { (receivedSize, totalSize) -> Void in
                 progressBlockIsCalled = true
-            }) { (image, error, imageURL, originalData) -> () in
+            }) { (image, error, imageURL, originalData) -> Void in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error!.code, NSURLErrorCancelled)
                 XCTAssert(progressBlockIsCalled == false, "ProgressBlock should not be called since it is canceled.")
@@ -287,9 +287,9 @@ class ImageDownloaderTests: XCTestCase {
         let group = DispatchGroup()
         
         group.enter()
-        let downloadTask = downloader.downloadImage(with: url, progressBlock: { (receivedSize, totalSize) -> () in
+        let downloadTask = downloader.downloadImage(with: url, progressBlock: { (receivedSize, totalSize) -> Void in
             progressBlockIsCalled = true
-        }) { (image, error, imageURL, originalData) -> () in
+        }) { (image, error, imageURL, originalData) -> Void in
             XCTAssertNotNil(error)
             XCTAssertEqual(error!.code, NSURLErrorCancelled)
             XCTAssert(progressBlockIsCalled == false, "ProgressBlock should not be called since it is canceled.")
@@ -302,9 +302,9 @@ class ImageDownloaderTests: XCTestCase {
         _ = stub!.go()
         
         group.enter()
-        downloader.downloadImage(with: url, progressBlock: { (receivedSize, totalSize) -> () in
+        downloader.downloadImage(with: url, progressBlock: { (receivedSize, totalSize) -> Void in
             progressBlockIsCalled = true
-        }) { (image, error, imageURL, originalData) -> () in
+        }) { (image, error, imageURL, originalData) -> Void in
             XCTAssertNotNil(image)
             group.leave()
         }
@@ -332,9 +332,9 @@ class ImageDownloaderTests: XCTestCase {
         let p = RoundCornerImageProcessor(cornerRadius: 40)
         let roundcornered = testImage.kf.image(withRoundRadius: 40, fit: testImage.kf.size)
         
-        downloader.downloadImage(with: url, options: [.processor(p)], progressBlock: { (receivedSize, totalSize) -> () in
+        downloader.downloadImage(with: url, options: [.processor(p)], progressBlock: { (receivedSize, totalSize) -> Void in
             
-        }) { (image, error, imageURL, data) -> () in
+        }) { (image, error, imageURL, data) -> Void in
             expectation.fulfill()
             XCTAssert(image != nil, "Download should be able to finished for URL: \(String(describing: imageURL))")
             XCTAssertFalse(image!.renderEqual(to: testImage), "The processed image should not equal to the original one.")
@@ -361,18 +361,18 @@ class ImageDownloaderTests: XCTestCase {
         
         var count = 0
         
-        downloader.downloadImage(with: url, options: [.processor(p1)], progressBlock: { (receivedSize, totalSize) -> () in
+        downloader.downloadImage(with: url, options: [.processor(p1)], progressBlock: { (receivedSize, totalSize) -> Void in
 
-        }) { (image, error, imageURL, data) -> () in
+        }) { (image, error, imageURL, data) -> Void in
             XCTAssertTrue(image!.renderEqual(to: roundcornered), "The processed image should equal to the one directly processed from original one.")
             
             count += 1
             if count == 2 { expectation.fulfill() }
         }
         
-        downloader.downloadImage(with: url, options: [.processor(p2)], progressBlock: { (receivedSize, totalSize) -> () in
+        downloader.downloadImage(with: url, options: [.processor(p2)], progressBlock: { (receivedSize, totalSize) -> Void in
             
-        }) { (image, error, imageURL, data) -> () in
+        }) { (image, error, imageURL, data) -> Void in
             XCTAssertTrue(image!.renderEqual(to: blurred), "The processed image should equal to the one directly processed from original one.")
             
             count += 1

--- a/Tests/KingfisherTests/ImagePrefetcherTests.swift
+++ b/Tests/KingfisherTests/ImagePrefetcherTests.swift
@@ -68,10 +68,10 @@ class ImagePrefetcherTests: XCTestCase {
         
         var progressCalledCount = 0
         let prefetcher = ImagePrefetcher(urls: urls, options: nil,
-                            progressBlock: { (skippedResources, failedResources, completedResources) -> () in
+                            progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
                                 progressCalledCount += 1
                             },
-                            completionHandler: {(skippedResources, failedResources, completedResources) -> () in
+                            completionHandler: {(skippedResources, failedResources, completedResources) -> Void in
                                 expectation.fulfill()
                                 XCTAssertEqual(skippedResources.count, 0, "There should be no items skipped.")
                                 XCTAssertEqual(failedResources.count, 0, "There should be no failed downloading.")
@@ -99,9 +99,9 @@ class ImagePrefetcherTests: XCTestCase {
         
         let maxConcurrentCount = 2
         let prefetcher = ImagePrefetcher(urls: urls, options: nil,
-                            progressBlock: { (skippedResources, failedResources, completedResources) -> () in
+                            progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
                             },
-                            completionHandler: {(skippedResources, failedResources, completedResources) -> () in
+                            completionHandler: {(skippedResources, failedResources, completedResources) -> Void in
                                 XCTAssertEqual(skippedResources.count, 0, "There should be no items skipped.")
                                 XCTAssertEqual(failedResources.count, urls.count, "The failed count should be the same with started downloads due to cancellation.")
                                 XCTAssertEqual(completedResources.count, 0, "None resources prefetching should complete.")
@@ -128,9 +128,9 @@ class ImagePrefetcherTests: XCTestCase {
             urls.append(URL(string: URLString)!)
         }
         
-        let prefetcher = ImagePrefetcher(urls: urls, options: nil, progressBlock: { (skippedResources, failedResources, completedResources) -> () in
+        let prefetcher = ImagePrefetcher(urls: urls, options: nil, progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
 
-            }) { (skippedResources, failedResources, completedResources) -> () in
+            }) { (skippedResources, failedResources, completedResources) -> Void in
                 expectation.fulfill()
                 XCTAssertEqual(skippedResources.count, 1, "There should be 1 item skipped.")
                 XCTAssertEqual(skippedResources[0].downloadURL.absoluteString, testKeys[0], "The correct image key should be skipped.")
@@ -157,9 +157,9 @@ class ImagePrefetcherTests: XCTestCase {
         }
         
         // Use `.ForceRefresh` to download it forcely.
-        let prefetcher = ImagePrefetcher(urls: urls, options: [.forceRefresh], progressBlock: { (skippedResources, failedResources, completedResources) -> () in
+        let prefetcher = ImagePrefetcher(urls: urls, options: [.forceRefresh], progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
             
-            }) { (skippedResources, failedResources, completedResources) -> () in
+            }) { (skippedResources, failedResources, completedResources) -> Void in
                 expectation.fulfill()
                 
                 XCTAssertEqual(skippedResources.count, 0, "There should be no item skipped.")
@@ -174,7 +174,7 @@ class ImagePrefetcherTests: XCTestCase {
     
     func testPrefetchWithWrongInitParameters() {
         let expectation = self.expectation(description: "wait for prefetching images")
-        let prefetcher = ImagePrefetcher(urls: [], options: nil, progressBlock: nil) { (skippedResources, failedResources, completedResources) -> () in
+        let prefetcher = ImagePrefetcher(urls: [], options: nil, progressBlock: nil) { (skippedResources, failedResources, completedResources) -> Void in
             expectation.fulfill()
             
             XCTAssertEqual(skippedResources.count, 0, "There should be no item skipped.")
@@ -200,10 +200,10 @@ class ImagePrefetcherTests: XCTestCase {
         func prefetchAgain() {
             var progressCalledCount = 0
             let prefetcher = ImagePrefetcher(urls: urls, options: [.processor(p)],
-                                             progressBlock: { (skippedResources, failedResources, completedResources) -> () in
+                                             progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
                                                 progressCalledCount += 1
             },
-                                             completionHandler: {(skippedResources, failedResources, completedResources) -> () in
+                                             completionHandler: {(skippedResources, failedResources, completedResources) -> Void in
                                                 
                                                 XCTAssertEqual(skippedResources.count, urls.count, "There should be one item skipped since it is just prefetched.")
                                                 XCTAssertEqual(failedResources.count, 0, "There should be no failed downloading.")
@@ -221,10 +221,10 @@ class ImagePrefetcherTests: XCTestCase {
         
         var progressCalledCount = 0
         let prefetcher = ImagePrefetcher(urls: urls, options: [.processor(p)],
-                                         progressBlock: { (skippedResources, failedResources, completedResources) -> () in
+                                         progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
                                             progressCalledCount += 1
         },
-                                         completionHandler: {(skippedResources, failedResources, completedResources) -> () in
+                                         completionHandler: {(skippedResources, failedResources, completedResources) -> Void in
                                             
                                             XCTAssertEqual(skippedResources.count, 0, "There should be no items skipped.")
                                             XCTAssertEqual(failedResources.count, 0, "There should be no failed downloading.")

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -68,10 +68,10 @@ class ImageViewExtensionTests: XCTestCase {
         
         var progressBlockIsCalled = false
         
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             progressBlockIsCalled = true
             XCTAssertTrue(Thread.isMainThread)
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             expectation.fulfill()
             
             XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
@@ -95,9 +95,9 @@ class ImageViewExtensionTests: XCTestCase {
         let url = URL(string: URLString)!
         
         let customQueue = DispatchQueue(label: "com.kingfisher.testQueue")
-        imageView.kf.setImage(with: url, placeholder: nil, options: [.callbackDispatchQueue(customQueue)], progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: [.callbackDispatchQueue(customQueue)], progressBlock: { (receivedSize, totalSize) -> Void in
             XCTAssertTrue(Thread.isMainThread)
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             XCTAssertTrue(Thread.isMainThread, "The image extension callback should be always in main queue.")
             expectation.fulfill()
         }
@@ -117,9 +117,9 @@ class ImageViewExtensionTests: XCTestCase {
         
         cleanDefaultCache()
         
-        _ = imageView.kf.setImage(with: resource, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        _ = imageView.kf.setImage(with: resource, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             progressBlockIsCalled = true
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 expectation.fulfill()
                 
                 XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
@@ -143,9 +143,9 @@ class ImageViewExtensionTests: XCTestCase {
         
         var progressBlockIsCalled = false
 
-        let task = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        let task = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             progressBlockIsCalled = true
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             XCTAssertEqual(error?.code, KingfisherError.downloadCancelledBeforeStarting.rawValue, "The error should be downloadCancelledBeforeStarting")
             XCTAssert(progressBlockIsCalled == false, "ProgressBlock should not be called since it is canceled.")
             expectation.fulfill()
@@ -166,9 +166,9 @@ class ImageViewExtensionTests: XCTestCase {
         
         cleanDefaultCache()
         
-        let task = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        let task = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             progressBlockIsCalled = true
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error?.code, NSURLErrorCancelled)
                 XCTAssert(progressBlockIsCalled == false, "ProgressBlock should not be called since it is canceled.")
@@ -193,26 +193,26 @@ class ImageViewExtensionTests: XCTestCase {
         let group = DispatchGroup()
         
         group.enter()
-        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
 
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNil(image)
                 XCTAssertEqual(error?.code, KingfisherError.downloadCancelledBeforeStarting.rawValue, "The error should be downloadCancelledBeforeStarting")
                 group.leave()
         }
         
         group.enter()
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(image)
                 group.leave()
         }
         
         group.enter()
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(image)
                 group.leave()
         }
@@ -234,25 +234,25 @@ class ImageViewExtensionTests: XCTestCase {
         let group = DispatchGroup()
         
         group.enter()
-        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(image)
                 group.leave()
         }
         
         group.enter()
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(image)
                 group.leave()
         }
         
         group.enter()
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(image)
                 group.leave()
         }
@@ -277,27 +277,27 @@ class ImageViewExtensionTests: XCTestCase {
         let group = DispatchGroup()
         
         group.enter()
-        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error?.code, NSURLErrorCancelled)
                 group.leave()
         }
         
         group.enter()
-        let task2 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        let task2 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error?.code, NSURLErrorCancelled)
                 group.leave()
         }
         
         group.enter()
-        let task3 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        let task3 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error?.code, NSURLErrorCancelled)
                 group.leave()
@@ -328,17 +328,17 @@ class ImageViewExtensionTests: XCTestCase {
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
         let url = URL(string: URLString)!
         
-        imageView.kf.setImage(with: url, placeholder: nil, options: [.targetCache(cache1)], progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: [.targetCache(cache1)], progressBlock: { (receivedSize, totalSize) -> Void in
             
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             
             XCTAssertTrue(cache1.imageCachedType(forKey: URLString).cached, "This image should be cached in cache1.")
             XCTAssertFalse(cache2.imageCachedType(forKey: URLString).cached, "This image should not be cached in cache2.")
             XCTAssertFalse(KingfisherManager.shared.cache.imageCachedType(forKey: URLString).cached, "This image should not be cached in default cache.")
             
-            self.imageView.kf.setImage(with: url, placeholder: nil, options: [.targetCache(cache2)], progressBlock: { (receivedSize, totalSize) -> () in
+            self.imageView.kf.setImage(with: url, placeholder: nil, options: [.targetCache(cache2)], progressBlock: { (receivedSize, totalSize) -> Void in
                 
-            }, completionHandler: { (image, error, cacheType, imageURL) -> () in
+            }, completionHandler: { (image, error, cacheType, imageURL) -> Void in
                 
                 XCTAssertTrue(cache1.imageCachedType(forKey: URLString).cached, "This image should be cached in cache1.")
                 XCTAssertTrue(cache2.imageCachedType(forKey: URLString).cached, "This image should be cached in cache2.")
@@ -375,13 +375,13 @@ class ImageViewExtensionTests: XCTestCase {
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
         let url = URL(string: URLString)!
         
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
             let indicator = self.imageView.kf.indicator
             XCTAssertNotNil(indicator, "The indicator view should exist when showIndicatorWhenLoading is true")
             XCTAssertFalse(indicator!.view.isHidden, "The indicator should be shown and animating when loading")
 
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             let indicator = self.imageView.kf.indicator
             XCTAssertTrue(indicator!.view.isHidden, "The indicator should stop and hidden after loading")
             expectation.fulfill()
@@ -404,13 +404,13 @@ class ImageViewExtensionTests: XCTestCase {
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
         let url = URL(string: URLString)!
         
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
             let indicator = self.imageView.kf.indicator
             XCTAssertNotNil(indicator, "The indicator view should exist when showIndicatorWhenLoading is true")
             XCTAssertFalse(indicator!.view.isHidden, "The indicator should be shown and animating when loading")
             
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             let indicator = self.imageView.kf.indicator
             XCTAssertTrue(indicator!.view.isHidden, "The indicator should stop and hidden after loading")
             expectation.fulfill()
@@ -426,9 +426,9 @@ class ImageViewExtensionTests: XCTestCase {
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
         let url = URL(string: URLString)!
         
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
                 XCTFail("Progress block should not be called.")
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error?.code, NSURLErrorCancelled)
                 
@@ -479,9 +479,9 @@ class ImageViewExtensionTests: XCTestCase {
         let expectation = self.expectation(description: "wait for downloading image")
         
         let url: URL? = nil
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             XCTFail("Progress block should not be called.")
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             XCTAssertNil(image)
             XCTAssertNil(error)
             XCTAssertEqual(cacheType, CacheType.none)
@@ -547,10 +547,10 @@ class ImageViewExtensionTests: XCTestCase {
             var progressBlockIsCalled = false
             ImageCache.default.clearMemoryCache()
             
-            imageView.kf.setImage(with: url, placeholder: nil, options: [], progressBlock: { (receivedSize, totalSize) -> () in
+            imageView.kf.setImage(with: url, placeholder: nil, options: [], progressBlock: { (receivedSize, totalSize) -> Void in
                 progressBlockIsCalled = true
                 XCTAssertTrue(Thread.isMainThread)
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 
                 XCTAssertFalse(progressBlockIsCalled, "progressBlock should not be called since the image is cached.")
                 XCTAssertNotNil(image, "Downloaded image should exist.")
@@ -565,10 +565,10 @@ class ImageViewExtensionTests: XCTestCase {
         }
         
         var progressBlockIsCalled = false
-        imageView.kf.setImage(with: url, placeholder: nil, options: [.onlyLoadFirstFrame], progressBlock: { (receivedSize, totalSize) -> () in
+        imageView.kf.setImage(with: url, placeholder: nil, options: [.onlyLoadFirstFrame], progressBlock: { (receivedSize, totalSize) -> Void in
             progressBlockIsCalled = true
             XCTAssertTrue(Thread.isMainThread)
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             XCTAssertTrue(progressBlockIsCalled, "progressBlock should be called at least once.")
             XCTAssertNotNil(image, "Downloaded image should exist.")
             XCTAssertNil(image!.kf.images, "images should not exist since we set only load first frame.")

--- a/Tests/KingfisherTests/NSButtonExtensionTests.swift
+++ b/Tests/KingfisherTests/NSButtonExtensionTests.swift
@@ -71,9 +71,9 @@ class NSButtonExtensionTests: XCTestCase {
 
         cleanDefaultCache()
 
-        button.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        button.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             progressBlockIsCalled = true
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             expectation.fulfill()
 
             XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
@@ -94,9 +94,9 @@ class NSButtonExtensionTests: XCTestCase {
         let url = URL(string: URLString)!
 
         var progressBlockIsCalled = false
-        button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             progressBlockIsCalled = true
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             expectation.fulfill()
 
             XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
@@ -117,9 +117,9 @@ class NSButtonExtensionTests: XCTestCase {
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
         let url = URL(string: URLString)!
 
-        button.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        button.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             XCTAssertNotNil(error)
             XCTAssertEqual(error?.code, NSURLErrorCancelled)
 
@@ -141,9 +141,9 @@ class NSButtonExtensionTests: XCTestCase {
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
         let url = URL(string: URLString)!
 
-        _ = button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        _ = button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             XCTFail("Progress block should not be called.")
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             XCTAssertNotNil(error)
             XCTAssertEqual(error?.code, NSURLErrorCancelled)
 
@@ -162,9 +162,9 @@ class NSButtonExtensionTests: XCTestCase {
         let expectation = self.expectation(description: "wait for downloading image")
         
         let url: URL? = nil
-        button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             XCTFail("Progress block should not be called.")
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             XCTAssertNil(image)
             XCTAssertNil(error)
             XCTAssertEqual(cacheType, CacheType.none)

--- a/Tests/KingfisherTests/UIButtonExtensionTests.swift
+++ b/Tests/KingfisherTests/UIButtonExtensionTests.swift
@@ -71,9 +71,9 @@ class UIButtonExtensionTests: XCTestCase {
         
         cleanDefaultCache()
         
-        button.kf.setImage(with: url, for: .highlighted, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        button.kf.setImage(with: url, for: .highlighted, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             progressBlockIsCalled = true
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             expectation.fulfill()
             
             XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
@@ -94,9 +94,9 @@ class UIButtonExtensionTests: XCTestCase {
         let url = Foundation.URL(string: URLString)!
         
         var progressBlockIsCalled = false
-        button.kf.setBackgroundImage(with: url, for: .normal, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        button.kf.setBackgroundImage(with: url, for: .normal, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             progressBlockIsCalled = true
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 expectation.fulfill()
                 
                 XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
@@ -117,9 +117,9 @@ class UIButtonExtensionTests: XCTestCase {
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
         let url = URL(string: URLString)!
 
-        button.kf.setImage(with: url, for: UIControlState.highlighted, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        button.kf.setImage(with: url, for: UIControlState.highlighted, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
                 
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error?.code, NSURLErrorCancelled)
 
@@ -140,9 +140,9 @@ class UIButtonExtensionTests: XCTestCase {
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
         let url = URL(string: URLString)!
         
-        button.kf.setBackgroundImage(with: url, for: UIControlState(), placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        button.kf.setBackgroundImage(with: url, for: UIControlState(), placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             XCTFail("Progress block should not be called.")
-            }) { (image, error, cacheType, imageURL) -> () in
+            }) { (image, error, cacheType, imageURL) -> Void in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error?.code, NSURLErrorCancelled)
                 
@@ -160,9 +160,9 @@ class UIButtonExtensionTests: XCTestCase {
         let expectation = self.expectation(description: "wait for downloading image")
         
         let url: URL? = nil
-        button.kf.setBackgroundImage(with: url, for: UIControlState(), placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> () in
+        button.kf.setBackgroundImage(with: url, for: UIControlState(), placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
             XCTFail("Progress block should not be called.")
-        }) { (image, error, cacheType, imageURL) -> () in
+        }) { (image, error, cacheType, imageURL) -> Void in
             XCTAssertNil(image)
             XCTAssertNil(error)
             XCTAssertEqual(cacheType, CacheType.none)


### PR DESCRIPTION
闭包返回值Void要比()更精确，表明这是Void类型。而()一般作为空的表达式，也可以作为Void类型。感觉Void更精准