### PR TITLE
Add new method to ImageDownloaderDelegate - didFinishDownloadingImageForURL:with:error

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/ViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewController.swift
@@ -95,3 +95,15 @@ extension ViewController: UICollectionViewDataSourcePrefetching {
         ImagePrefetcher(urls: urls).start()
     }
 }
+
+
+// Inspired by: https://fdp.io/blog/2018/03/22/supporting-compactmap-in-swift-4/
+#if swift(>=4.1)
+    // This is provided by the stdlib
+#else
+    extension Sequence {
+        func compactMap<T>(_ transform: (Self.Element) throws -> T?) rethrows -> [T] {
+            return try flatMap(transform)
+        }
+    }
+#endif

--- a/Sources/ImageDownloader.swift
+++ b/Sources/ImageDownloader.swift
@@ -484,6 +484,12 @@ final class ImageDownloaderSessionHandler: NSObject, URLSessionDataDelegate, Aut
             let error = NSError(domain: KingfisherErrorDomain,
                                 code: KingfisherError.invalidStatusCode.rawValue,
                                 userInfo: [KingfisherErrorStatusCodeKey: statusCode, NSLocalizedDescriptionKey: HTTPURLResponse.localizedString(forStatusCode: statusCode)])
+            
+            // Needs to be called before callCompletionHandlerFailure() because it removes downloadHolder
+            if let downloader = downloadHolder {
+                downloader.delegate?.imageDownloader(downloader, didFinishDownloadingImageForURL: url, with: response, error: error)
+            }
+            
             callCompletionHandlerFailure(error: error, url: url)
         }
         


### PR DESCRIPTION
This allows using network activity indicator correctly. Fixes https://github.com/onevcat/Kingfisher/issues/605

I have been using this my fork for some time and thought it would be good idea to merge it back to the official repo.

Maybe the naming could be better. Any ideas?