### PR TITLE
Fixes Gif Loop Counting and Frame Skipping

### DIFF
--- a/Sources/AnimatedImageView.swift
+++ b/Sources/AnimatedImageView.swift
@@ -305,6 +305,7 @@ class Animator {
     fileprivate let maxTimeStep: TimeInterval = 1.0
     fileprivate var frameCount = 0
     fileprivate var currentFrameIndex = 0
+    fileprivate var currentFrameIndexInBuffer = 0
     fileprivate var currentPreloadIndex = 0
     fileprivate var timeSinceLastFrameChange: TimeInterval = 0.0
     fileprivate var needsPrescaling = true
@@ -315,7 +316,7 @@ class Animator {
     private var loopCount = 0
     
     var currentFrame: UIImage? {
-        return frame(at: currentFrameIndex)
+        return frame(at: currentFrameIndexInBuffer)
     }
 
     var isReachMaxRepeatCount: Bool {
@@ -426,21 +427,24 @@ class Animator {
      */
     func updateCurrentFrame(duration: CFTimeInterval) -> Bool {
         timeSinceLastFrameChange += min(maxTimeStep, duration)
-        guard let frameDuration = animatedFrames[safe: currentFrameIndex]?.duration, frameDuration <= timeSinceLastFrameChange else {
+        guard let frameDuration = animatedFrames[safe: currentFrameIndexInBuffer]?.duration, frameDuration <= timeSinceLastFrameChange else {
             return false
         }
         
         timeSinceLastFrameChange -= frameDuration
         
-        let lastFrameIndex = currentFrameIndex
-        currentFrameIndex += 1
-        currentFrameIndex = currentFrameIndex % animatedFrames.count
-
+        let lastFrameIndex = currentFrameIndexInBuffer
+        currentFrameIndexInBuffer += 1
+        currentFrameIndexInBuffer = currentFrameIndexInBuffer % animatedFrames.count
+        
         if animatedFrames.count < frameCount {
             preloadFrameAsynchronously(at: lastFrameIndex)
         }
-
-        if currentFrameIndex == 0 {
+        
+        currentFrameIndex += 1
+        
+        if currentFrameIndex == frameCount {
+            currentFrameIndex = 0
             currentRepeatCount += 1
 
             delegate?.animator(self, didPlayAnimationLoops: currentRepeatCount)

--- a/Sources/AnimatedImageView.swift
+++ b/Sources/AnimatedImageView.swift
@@ -380,7 +380,7 @@ class Animator {
         let frameToProcess = min(frameCount, maxFrameCount)
         animatedFrames.reserveCapacity(frameToProcess)
         animatedFrames = (0..<frameToProcess).reduce([]) { $0 + pure(prepareFrame(at: $1))}
-        currentPreloadIndex = (frameToProcess + 1) % frameCount
+        currentPreloadIndex = (frameToProcess + 1) % frameCount - 1
     }
     
     private func prepareFrame(at index: Int) -> AnimatedFrame {


### PR DESCRIPTION
Fixes #860

## What it does

Fixes two issues that occur when the image buffer holds less frames than exist in an animated image:

1. Incrementing the loop count would occur when the number of frames in the buffer were displayed, not when all frames in the animated image were displayed.
1. The first loop of the animated image would skip a frame.

## How to test

1. See the example project linked from #860. You can either open that project and change the Podfile to use `pod 'Kingfisher', :git => 'git@github.com:mliberatore/Kingfisher.git', :branch => 'fix-loop-counting'`, and run `pod install`, or you can download the already updated project here:
[KingfisherLooping.zip](https://github.com/onevcat/Kingfisher/files/1720525/KingfisherLooping.zip).
1. Run the updated project, tap the play button, and see that the gif stops playback when an entire loop has completed, and that no frames were skipped.
1. Tap the play button again and see that the entire gif plays again.
1. Adjust the `framePreloadCount` to other values to see that it still works when it is greater than or equal to the number of frames (`10`).

## Gif

This shows the updated project with the expected behavior:

![feb-13-2018 10-43-20](https://user-images.githubusercontent.com/7883805/36159128-fc881f38-10ab-11e8-9cd6-25c5c1396b52.gif)