### PR TITLE
Add an activity indicator style

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/ViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewController.swift
@@ -81,7 +81,7 @@ extension ViewController {
     
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "collectionViewCell", for: indexPath) as! CollectionViewCell
-        cell.cellImageView.kf.indicatorType = .activity
+        cell.cellImageView.kf.indicatorType = .activity(style: .white)
         return cell
     }
 }

--- a/Demo/Demo/Kingfisher-macOS-Demo/ViewController.swift
+++ b/Demo/Demo/Kingfisher-macOS-Demo/ViewController.swift
@@ -57,7 +57,7 @@ extension ViewController: NSCollectionViewDataSource {
         
         let url = URL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher/master/images/kingfisher-\(indexPath.item + 1).jpg")!
         
-        item.imageView?.kf.indicatorType = .activity
+        item.imageView?.kf.indicatorType = .activity(style: .spinning)
         item.imageView?.kf.setImage(with: url, placeholder: nil, options: nil,
                                                    progressBlock: { receivedSize, totalSize in
                                                     print("\(indexPath.item + 1): \(receivedSize)/\(totalSize)")

--- a/Sources/ImageView+Kingfisher.swift
+++ b/Sources/ImageView+Kingfisher.swift
@@ -181,8 +181,8 @@ extension Kingfisher where Base: ImageView {
             switch newValue {
             case .none:
                 indicator = nil
-            case .activity:
-                indicator = ActivityIndicator()
+            case .activity(let style):
+                indicator = ActivityIndicator(style: style)
             case .image(let data):
                 indicator = ImageIndicator(imageData: data)
             case .custom(let anIndicator):

--- a/Sources/Indicator.swift
+++ b/Sources/Indicator.swift
@@ -32,15 +32,17 @@
 
 #if os(macOS)
     public typealias IndicatorView = NSView
+    public typealias ActivityIndicatorStyle = NSProgressIndicator.Style
 #else
     public typealias IndicatorView = UIView
+    public typealias ActivityIndicatorStyle = UIActivityIndicatorViewStyle
 #endif
 
 public enum IndicatorType {
     /// No indicator.
     case none
     /// Use system activity indicator.
-    case activity
+    case activity(style: ActivityIndicatorStyle)
     /// Use an image as indicator. GIF is supported.
     case image(imageData: Data)
     /// Use a custom indicator, which conforms to the `Indicator` protocol.
@@ -124,18 +126,13 @@ final class ActivityIndicator: Indicator {
         }
     }
 
-    init() {
+    init(style: ActivityIndicatorStyle) {
         #if os(macOS)
             activityIndicatorView = NSProgressIndicator(frame: CGRect(x: 0, y: 0, width: 16, height: 16))
             activityIndicatorView.controlSize = .small
-            activityIndicatorView.style = .spinning
+            activityIndicatorView.style = style
         #else
-            #if os(tvOS)
-                let indicatorStyle = UIActivityIndicatorViewStyle.white
-            #else
-                let indicatorStyle = UIActivityIndicatorViewStyle.gray
-            #endif
-            activityIndicatorView = UIActivityIndicatorView(activityIndicatorStyle:indicatorStyle)
+            activityIndicatorView = UIActivityIndicatorView(activityIndicatorStyle: style)
             activityIndicatorView.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin, .flexibleBottomMargin, .flexibleTopMargin]
         #endif
     }

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -357,7 +357,11 @@ class ImageViewExtensionTests: XCTestCase {
     }
     
     func testIndicatorViewExisting() {
-        imageView.kf.indicatorType = .activity(style: .white)
+        #if os(macOS)
+            imageView.kf.indicatorType = .activity(style: .spinning)
+        #else
+            imageView.kf.indicatorType = .activity(style: .white)
+        #endif
         XCTAssertNotNil(imageView.kf.indicator, "The indicator should exist when indicatorType is different than .none")
         XCTAssertTrue(imageView.kf.indicator is ActivityIndicator)
 
@@ -381,7 +385,11 @@ class ImageViewExtensionTests: XCTestCase {
     }
     
     func testActivityIndicatorViewAnimating() {
-        imageView.kf.indicatorType = .activity(style: .white)
+        #if os(macOS)
+            imageView.kf.indicatorType = .activity(style: .spinning)
+        #else
+            imageView.kf.indicatorType = .activity(style: .white)
+        #endif
         
         let expectation = self.expectation(description: "wait for downloading image")
         

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -357,7 +357,7 @@ class ImageViewExtensionTests: XCTestCase {
     }
     
     func testIndicatorViewExisting() {
-        imageView.kf.indicatorType = .activity
+        imageView.kf.indicatorType = .activity(style: .white)
         XCTAssertNotNil(imageView.kf.indicator, "The indicator should exist when indicatorType is different than .none")
         XCTAssertTrue(imageView.kf.indicator is ActivityIndicator)
 
@@ -381,7 +381,7 @@ class ImageViewExtensionTests: XCTestCase {
     }
     
     func testActivityIndicatorViewAnimating() {
-        imageView.kf.indicatorType = .activity
+        imageView.kf.indicatorType = .activity(style: .white)
         
         let expectation = self.expectation(description: "wait for downloading image")
         


### PR DESCRIPTION
Currently there is a default indicator style for each OS version. Since the indicator is not visible depending on the background color of the screen, I added the style item so that it can be decided by the user.