### PR TITLE
Add option to remove image only from disk cache and not memory

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -234,7 +234,8 @@ open class ImageCache {
     - parameter key:               Key for the image.
     - parameter identifier:        The identifier of processor used. If you are using a processor for the image, pass the identifier of processor to it.
                                    This identifier will be used to generate a corresponding key for the combination of `key` and processor.
-    - parameter fromDisk:          Whether this image should be removed from disk or not. If false, the image will be only removed from memory.
+    - parameter fromMemory:        Whether this image should be removed from memory or not. If false, the image won't be removed from memory.
+    - parameter fromDisk:          Whether this image should be removed from disk or not. If false, the image won't be removed from disk.
     - parameter completionHandler: Called when removal operation completes.
     */
     open func removeImage(forKey key: String,

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -239,11 +239,15 @@ open class ImageCache {
     */
     open func removeImage(forKey key: String,
                           processorIdentifier identifier: String = "",
+                          fromMemory: Bool = true,
                           fromDisk: Bool = true,
                           completionHandler: (() -> Void)? = nil)
     {
         let computedKey = key.computedKey(with: identifier)
-        memoryCache.removeObject(forKey: computedKey as NSString)
+
+        if fromMemory {
+            memoryCache.removeObject(forKey: computedKey as NSString)
+        }
         
         func callHandlerInMainQueue() {
             if let handler = completionHandler {


### PR DESCRIPTION
Use Case:

New Images for new Data Models are downloaded in the background but the UI isn't refreshed yet.
So we want to keep the currently visible Images in memory cache so that e.g. a TableViewCell can still display them (from memory cache) but want to delete images from disk cache to keep the disk footprint low.