### PR TITLE
Replace  StringProxy with Kingfisher<Base>

### DIFF
--- a/Sources/String+MD5.swift
+++ b/Sources/String+MD5.swift
@@ -21,21 +21,9 @@ Permission is granted to anyone to use this software for any purpose,including c
 
 import Foundation
 
-public struct StringProxy {
-    fileprivate let base: String
-    init(proxy: String) {
-        base = proxy
-    }
-}
+extension String: KingfisherCompatible { }
 
-extension String: KingfisherCompatible {
-    public typealias CompatibleType = StringProxy
-    public var kf: CompatibleType {
-        return StringProxy(proxy: self)
-    }
-}
-
-extension StringProxy {
+extension Kingfisher where Base == String {
     var md5: String {
         if let data = base.data(using: .utf8, allowLossyConversion: true) {
 


### PR DESCRIPTION
Using Kingfisher<Base> as String proxy is a better way, like UIImageView, UIImage, etc.
```
extension String: KingfisherCompatible { }

extension Kingfisher where Base == String
```

@onevcat 