### PR TITLE
Replace class-only protocol keyword with AnyObject

### DIFF
--- a/Sources/AnimatedImageView.swift
+++ b/Sources/AnimatedImageView.swift
@@ -35,7 +35,7 @@ import UIKit
 import ImageIO
 
 /// Protocol of `AnimatedImageView`.
-public protocol AnimatedImageViewDelegate: class {
+public protocol AnimatedImageViewDelegate: AnyObject {
     /**
      Called after the animatedImageView has finished each animation loop.
 
@@ -289,7 +289,7 @@ struct AnimatedFrame {
     static let null: AnimatedFrame = AnimatedFrame(image: .none, duration: 0.0)
 }
 
-protocol AnimatorDelegate: class {
+protocol AnimatorDelegate: AnyObject {
     func animator(_ animator: Animator, didPlayAnimationLoops count: UInt)
 }
 

--- a/Sources/ImageDownloader.swift
+++ b/Sources/ImageDownloader.swift
@@ -97,7 +97,7 @@ public enum KingfisherError: Int {
 public let KingfisherErrorStatusCodeKey = "statusCode"
 
 /// Protocol of `ImageDownloader`.
-public protocol ImageDownloaderDelegate: class {
+public protocol ImageDownloaderDelegate: AnyObject {
     /**
      Called when the `ImageDownloader` object will start downloading an image from specified URL.
      
@@ -175,7 +175,7 @@ extension ImageDownloaderDelegate {
 }
 
 /// Protocol indicates that an authentication challenge could be handled.
-public protocol AuthenticationChallengeResponsable: class {
+public protocol AuthenticationChallengeResponsable: AnyObject {
     /**
      Called when an session level authentication challenge is received.
      This method provide a chance to handle and response to the authentication challenge before downloading could start.


### PR DESCRIPTION
`Swift3` has already changed the keyword of class-only protocol, let's change to `AnyObject` as well.
<img width="502" alt="image" src="https://user-images.githubusercontent.com/5061845/44396699-51accf00-a570-11e8-826b-a5e78b1a8f62.png">
