### PR TITLE
`KingfisherDidCleanDiskCache` should be a constant

### DIFF
--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -30,7 +30,7 @@ import AppKit
 import UIKit
 #endif
 
-public extension Notification.Name {
+extension Notification.Name {
     /**
      This notification will be sent when the disk cache got cleaned either there are cached files expired or the total size exceeding the max allowed size. The manually invoking of `clearDiskCache` method will not trigger this notification.
      
@@ -40,7 +40,7 @@ public extension Notification.Name {
      
      The main purpose of this notification is supplying a chance to maintain some necessary information on the cached files. See [this wiki](https://github.com/onevcat/Kingfisher/wiki/How-to-implement-ETag-based-304-(Not-Modified)-handling-in-Kingfisher) for a use case on it.
      */
-    public static var KingfisherDidCleanDiskCache = Notification.Name.init("com.onevcat.Kingfisher.KingfisherDidCleanDiskCache")
+    public static let KingfisherDidCleanDiskCache = Notification.Name.init("com.onevcat.Kingfisher.KingfisherDidCleanDiskCache")
 }
 
 /**


### PR DESCRIPTION
I noticed that the `KingfisherDidCleanDiskCache` changed from constant to variable in the [migration](https://github.com/kukushi/Kingfisher/commit/b35af72) to Swift 3.

IMO, this may be an unintended modification, because any changes to `KingfisherDidCleanDiskCache`'s value may lead to unexpected behaviors.