### PR TITLE
Draw image > UIGraphicsBeginImageContextWithOptions > use scale 0

### DIFF
--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -935,7 +935,7 @@ extension Kingfisher where Base: Image {
         return outputImage
         #else
             
-        UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        UIGraphicsBeginImageContextWithOptions(size, false, 0)
         defer { UIGraphicsEndImageContext() }
         draw()
         return UIGraphicsGetImageFromCurrentImageContext() ?? base


### PR DESCRIPTION
According to [documentation](https://developer.apple.com/documentation/uikit/1623912-uigraphicsbeginimagecontextwitho), scale factor 0 would work correctly.

[Scale property of UIImage](https://developer.apple.com/documentation/uikit/uiimage/1624110-scale) is 1 by default unless we didn't set specific scale value or set filename as "imageName@2x.jpg". So it's not good for retina display devices.

Please let me know if is anything wrong. (pardon my english)