### PR TITLE
Add superview check when remove placeholder view

### DIFF
--- a/Sources/Placeholder.swift
+++ b/Sources/Placeholder.swift
@@ -77,6 +77,8 @@ extension Placeholder where Self: View {
 
     /// How the placeholder should be removed from a given image view.
     public func remove(from imageView: ImageView) {
-        self.removeFromSuperview()
+        if self.superview == imageView {
+            self.removeFromSuperview()
+        }
     }
 }


### PR DESCRIPTION
Only remove placeholder view from superview if superview equal to imageView, because maybe placeholder view's superview is not equal to imageView. 