### PR TITLE
Add swift_version to spec

### DIFF
--- a/Kingfisher.podspec
+++ b/Kingfisher.podspec
@@ -25,6 +25,8 @@ Pod::Spec.new do |s|
   s.authors            = { "onevcat" => "onevcat@gmail.com" }
   s.social_media_url   = "http://twitter.com/onevcat"
 
+  s.swift_version = "4.0"
+
   s.ios.deployment_target = "8.0"
   s.tvos.deployment_target = "9.0"
   s.osx.deployment_target = "10.10"

--- a/Kingfisher.podspec
+++ b/Kingfisher.podspec
@@ -52,6 +52,4 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.framework = "CFNetwork"
 
-  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.0' }
-
 end


### PR DESCRIPTION
* Specifies the swift version that will be used for the pod regardless of the swift version the app target uses.

Note: This feature was added on CocoaPods 1.4.0 (http://blog.cocoapods.org/CocoaPods-1.4.0/)