### PR TITLE
Cleanup code

### DIFF
--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -1021,10 +1021,10 @@ extension RectCorner {
         
         var result: UIRectCorner = []
         
-        if self.contains(.topLeft) { result.insert(.topLeft) }
-        if self.contains(.topRight) { result.insert(.topRight) }
-        if self.contains(.bottomLeft) { result.insert(.bottomLeft) }
-        if self.contains(.bottomRight) { result.insert(.bottomRight) }
+        if contains(.topLeft) { result.insert(.topLeft) }
+        if contains(.topRight) { result.insert(.topRight) }
+        if contains(.bottomLeft) { result.insert(.bottomLeft) }
+        if contains(.bottomRight) { result.insert(.bottomRight) }
         
         return result
     }

--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -83,9 +83,9 @@ extension Kingfisher where Base: Image {
     }
     
     var size: CGSize {
-        return base.representations.reduce(CGSize.zero, { size, rep in
+        return base.representations.reduce(CGSize.zero) { size, rep in
             return CGSize(width: max(size.width, CGFloat(rep.pixelsWide)), height: max(size.height, CGFloat(rep.pixelsHigh)))
-        })
+        }
     }
     
     #else

--- a/Sources/ImageCache.swift
+++ b/Sources/ImageCache.swift
@@ -40,7 +40,7 @@ extension Notification.Name {
      
      The main purpose of this notification is supplying a chance to maintain some necessary information on the cached files. See [this wiki](https://github.com/onevcat/Kingfisher/wiki/How-to-implement-ETag-based-304-(Not-Modified)-handling-in-Kingfisher) for a use case on it.
      */
-    public static let KingfisherDidCleanDiskCache = Notification.Name.init("com.onevcat.Kingfisher.KingfisherDidCleanDiskCache")
+    public static let KingfisherDidCleanDiskCache = Notification.Name("com.onevcat.Kingfisher.KingfisherDidCleanDiskCache")
 }
 
 /**
@@ -84,7 +84,7 @@ open class ImageCache {
     /// memory warning notification is received.
     open var maxMemoryCost: UInt = 0 {
         didSet {
-            self.memoryCache.totalCostLimit = Int(maxMemoryCost)
+            memoryCache.totalCostLimit = Int(maxMemoryCost)
         }
     }
     
@@ -295,7 +295,7 @@ open class ImageCache {
         let options = options ?? KingfisherEmptyOptionsInfo
         let imageModifier = options.imageModifier
 
-        if let image = self.retrieveImageInMemoryCache(forKey: key, options: options) {
+        if let image = retrieveImageInMemoryCache(forKey: key, options: options) {
             options.callbackDispatchQueue.safeAsync {
                 completionHandler(imageModifier.modify(image), .memory)
             }
@@ -650,7 +650,7 @@ extension ImageCache {
     }
     
     func cacheFileName(forComputedKey key: String) -> String {
-        if let ext = self.pathExtension {
+        if let ext = pathExtension {
           return (key.kf.md5 as NSString).appendingPathExtension(ext)!
         }
         return key.kf.md5

--- a/Sources/ImageDownloader.swift
+++ b/Sources/ImageDownloader.swift
@@ -355,7 +355,7 @@ open class ImageDownloader {
         }
         
         var downloadTask: RetrieveImageDownloadTask?
-        setup(progressBlock: progressBlock, with: completionHandler, for: url, options: options) {(session, fetchLoad) -> Void in
+        setup(progressBlock: progressBlock, with: completionHandler, for: url, options: options) { session, fetchLoad in
             if fetchLoad.downloadTask == nil {
                 let dataTask = session.dataTask(with: request)
                 

--- a/Sources/ImageDownloader.swift
+++ b/Sources/ImageDownloader.swift
@@ -334,7 +334,7 @@ open class ImageDownloader {
             return nil
         }
         
-        let timeout = self.downloadTimeout == 0.0 ? 15.0 : self.downloadTimeout
+        let timeout = downloadTimeout == 0.0 ? 15.0 : downloadTimeout
         
         // We need to set the URL as the load key. So before setup progress, we need to ask the `requestModifier` for a final URL.
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: timeout)
@@ -418,7 +418,7 @@ extension ImageDownloader {
         
         func getFetchLoad(from task: RetrieveImageDownloadTask) -> ImageFetchLoad? {
             guard let URL = task.internalTask.originalRequest?.url,
-                  let imageFetchLoad = self.fetchLoads[URL] else
+                  let imageFetchLoad = fetchLoads[URL] else
             {
                 return nil
             }

--- a/Sources/ImagePrefetcher.swift
+++ b/Sources/ImagePrefetcher.swift
@@ -75,7 +75,7 @@ public class ImagePrefetcher {
     private let manager: KingfisherManager
     
     private var finished: Bool {
-        return failedResources.count + skippedResources.count + completedResources.count == prefetchResources.count && self.tasks.isEmpty
+        return failedResources.count + skippedResources.count + completedResources.count == prefetchResources.count && tasks.isEmpty
     }
     
     /**
@@ -137,10 +137,10 @@ public class ImagePrefetcher {
         // Add our own callback dispatch queue to make sure all callbacks are coming back in our expected queue
         optionsInfoWithoutQueue.append(.callbackDispatchQueue(prefetchQueue))
         
-        self.optionsInfo = optionsInfoWithoutQueue
+        optionsInfo = optionsInfoWithoutQueue
         
-        let cache = self.optionsInfo.targetCache ?? .default
-        let downloader = self.optionsInfo.downloader ?? .default
+        let cache = optionsInfo.targetCache ?? .default
+        let downloader = optionsInfo.downloader ?? .default
         manager = KingfisherManager(downloader: downloader, cache: cache)
         
         self.progressBlock = progressBlock

--- a/Sources/ImagePrefetcher.swift
+++ b/Sources/ImagePrefetcher.swift
@@ -197,7 +197,7 @@ public class ImagePrefetcher {
     
     func downloadAndCache(_ resource: Resource) {
 
-        let downloadTaskCompletionHandler: CompletionHandler = { (image, error, _, _) -> Void in
+        let downloadTaskCompletionHandler: CompletionHandler = { image, error, _, _ in
             self.tasks.removeValue(forKey: resource.downloadURL)
             if let _ = error {
                 self.failedResources.append(resource)

--- a/Sources/ImageProcessor.swift
+++ b/Sources/ImageProcessor.swift
@@ -211,7 +211,7 @@ public struct BlendImageProcessor: ImageProcessor {
         case .image(let image):
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.image(withBlendMode: blendMode, alpha: alpha, backgroundColor: backgroundColor)
-        case .data(_):
+        case .data:
             return (DefaultImageProcessor.default >> self).process(item: item, options: options)
         }
     }
@@ -269,7 +269,7 @@ public struct CompositingImageProcessor: ImageProcessor {
         case .image(let image):
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.image(withCompositingOperation: compositingOperation, alpha: alpha, backgroundColor: backgroundColor)
-        case .data(_):
+        case .data:
             return (DefaultImageProcessor.default >> self).process(item: item, options: options)
         }
     }
@@ -415,7 +415,7 @@ public struct ResizingImageProcessor: ImageProcessor {
         case .image(let image):
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.resize(to: referenceSize, for: targetContentMode)
-        case .data(_):
+        case .data:
             return (DefaultImageProcessor.default >> self).process(item: item, options: options)
         }
     }
@@ -454,7 +454,7 @@ public struct BlurImageProcessor: ImageProcessor {
             let radius = blurRadius * options.scaleFactor
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.blurred(withRadius: radius)
-        case .data(_):
+        case .data:
             return (DefaultImageProcessor.default >> self).process(item: item, options: options)
         }
     }
@@ -497,7 +497,7 @@ public struct OverlayImageProcessor: ImageProcessor {
         case .image(let image):
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.overlaying(with: overlay, fraction: fraction)
-        case .data(_):
+        case .data:
             return (DefaultImageProcessor.default >> self).process(item: item, options: options)
         }
     }
@@ -534,7 +534,7 @@ public struct TintImageProcessor: ImageProcessor {
         case .image(let image):
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.tinted(with: tint)
-        case .data(_):
+        case .data:
             return (DefaultImageProcessor.default >> self).process(item: item, options: options)
         }
     }
@@ -587,7 +587,7 @@ public struct ColorControlsProcessor: ImageProcessor {
         case .image(let image):
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.adjusted(brightness: brightness, contrast: contrast, saturation: saturation, inputEV: inputEV)
-        case .data(_):
+        case .data:
             return (DefaultImageProcessor.default >> self).process(item: item, options: options)
         }
     }
@@ -673,7 +673,7 @@ public struct CroppingImageProcessor: ImageProcessor {
         case .image(let image):
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.crop(to: size, anchorOn: anchor)
-        case .data(_): return (DefaultImageProcessor.default >> self).process(item: item, options: options)
+        case .data: return (DefaultImageProcessor.default >> self).process(item: item, options: options)
         }
     }
 }

--- a/Sources/ImageTransition.swift
+++ b/Sources/ImageTransition.swift
@@ -100,12 +100,12 @@ public enum ImageTransition {
     var animationOptions: UIView.AnimationOptions {
         switch self {
         case .none:                         return []
-        case .fade(_):                      return .transitionCrossDissolve
+        case .fade:                         return .transitionCrossDissolve
             
-        case .flipFromLeft(_):              return .transitionFlipFromLeft
-        case .flipFromRight(_):             return .transitionFlipFromRight
-        case .flipFromTop(_):               return .transitionFlipFromTop
-        case .flipFromBottom(_):            return .transitionFlipFromBottom
+        case .flipFromLeft:                 return .transitionFlipFromLeft
+        case .flipFromRight:                return .transitionFlipFromRight
+        case .flipFromTop:                  return .transitionFlipFromTop
+        case .flipFromBottom:               return .transitionFlipFromBottom
             
         case .custom(_, let options, _, _): return options
         }

--- a/Sources/Indicator.swift
+++ b/Sources/Indicator.swift
@@ -168,8 +168,8 @@ final class ImageIndicator: Indicator {
         
         #if os(macOS)
             // Need for gif to animate on macOS
-            self.animatedImageIndicatorView.imageScaling = .scaleNone
-            self.animatedImageIndicatorView.canDrawSubviewsIntoLayer = true
+            animatedImageIndicatorView.imageScaling = .scaleNone
+            animatedImageIndicatorView.canDrawSubviewsIntoLayer = true
         #else
             animatedImageIndicatorView.contentMode = .center
             animatedImageIndicatorView.autoresizingMask = [.flexibleLeftMargin,

--- a/Sources/KingfisherManager.swift
+++ b/Sources/KingfisherManager.swift
@@ -123,7 +123,7 @@ public class KingfisherManager {
         let task = RetrieveImageTask()
         let options = currentDefaultOptions + (options ?? KingfisherEmptyOptionsInfo)
         if options.forceRefresh {
-            _ = downloadAndCacheImage(
+            downloadAndCacheImage(
                 with: resource.downloadURL,
                 forKey: resource.cacheKey,
                 retrieveImageTask: task,
@@ -224,7 +224,7 @@ public class KingfisherManager {
                 diskTaskCompletionHandler(nil, error, .none, url)
                 return
             }
-            self.downloadAndCacheImage(
+            downloadAndCacheImage(
                 with: url,
                 forKey: key,
                 retrieveImageTask: retrieveImageTask,

--- a/Sources/KingfisherManager.swift
+++ b/Sources/KingfisherManager.swift
@@ -163,9 +163,9 @@ public class KingfisherManager {
                 if let error = error, error.code == KingfisherError.notModified.rawValue {
                     // Not modified. Try to find the image from cache.
                     // (The image should be in cache. It should be guaranteed by the framework users.)
-                    targetCache.retrieveImage(forKey: key, options: options, completionHandler: { (cacheImage, cacheType) -> Void in
+                    targetCache.retrieveImage(forKey: key, options: options) { cacheImage, cacheType in
                         completionHandler?(cacheImage, nil, cacheType, url)
-                    })
+                    }
                     return
                 }
                 
@@ -214,7 +214,7 @@ public class KingfisherManager {
                                         options: KingfisherOptionsInfo)
     {
 
-        let diskTaskCompletionHandler: CompletionHandler = { (image, error, cacheType, imageURL) -> Void in
+        let diskTaskCompletionHandler: CompletionHandler = { image, error, cacheType, imageURL in
             completionHandler?(image, error, cacheType, imageURL)
         }
         

--- a/Sources/KingfisherOptionsInfo.swift
+++ b/Sources/KingfisherOptionsInfo.swift
@@ -159,11 +159,11 @@ infix operator <== : ItemComparisonPrecedence
 // This operator returns true if two `KingfisherOptionsInfoItem` enum is the same, without considering the associated values.
 func <== (lhs: KingfisherOptionsInfoItem, rhs: KingfisherOptionsInfoItem) -> Bool {
     switch (lhs, rhs) {
-    case (.targetCache(_), .targetCache(_)): return true
-    case (.originalCache(_), .originalCache(_)): return true
-    case (.downloader(_), .downloader(_)): return true
-    case (.transition(_), .transition(_)): return true
-    case (.downloadPriority(_), .downloadPriority(_)): return true
+    case (.targetCache, .targetCache): return true
+    case (.originalCache, .originalCache): return true
+    case (.downloader, .downloader): return true
+    case (.transition, .transition): return true
+    case (.downloadPriority, .downloadPriority): return true
     case (.forceRefresh, .forceRefresh): return true
     case (.fromMemoryCacheOrRefresh, .fromMemoryCacheOrRefresh): return true
     case (.forceTransition, .forceTransition): return true
@@ -171,13 +171,13 @@ func <== (lhs: KingfisherOptionsInfoItem, rhs: KingfisherOptionsInfoItem) -> Boo
     case (.waitForCache, .waitForCache): return true
     case (.onlyFromCache, .onlyFromCache): return true
     case (.backgroundDecode, .backgroundDecode): return true
-    case (.callbackDispatchQueue(_), .callbackDispatchQueue(_)): return true
-    case (.scaleFactor(_), .scaleFactor(_)): return true
+    case (.callbackDispatchQueue, .callbackDispatchQueue): return true
+    case (.scaleFactor, .scaleFactor): return true
     case (.preloadAllAnimationData, .preloadAllAnimationData): return true
-    case (.requestModifier(_), .requestModifier(_)): return true
-    case (.processor(_), .processor(_)): return true
-    case (.cacheSerializer(_), .cacheSerializer(_)): return true
-    case (.imageModifier(_), .imageModifier(_)): return true
+    case (.requestModifier, .requestModifier): return true
+    case (.processor, .processor): return true
+    case (.cacheSerializer, .cacheSerializer): return true
+    case (.imageModifier, .imageModifier): return true
     case (.keepCurrentImageWhileLoading, .keepCurrentImageWhileLoading): return true
     case (.onlyLoadFirstFrame, .onlyLoadFirstFrame): return true
     case (.cacheOriginalImage, .cacheOriginalImage): return true

--- a/Sources/Placeholder.swift
+++ b/Sources/Placeholder.swift
@@ -66,7 +66,7 @@ extension Placeholder where Self: View {
     public func add(to imageView: ImageView) {
         imageView.addSubview(self)
 
-        self.translatesAutoresizingMaskIntoConstraints = false
+        translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             NSLayoutConstraint(item: self, attribute: .centerX, relatedBy: .equal, toItem: imageView, attribute: .centerX, multiplier: 1, constant: 0),
             NSLayoutConstraint(item: self, attribute: .centerY, relatedBy: .equal, toItem: imageView, attribute: .centerY, multiplier: 1, constant: 0),
@@ -77,6 +77,6 @@ extension Placeholder where Self: View {
 
     /// How the placeholder should be removed from a given image view.
     public func remove(from imageView: ImageView) {
-        self.removeFromSuperview()
+        removeFromSuperview()
     }
 }

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -94,13 +94,13 @@ class ImageCacheTests: XCTestCase {
     func testClearMemoryCache() {
         let expectation = self.expectation(description: "wait for retrieving image")
         
-        cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) { () -> Void in
+        cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) {
             self.cache.clearMemoryCache()
-            self.cache.retrieveImage(forKey: testKeys[0], options: nil, completionHandler: { (image, type) -> Void in
+            self.cache.retrieveImage(forKey: testKeys[0], options: nil) { image, type in
                 XCTAssert(image != nil && type == .disk, "Should be cached in disk. But \(type)")
 
                 expectation.fulfill()
-            })
+            }
         }
         
         waitForExpectations(timeout: 5, handler: nil)
@@ -110,10 +110,10 @@ class ImageCacheTests: XCTestCase {
         let expectation = self.expectation(description: "wait for retrieving image")
         
         cache.clearDiskCache {
-            self.cache.retrieveImage(forKey: testKeys[0], options: nil, completionHandler: { (image, type) -> Void in
+            self.cache.retrieveImage(forKey: testKeys[0], options: nil) { image, type in
                 XCTAssert(image == nil, "Should not be cached in memory yet")
                 expectation.fulfill()
-            })
+            }
             return
         }
         
@@ -123,11 +123,11 @@ class ImageCacheTests: XCTestCase {
     func testStoreImageInMemory() {
         let expectation = self.expectation(description: "wait for retrieving image")
         
-        cache.store(testImage, forKey: testKeys[0], toDisk: false) { () -> Void in
-            self.cache.retrieveImage(forKey: testKeys[0], options: nil, completionHandler: { (image, type) -> Void in
+        cache.store(testImage, forKey: testKeys[0], toDisk: false) {
+            self.cache.retrieveImage(forKey: testKeys[0], options: nil) { image, type in
                 XCTAssert(image != nil && type == .memory, "Should be cached in memory.")
                 expectation.fulfill()
-            })
+            }
             return
         }
         
@@ -137,7 +137,7 @@ class ImageCacheTests: XCTestCase {
     func testStoreMultipleImages() {
         let expectation = self.expectation(description: "wait for writing image")
         
-        storeMultipleImages { () -> Void in
+        storeMultipleImages {
             let diskCachePath = self.cache.diskCachePath
             let files: [String]?
             do {
@@ -162,13 +162,13 @@ class ImageCacheTests: XCTestCase {
         let exists = cache.imageCachedType(forKey: url.cacheKey).cached
         XCTAssertFalse(exists)
         
-        cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
+        cache.retrieveImage(forKey: URLString, options: nil) { image, type in
             XCTAssertNil(image, "Should not be cached yet")
             
             XCTAssertEqual(type, .none)
 
-            self.cache.store(testImage, forKey: URLString, toDisk: true) { () -> Void in
-                self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
+            self.cache.store(testImage, forKey: URLString, toDisk: true) {
+                self.cache.retrieveImage(forKey: URLString, options: nil) { image, type in
                     XCTAssertNotNil(image, "Should be cached (memory or disk)")
                     XCTAssertEqual(type, .memory)
 
@@ -176,7 +176,7 @@ class ImageCacheTests: XCTestCase {
                     XCTAssertTrue(exists, "Image should exist in the cache (memory or disk)")
 
                     self.cache.clearMemoryCache()
-                    self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
+                    self.cache.retrieveImage(forKey: URLString, options: nil) { image, type in
                         XCTAssertNotNil(image, "Should be cached (disk)")
                         XCTAssertEqual(type, CacheType.disk)
                         
@@ -184,10 +184,10 @@ class ImageCacheTests: XCTestCase {
                         XCTAssertTrue(exists, "Image should exist in the cache (disk)")
                         
                         expectation.fulfill()
-                    })
-                })
+                    }
+                }
             }
-        })
+        }
         
         waitForExpectations(timeout: 5, handler: nil)
     }
@@ -210,13 +210,13 @@ class ImageCacheTests: XCTestCase {
         let exists = cache.imageCachedType(forKey: url.cacheKey).cached
         XCTAssertFalse(exists)
         
-        cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
+        cache.retrieveImage(forKey: URLString, options: nil) { image, type in
             XCTAssertNil(image, "Should not be cached yet")
             
             XCTAssertEqual(type, .none)
             
-            self.cache.store(testImage, forKey: URLString, toDisk: true) { () -> Void in
-                self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
+            self.cache.store(testImage, forKey: URLString, toDisk: true) {
+                self.cache.retrieveImage(forKey: URLString, options: nil) { image, type in
                     XCTAssertNotNil(image, "Should be cached (memory or disk)")
                     XCTAssertEqual(type, .memory)
                     
@@ -224,7 +224,7 @@ class ImageCacheTests: XCTestCase {
                     XCTAssertTrue(exists, "Image should exist in the cache (memory or disk)")
                     
                     self.cache.clearMemoryCache()
-                    self.cache.retrieveImage(forKey: URLString, options: nil, completionHandler: { (image, type) -> Void in
+                    self.cache.retrieveImage(forKey: URLString, options: nil) { image, type in
                         XCTAssertNotNil(image, "Should be cached (disk)")
                         XCTAssertEqual(type, CacheType.disk)
                         
@@ -236,23 +236,23 @@ class ImageCacheTests: XCTestCase {
                         XCTAssert(hasExtension, "Should have .jpg file extension")
                         
                         expectation.fulfill()
-                    })
-                })
+                    }
+                }
             }
-        })
+        }
         
         waitForExpectations(timeout: 5, handler: nil)
     }
 
   
     func testCachedImageIsFetchedSyncronouslyFromTheMemoryCache() {
-        cache.store(testImage, forKey: testKeys[0], toDisk: false) { () -> Void in
+        cache.store(testImage, forKey: testKeys[0], toDisk: false) {
             // do nothing
         }
 
         var foundImage: Image?
 
-        cache.retrieveImage(forKey: testKeys[0], options: [.backgroundDecode]) { (image, type) -> Void in
+        cache.retrieveImage(forKey: testKeys[0], options: [.backgroundDecode]) { image, type in
             foundImage = image
         }
 
@@ -263,7 +263,7 @@ class ImageCacheTests: XCTestCase {
         let expectation = self.expectation(description: "wait for caching image")
         
         XCTAssert(self.cache.imageCachedType(forKey: testKeys[0]).cached == false, "This image should not be cached yet.")
-        self.cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) { () -> Void in
+        self.cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) {
             XCTAssert(self.cache.imageCachedType(forKey: testKeys[0]).cached == true, "This image should be already cached.")
             expectation.fulfill()
         }
@@ -274,12 +274,12 @@ class ImageCacheTests: XCTestCase {
     func testRetrievingImagePerformance() {
 
         let expectation = self.expectation(description: "wait for retrieving image")
-        self.cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) { () -> Void in
-            self.measure({ () -> Void in
+        self.cache.store(testImage, original: testImageData as Data, forKey: testKeys[0], toDisk: true) {
+            self.measure {
                 for _ in 1 ..< 200 {
                     _ = self.cache.retrieveImageInDiskCache(forKey: testKeys[0])
                 }
-            })
+            }
             expectation.fulfill()
         }
         
@@ -289,9 +289,9 @@ class ImageCacheTests: XCTestCase {
     func testCleanDiskCacheNotification() {
         let expectation = self.expectation(description: "wait for retrieving image")
         
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) { () -> Void in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) {
 
-            self.observer = NotificationCenter.default.addObserver(forName: .KingfisherDidCleanDiskCache, object: self.cache, queue: OperationQueue.main, using: { (noti) -> Void in
+            self.observer = NotificationCenter.default.addObserver(forName: .KingfisherDidCleanDiskCache, object: self.cache, queue: OperationQueue.main) { noti in
 
                 let receivedCache = noti.object as? ImageCache
                 XCTAssertNotNil(receivedCache)
@@ -308,7 +308,7 @@ class ImageCacheTests: XCTestCase {
                 
                 NotificationCenter.default.removeObserver(self.observer)
                 expectation.fulfill()
-            })
+            }
             
             self.cache.maxCachePeriodInSecond = 0
             self.cache.cleanExpiredDiskCache()
@@ -321,14 +321,14 @@ class ImageCacheTests: XCTestCase {
         let expectation = self.expectation(description: "wait for retrieving image")
         let p = RoundCornerImageProcessor(cornerRadius: 40)
         
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) { () -> Void in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) {
             
-            self.cache.retrieveImage(forKey: testKeys[0], options: [.processor(p)], completionHandler: { (image, type) -> Void in
+            self.cache.retrieveImage(forKey: testKeys[0], options: [.processor(p)]) { image, type in
                 
                 XCTAssert(image == nil, "The image with prosossor should not be cached yet.")
                 
                 expectation.fulfill()
-            })
+            }
         }
         
         waitForExpectations(timeout: 5, handler: nil)
@@ -338,14 +338,14 @@ class ImageCacheTests: XCTestCase {
         let expectation = self.expectation(description: "wait for retrieving image")
         let p = RoundCornerImageProcessor(cornerRadius: 40)
         
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], processorIdentifier: p.identifier,toDisk: true) { () -> Void in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], processorIdentifier: p.identifier,toDisk: true) {
             
-            self.cache.retrieveImage(forKey: testKeys[0], options: [.processor(p)], completionHandler: { (image, type) -> Void in
+            self.cache.retrieveImage(forKey: testKeys[0], options: [.processor(p)]) { image, type in
                 
                 XCTAssert(image != nil, "The image with prosossor should already be cached.")
                 
                 expectation.fulfill()
-            })
+            }
         }
         
         waitForExpectations(timeout: 5, handler: nil)
@@ -401,19 +401,19 @@ class ImageCacheTests: XCTestCase {
         let group = DispatchGroup()
         
         group.enter()
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) { () -> Void in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[0], toDisk: true) {
             group.leave()
         }
         group.enter()
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[1], toDisk: true) { () -> Void in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[1], toDisk: true) {
             group.leave()
         }
         group.enter()
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[2], toDisk: true) { () -> Void in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[2], toDisk: true) {
             group.leave()
         }
         group.enter()
-        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[3], toDisk: true) { () -> Void in
+        cache.store(testImage, original: testImageData as Data?, forKey: testKeys[3], toDisk: true) {
             group.leave()
         }
         

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -64,9 +64,9 @@ class ImageDownloaderTests: XCTestCase {
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
 
         let url = URL(string: URLString)!
-        downloader.downloadImage(with: url, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        downloader.downloadImage(with: url, options: nil, progressBlock: { receivedSize, totalSize in
             return
-        }) { (image, error, imageURL, data) -> Void in
+        }) { image, error, imageURL, data in
             expectation.fulfill()
             XCTAssert(image != nil, "Download should be able to finished for URL: \(String(describing: imageURL))")
         }
@@ -83,9 +83,9 @@ class ImageDownloaderTests: XCTestCase {
             if let url = URL(string: URLString) {
                 group.enter()
                 _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
-                downloader.downloadImage(with: url, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+                downloader.downloadImage(with: url, options: nil, progressBlock: { receivedSize, totalSize in
                     
-                }, completionHandler: { (image, error, imageURL, data) -> Void in
+                }, completionHandler: { image, error, imageURL, data in
                     XCTAssert(image != nil, "Download should be able to finished for URL: \(String(describing: imageURL)).")
                     group.leave()
                 })
@@ -105,9 +105,9 @@ class ImageDownloaderTests: XCTestCase {
 
         for _ in 0...5 {
             group.enter()
-            downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+            downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { receivedSize, totalSize in
                 
-                }) { (image, error, imageURL, data) -> Void in
+                }) { image, error, imageURL, data in
                     XCTAssert(image != nil, "Download should be able to finished for URL: \(String(describing: imageURL)).")
                     group.leave()
                     
@@ -127,9 +127,9 @@ class ImageDownloaderTests: XCTestCase {
         modifier.url = URL(string: URLString)
         
         let someURL = URL(string: "some_strange_url")!
-        downloader.downloadImage(with: someURL, options: [.requestModifier(modifier)], progressBlock: { (receivedSize, totalSize) -> Void in
+        downloader.downloadImage(with: someURL, options: [.requestModifier(modifier)], progressBlock: { receivedSize, totalSize in
             
-        }) { (image, error, imageURL, data) -> Void in
+        }) { image, error, imageURL, data in
             XCTAssert(image != nil, "Download should be able to finished for URL: \(String(describing: imageURL)).")
             XCTAssertEqual(imageURL!, URL(string: URLString)!, "The returned imageURL should be the replaced one")
             expectation.fulfill()
@@ -143,9 +143,9 @@ class ImageDownloaderTests: XCTestCase {
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(304)
         
-        downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { receivedSize, totalSize in
             
-        }) { (image, error, imageURL, data) -> Void in
+        }) { image, error, imageURL, data in
             XCTAssertNotNil(error, "There should be an error since server returning 304 and no image downloaded.")
             XCTAssertEqual(error!.code, KingfisherError.notModified.rawValue, "The error should be NotModified.")
             expectation.fulfill()
@@ -159,9 +159,9 @@ class ImageDownloaderTests: XCTestCase {
         let URLString = testKeys[0]
         _ = stubRequest("GET", URLString).andReturn(404)?.withBody(testImageData)
         
-        downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        downloader.downloadImage(with: URL(string: URLString)!, options: nil, progressBlock: { receivedSize, totalSize in
             
-        }) { (image, error, imageURL, data) -> Void in
+        }) { image, error, imageURL, data in
             XCTAssertNotNil(error, "There should be an error since server returning 404")
             XCTAssertEqual(error!.code, KingfisherError.invalidStatusCode.rawValue, "The error should be InvalidStatusCode.")
             XCTAssertEqual(error!.userInfo["statusCode"]! as? Int, 404, "The error should be InvalidStatusCode.")
@@ -181,7 +181,7 @@ class ImageDownloaderTests: XCTestCase {
         
         let expectation = self.expectation(description: "wait for download from an invalid ssl site.")
         
-        downloader.downloadImage(with: url, progressBlock: nil, completionHandler: { (image, error, imageURL, data) -> Void in
+        downloader.downloadImage(with: url, progressBlock: nil, completionHandler: { image, error, imageURL, data in
             XCTAssertNotNil(error, "Error should not be nil")
             XCTAssert(error?.code == NSURLErrorServerCertificateUntrusted || error?.code == NSURLErrorSecureConnectionFailed, "Error should be NSURLErrorServerCertificateUntrusted, but \(String(describing: error))")
             expectation.fulfill()
@@ -202,14 +202,14 @@ class ImageDownloaderTests: XCTestCase {
         stubRequest("GET", URLString).andFailWithError(NSError(domain: "stubError", code: -1, userInfo: nil))
         let url = URL(string: URLString)!
         
-        downloader.downloadImage(with: url, progressBlock: nil) { (image, error, imageURL, data) -> Void in
+        downloader.downloadImage(with: url, progressBlock: nil) { image, error, imageURL, data in
             XCTAssertNotNil(error, "Should return with an error")
             
             LSNocilla.sharedInstance().clearStubs()
             _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
             
             // Retry the download
-            self.downloader.downloadImage(with: url, progressBlock: nil, completionHandler: { (image, error, imageURL, data) -> Void in
+            self.downloader.downloadImage(with: url, progressBlock: nil, completionHandler: { image, error, imageURL, data in
                 XCTAssertNil(error, "Download should be finished without error")
                 expectation.fulfill()
             })
@@ -224,9 +224,9 @@ class ImageDownloaderTests: XCTestCase {
         modifier.url = nil
         
         let url = URL(string: "http://onevcat.com")
-        downloader.downloadImage(with: url!, options: [.requestModifier(modifier)], progressBlock: { (receivedSize, totalSize) -> Void in
+        downloader.downloadImage(with: url!, options: [.requestModifier(modifier)], progressBlock: { receivedSize, totalSize in
             XCTFail("The progress block should not be called.")
-            }) { (image, error, imageURL, originalData) -> Void in
+            }) { image, error, imageURL, originalData in
                 XCTAssertNotNil(error, "An error should happen for empty URL")
                 XCTAssertEqual(error!.code, KingfisherError.invalidURL.rawValue)
                 self.downloader.delegate = nil
@@ -236,9 +236,9 @@ class ImageDownloaderTests: XCTestCase {
     }
     
     func testDownloadTaskProperty() {
-        let task = downloader.downloadImage(with: URL(string: "1234")!, progressBlock: { (receivedSize, totalSize) -> Void in
+        let task = downloader.downloadImage(with: URL(string: "1234")!, progressBlock: { receivedSize, totalSize in
 
-            }) { (image, error, imageURL, originalData) -> Void in
+            }) { image, error, imageURL, originalData in
         }
         
         XCTAssertNotNil(task, "The task should exist.")
@@ -256,9 +256,9 @@ class ImageDownloaderTests: XCTestCase {
         
         var progressBlockIsCalled = false
         
-        let downloadTask = downloader.downloadImage(with: url, progressBlock: { (receivedSize, totalSize) -> Void in
+        let downloadTask = downloader.downloadImage(with: url, progressBlock: { receivedSize, totalSize in
                 progressBlockIsCalled = true
-            }) { (image, error, imageURL, originalData) -> Void in
+            }) { image, error, imageURL, originalData in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error!.code, NSURLErrorCancelled)
                 XCTAssert(progressBlockIsCalled == false, "ProgressBlock should not be called since it is canceled.")
@@ -329,9 +329,9 @@ class ImageDownloaderTests: XCTestCase {
         let group = DispatchGroup()
         
         group.enter()
-        let downloadTask = downloader.downloadImage(with: url, progressBlock: { (receivedSize, totalSize) -> Void in
+        let downloadTask = downloader.downloadImage(with: url, progressBlock: { receivedSize, totalSize in
             progressBlockIsCalled = true
-        }) { (image, error, imageURL, originalData) -> Void in
+        }) { image, error, imageURL, originalData in
             XCTAssertNotNil(error)
             XCTAssertEqual(error!.code, NSURLErrorCancelled)
             XCTAssert(progressBlockIsCalled == false, "ProgressBlock should not be called since it is canceled.")
@@ -344,9 +344,9 @@ class ImageDownloaderTests: XCTestCase {
         _ = stub!.go()
         
         group.enter()
-        downloader.downloadImage(with: url, progressBlock: { (receivedSize, totalSize) -> Void in
+        downloader.downloadImage(with: url, progressBlock: { receivedSize, totalSize in
             progressBlockIsCalled = true
-        }) { (image, error, imageURL, originalData) -> Void in
+        }) { image, error, imageURL, originalData in
             XCTAssertNotNil(image)
             group.leave()
         }
@@ -374,9 +374,9 @@ class ImageDownloaderTests: XCTestCase {
         let p = RoundCornerImageProcessor(cornerRadius: 40)
         let roundcornered = testImage.kf.image(withRoundRadius: 40, fit: testImage.kf.size)
         
-        downloader.downloadImage(with: url, options: [.processor(p)], progressBlock: { (receivedSize, totalSize) -> Void in
+        downloader.downloadImage(with: url, options: [.processor(p)], progressBlock: { receivedSize, totalSize in
             
-        }) { (image, error, imageURL, data) -> Void in
+        }) { image, error, imageURL, data in
             expectation.fulfill()
             XCTAssert(image != nil, "Download should be able to finished for URL: \(String(describing: imageURL))")
             XCTAssertFalse(image!.renderEqual(to: testImage), "The processed image should not equal to the original one.")
@@ -403,18 +403,18 @@ class ImageDownloaderTests: XCTestCase {
         
         var count = 0
         
-        downloader.downloadImage(with: url, options: [.processor(p1)], progressBlock: { (receivedSize, totalSize) -> Void in
+        downloader.downloadImage(with: url, options: [.processor(p1)], progressBlock: { receivedSize, totalSize in
 
-        }) { (image, error, imageURL, data) -> Void in
+        }) { image, error, imageURL, data in
             XCTAssertTrue(image!.renderEqual(to: roundcornered), "The processed image should equal to the one directly processed from original one.")
             
             count += 1
             if count == 2 { expectation.fulfill() }
         }
         
-        downloader.downloadImage(with: url, options: [.processor(p2)], progressBlock: { (receivedSize, totalSize) -> Void in
+        downloader.downloadImage(with: url, options: [.processor(p2)], progressBlock: { receivedSize, totalSize in
             
-        }) { (image, error, imageURL, data) -> Void in
+        }) { image, error, imageURL, data in
             XCTAssertTrue(image!.renderEqual(to: blurred), "The processed image should equal to the one directly processed from original one.")
             
             count += 1

--- a/Tests/KingfisherTests/ImagePrefetcherTests.swift
+++ b/Tests/KingfisherTests/ImagePrefetcherTests.swift
@@ -68,10 +68,10 @@ class ImagePrefetcherTests: XCTestCase {
         
         var progressCalledCount = 0
         let prefetcher = ImagePrefetcher(urls: urls, options: nil,
-                            progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
+                            progressBlock: { skippedResources, failedResources, completedResources in
                                 progressCalledCount += 1
                             },
-                            completionHandler: {(skippedResources, failedResources, completedResources) -> Void in
+                            completionHandler: { skippedResources, failedResources, completedResources in
                                 expectation.fulfill()
                                 XCTAssertEqual(skippedResources.count, 0, "There should be no items skipped.")
                                 XCTAssertEqual(failedResources.count, 0, "There should be no failed downloading.")
@@ -99,9 +99,9 @@ class ImagePrefetcherTests: XCTestCase {
         
         let maxConcurrentCount = 2
         let prefetcher = ImagePrefetcher(urls: urls, options: nil,
-                            progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
+                            progressBlock: { skippedResources, failedResources, completedResources in
                             },
-                            completionHandler: {(skippedResources, failedResources, completedResources) -> Void in
+                            completionHandler: { skippedResources, failedResources, completedResources in
                                 XCTAssertEqual(skippedResources.count, 0, "There should be no items skipped.")
                                 XCTAssertEqual(failedResources.count, urls.count, "The failed count should be the same with started downloads due to cancellation.")
                                 XCTAssertEqual(completedResources.count, 0, "None resources prefetching should complete.")
@@ -128,9 +128,9 @@ class ImagePrefetcherTests: XCTestCase {
             urls.append(URL(string: URLString)!)
         }
         
-        let prefetcher = ImagePrefetcher(urls: urls, options: nil, progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
+        let prefetcher = ImagePrefetcher(urls: urls, options: nil, progressBlock: { skippedResources, failedResources, completedResources in
 
-            }) { (skippedResources, failedResources, completedResources) -> Void in
+            }) { skippedResources, failedResources, completedResources in
                 expectation.fulfill()
                 XCTAssertEqual(skippedResources.count, 1, "There should be 1 item skipped.")
                 XCTAssertEqual(skippedResources[0].downloadURL.absoluteString, testKeys[0], "The correct image key should be skipped.")
@@ -157,9 +157,9 @@ class ImagePrefetcherTests: XCTestCase {
         }
         
         // Use `.ForceRefresh` to download it forcely.
-        let prefetcher = ImagePrefetcher(urls: urls, options: [.forceRefresh], progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
+        let prefetcher = ImagePrefetcher(urls: urls, options: [.forceRefresh], progressBlock: { skippedResources, failedResources, completedResources in
             
-            }) { (skippedResources, failedResources, completedResources) -> Void in
+            }) { skippedResources, failedResources, completedResources in
                 expectation.fulfill()
                 
                 XCTAssertEqual(skippedResources.count, 0, "There should be no item skipped.")
@@ -174,7 +174,7 @@ class ImagePrefetcherTests: XCTestCase {
     
     func testPrefetchWithWrongInitParameters() {
         let expectation = self.expectation(description: "wait for prefetching images")
-        let prefetcher = ImagePrefetcher(urls: [], options: nil, progressBlock: nil) { (skippedResources, failedResources, completedResources) -> Void in
+        let prefetcher = ImagePrefetcher(urls: [], options: nil, progressBlock: nil) { skippedResources, failedResources, completedResources in
             expectation.fulfill()
             
             XCTAssertEqual(skippedResources.count, 0, "There should be no item skipped.")
@@ -200,10 +200,10 @@ class ImagePrefetcherTests: XCTestCase {
         func prefetchAgain() {
             var progressCalledCount = 0
             let prefetcher = ImagePrefetcher(urls: urls, options: [.processor(p)],
-                                             progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
+                                             progressBlock: { skippedResources, failedResources, completedResources in
                                                 progressCalledCount += 1
             },
-                                             completionHandler: {(skippedResources, failedResources, completedResources) -> Void in
+                                             completionHandler: { skippedResources, failedResources, completedResources in
                                                 
                                                 XCTAssertEqual(skippedResources.count, urls.count, "There should be one item skipped since it is just prefetched.")
                                                 XCTAssertEqual(failedResources.count, 0, "There should be no failed downloading.")
@@ -221,10 +221,10 @@ class ImagePrefetcherTests: XCTestCase {
         
         var progressCalledCount = 0
         let prefetcher = ImagePrefetcher(urls: urls, options: [.processor(p)],
-                                         progressBlock: { (skippedResources, failedResources, completedResources) -> Void in
+                                         progressBlock: { skippedResources, failedResources, completedResources in
                                             progressCalledCount += 1
         },
-                                         completionHandler: {(skippedResources, failedResources, completedResources) -> Void in
+                                         completionHandler: { skippedResources, failedResources, completedResources in
                                             
                                             XCTAssertEqual(skippedResources.count, 0, "There should be no items skipped.")
                                             XCTAssertEqual(failedResources.count, 0, "There should be no failed downloading.")

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -68,10 +68,10 @@ class ImageViewExtensionTests: XCTestCase {
         
         var progressBlockIsCalled = false
         
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             progressBlockIsCalled = true
             XCTAssertTrue(Thread.isMainThread)
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             expectation.fulfill()
             
             XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
@@ -95,9 +95,9 @@ class ImageViewExtensionTests: XCTestCase {
         let url = URL(string: URLString)!
         
         let customQueue = DispatchQueue(label: "com.kingfisher.testQueue")
-        imageView.kf.setImage(with: url, placeholder: nil, options: [.callbackDispatchQueue(customQueue)], progressBlock: { (receivedSize, totalSize) -> Void in
+        imageView.kf.setImage(with: url, placeholder: nil, options: [.callbackDispatchQueue(customQueue)], progressBlock: { receivedSize, totalSize in
             XCTAssertTrue(Thread.isMainThread)
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             XCTAssertTrue(Thread.isMainThread, "The image extension callback should be always in main queue.")
             expectation.fulfill()
         }
@@ -117,9 +117,9 @@ class ImageViewExtensionTests: XCTestCase {
         
         cleanDefaultCache()
         
-        _ = imageView.kf.setImage(with: resource, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        _ = imageView.kf.setImage(with: resource, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             progressBlockIsCalled = true
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 expectation.fulfill()
                 
                 XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
@@ -143,9 +143,9 @@ class ImageViewExtensionTests: XCTestCase {
         
         var progressBlockIsCalled = false
 
-        let task = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        let task = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             progressBlockIsCalled = true
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURLin in
             XCTAssertEqual(error?.code, KingfisherError.downloadCancelledBeforeStarting.rawValue, "The error should be downloadCancelledBeforeStarting")
             XCTAssert(progressBlockIsCalled == false, "ProgressBlock should not be called since it is canceled.")
             expectation.fulfill()
@@ -166,9 +166,9 @@ class ImageViewExtensionTests: XCTestCase {
         
         cleanDefaultCache()
         
-        let task = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        let task = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             progressBlockIsCalled = true
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error?.code, NSURLErrorCancelled)
                 XCTAssert(progressBlockIsCalled == false, "ProgressBlock should not be called since it is canceled.")
@@ -193,26 +193,26 @@ class ImageViewExtensionTests: XCTestCase {
         let group = DispatchGroup()
         
         group.enter()
-        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
 
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 XCTAssertNil(image)
                 XCTAssertEqual(error?.code, KingfisherError.downloadCancelledBeforeStarting.rawValue, "The error should be downloadCancelledBeforeStarting")
                 group.leave()
         }
         
         group.enter()
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 XCTAssertNotNil(image)
                 group.leave()
         }
         
         group.enter()
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 XCTAssertNotNil(image)
                 group.leave()
         }
@@ -234,25 +234,25 @@ class ImageViewExtensionTests: XCTestCase {
         let group = DispatchGroup()
         
         group.enter()
-        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 XCTAssertNotNil(image)
                 group.leave()
         }
         
         group.enter()
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 XCTAssertNotNil(image)
                 group.leave()
         }
         
         group.enter()
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 XCTAssertNotNil(image)
                 group.leave()
         }
@@ -277,27 +277,27 @@ class ImageViewExtensionTests: XCTestCase {
         let group = DispatchGroup()
         
         group.enter()
-        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        let task1 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error?.code, NSURLErrorCancelled)
                 group.leave()
         }
         
         group.enter()
-        let task2 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        let task2 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error?.code, NSURLErrorCancelled)
                 group.leave()
         }
         
         group.enter()
-        let task3 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        let task3 = imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 XCTAssertNotNil(error)
                 XCTAssertEqual(error?.code, NSURLErrorCancelled)
                 group.leave()
@@ -328,17 +328,17 @@ class ImageViewExtensionTests: XCTestCase {
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
         let url = URL(string: URLString)!
         
-        imageView.kf.setImage(with: url, placeholder: nil, options: [.targetCache(cache1)], progressBlock: { (receivedSize, totalSize) -> Void in
+        imageView.kf.setImage(with: url, placeholder: nil, options: [.targetCache(cache1)], progressBlock: { receivedSize, totalSize in
             
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             
             XCTAssertTrue(cache1.imageCachedType(forKey: URLString).cached, "This image should be cached in cache1.")
             XCTAssertFalse(cache2.imageCachedType(forKey: URLString).cached, "This image should not be cached in cache2.")
             XCTAssertFalse(KingfisherManager.shared.cache.imageCachedType(forKey: URLString).cached, "This image should not be cached in default cache.")
             
-            self.imageView.kf.setImage(with: url, placeholder: nil, options: [.targetCache(cache2)], progressBlock: { (receivedSize, totalSize) -> Void in
+            self.imageView.kf.setImage(with: url, placeholder: nil, options: [.targetCache(cache2)], progressBlock: { receivedSize, totalSize in
                 
-            }, completionHandler: { (image, error, cacheType, imageURL) -> Void in
+            }, completionHandler: { image, error, cacheType, imageURL in
                 
                 XCTAssertTrue(cache1.imageCachedType(forKey: URLString).cached, "This image should be cached in cache1.")
                 XCTAssertTrue(cache2.imageCachedType(forKey: URLString).cached, "This image should be cached in cache2.")
@@ -351,9 +351,9 @@ class ImageViewExtensionTests: XCTestCase {
             
         }
         
-        waitForExpectations(timeout: 5, handler: { (error) -> Void in
+        waitForExpectations(timeout: 5) { error in
             clearCaches([cache1, cache2])
-        })
+        }
     }
     
     func testIndicatorViewExisting() {
@@ -389,13 +389,13 @@ class ImageViewExtensionTests: XCTestCase {
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
         let url = URL(string: URLString)!
         
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             
             let indicator = self.imageView.kf.indicator
             XCTAssertNotNil(indicator, "The indicator view should exist when showIndicatorWhenLoading is true")
             XCTAssertFalse(indicator!.view.isHidden, "The indicator should be shown and animating when loading")
 
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             let indicator = self.imageView.kf.indicator
             XCTAssertTrue(indicator!.view.isHidden, "The indicator should stop and hidden after loading")
             expectation.fulfill()
@@ -418,13 +418,13 @@ class ImageViewExtensionTests: XCTestCase {
         _ = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)
         let url = URL(string: URLString)!
         
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             
             let indicator = self.imageView.kf.indicator
             XCTAssertNotNil(indicator, "The indicator view should exist when showIndicatorWhenLoading is true")
             XCTAssertFalse(indicator!.view.isHidden, "The indicator should be shown and animating when loading")
             
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             let indicator = self.imageView.kf.indicator
             XCTAssertTrue(indicator!.view.isHidden, "The indicator should stop and hidden after loading")
             expectation.fulfill()
@@ -440,13 +440,12 @@ class ImageViewExtensionTests: XCTestCase {
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
         let url = URL(string: URLString)!
         
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
-                XCTFail("Progress block should not be called.")
-            }) { (image, error, cacheType, imageURL) -> Void in
-                XCTAssertNotNil(error)
-                XCTAssertEqual(error?.code, NSURLErrorCancelled)
-                
-                expectation.fulfill()
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
+            XCTFail("Progress block should not be called.")
+        }) { image, error, cacheType, imageURL in
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error?.code, NSURLErrorCancelled)
+            expectation.fulfill()
         }
         
         delay(0.1) { 
@@ -493,9 +492,9 @@ class ImageViewExtensionTests: XCTestCase {
         let expectation = self.expectation(description: "wait for downloading image")
         
         let url: URL? = nil
-        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        imageView.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             XCTFail("Progress block should not be called.")
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             XCTAssertNil(image)
             XCTAssertNil(error)
             XCTAssertEqual(cacheType, CacheType.none)
@@ -561,10 +560,10 @@ class ImageViewExtensionTests: XCTestCase {
             var progressBlockIsCalled = false
             ImageCache.default.clearMemoryCache()
             
-            imageView.kf.setImage(with: url, placeholder: nil, options: [], progressBlock: { (receivedSize, totalSize) -> Void in
+            imageView.kf.setImage(with: url, placeholder: nil, options: [], progressBlock: { receivedSize, totalSize in
                 progressBlockIsCalled = true
                 XCTAssertTrue(Thread.isMainThread)
-            }) { (image, error, cacheType, imageURL) -> Void in
+            }) { image, error, cacheType, imageURL in
                 
                 XCTAssertFalse(progressBlockIsCalled, "progressBlock should not be called since the image is cached.")
                 XCTAssertNotNil(image, "Downloaded image should exist.")
@@ -579,10 +578,10 @@ class ImageViewExtensionTests: XCTestCase {
         }
         
         var progressBlockIsCalled = false
-        imageView.kf.setImage(with: url, placeholder: nil, options: [.onlyLoadFirstFrame], progressBlock: { (receivedSize, totalSize) -> Void in
+        imageView.kf.setImage(with: url, placeholder: nil, options: [.onlyLoadFirstFrame], progressBlock: { receivedSize, totalSize in
             progressBlockIsCalled = true
             XCTAssertTrue(Thread.isMainThread)
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             XCTAssertTrue(progressBlockIsCalled, "progressBlock should be called at least once.")
             XCTAssertNotNil(image, "Downloaded image should exist.")
             XCTAssertNil(image!.kf.images, "images should not exist since we set only load first frame.")

--- a/Tests/KingfisherTests/NSButtonExtensionTests.swift
+++ b/Tests/KingfisherTests/NSButtonExtensionTests.swift
@@ -71,9 +71,9 @@ class NSButtonExtensionTests: XCTestCase {
 
         cleanDefaultCache()
 
-        button.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        button.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             progressBlockIsCalled = true
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             expectation.fulfill()
 
             XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
@@ -94,9 +94,9 @@ class NSButtonExtensionTests: XCTestCase {
         let url = URL(string: URLString)!
 
         var progressBlockIsCalled = false
-        button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             progressBlockIsCalled = true
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             expectation.fulfill()
 
             XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
@@ -117,9 +117,9 @@ class NSButtonExtensionTests: XCTestCase {
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
         let url = URL(string: URLString)!
 
-        button.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        button.kf.setImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             XCTAssertNotNil(error)
             XCTAssertEqual(error?.code, NSURLErrorCancelled)
 
@@ -141,9 +141,9 @@ class NSButtonExtensionTests: XCTestCase {
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
         let url = URL(string: URLString)!
 
-        _ = button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        _ = button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             XCTFail("Progress block should not be called.")
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             XCTAssertNotNil(error)
             XCTAssertEqual(error?.code, NSURLErrorCancelled)
 
@@ -162,9 +162,9 @@ class NSButtonExtensionTests: XCTestCase {
         let expectation = self.expectation(description: "wait for downloading image")
         
         let url: URL? = nil
-        button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        button.kf.setAlternateImage(with: url, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             XCTFail("Progress block should not be called.")
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             XCTAssertNil(image)
             XCTAssertNil(error)
             XCTAssertEqual(cacheType, CacheType.none)

--- a/Tests/KingfisherTests/UIButtonExtensionTests.swift
+++ b/Tests/KingfisherTests/UIButtonExtensionTests.swift
@@ -71,9 +71,9 @@ class UIButtonExtensionTests: XCTestCase {
         
         cleanDefaultCache()
         
-        button.kf.setImage(with: url, for: .highlighted, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        button.kf.setImage(with: url, for: .highlighted, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             progressBlockIsCalled = true
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             expectation.fulfill()
             
             XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
@@ -94,18 +94,17 @@ class UIButtonExtensionTests: XCTestCase {
         let url = Foundation.URL(string: URLString)!
         
         var progressBlockIsCalled = false
-        button.kf.setBackgroundImage(with: url, for: .normal, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        button.kf.setBackgroundImage(with: url, for: .normal, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             progressBlockIsCalled = true
-            }) { (image, error, cacheType, imageURL) -> Void in
-                expectation.fulfill()
+        }) { image, error, cacheType, imageURL in
+            expectation.fulfill()
                 
-                XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
-                XCTAssert(image != nil, "Downloaded image should exist.")
-                XCTAssert(image! == testImage, "Downloaded image should be the same as test image.")
-                XCTAssert(self.button.backgroundImage(for: .normal)! == testImage, "Downloaded image should be already set to the image for state")
-                XCTAssert(self.button.kf.backgroundWebURL(for: .normal) == imageURL, "Web URL should equal to the downloaded url.")
-                XCTAssert(cacheType == .none, "cacheType should be .None since the image was just downloaded.")
-
+            XCTAssert(progressBlockIsCalled, "progressBlock should be called at least once.")
+            XCTAssert(image != nil, "Downloaded image should exist.")
+            XCTAssert(image! == testImage, "Downloaded image should be the same as test image.")
+            XCTAssert(self.button.backgroundImage(for: .normal)! == testImage, "Downloaded image should be already set to the image for state")
+            XCTAssert(self.button.kf.backgroundWebURL(for: .normal) == imageURL, "Web URL should equal to the downloaded url.")
+            XCTAssert(cacheType == .none, "cacheType should be .None since the image was just downloaded.")
         }
         waitForExpectations(timeout: 5, handler: nil)
     }
@@ -117,13 +116,12 @@ class UIButtonExtensionTests: XCTestCase {
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
         let url = URL(string: URLString)!
 
-        button.kf.setImage(with: url, for: UIControl.State.highlighted, placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        button.kf.setImage(with: url, for: UIControl.State.highlighted, placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
                 
-            }) { (image, error, cacheType, imageURL) -> Void in
-                XCTAssertNotNil(error)
-                XCTAssertEqual(error?.code, NSURLErrorCancelled)
-
-                expectation.fulfill()
+        }) { image, error, cacheType, imageURL in
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error?.code, NSURLErrorCancelled)
+            expectation.fulfill()
         }
         delay(0.1) { 
             self.button.kf.cancelImageDownloadTask()
@@ -140,13 +138,13 @@ class UIButtonExtensionTests: XCTestCase {
         let stub = stubRequest("GET", URLString).andReturn(200)?.withBody(testImageData)?.delay()
         let url = URL(string: URLString)!
         
-        button.kf.setBackgroundImage(with: url, for: UIControl.State(), placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        button.kf.setBackgroundImage(with: url, for: UIControl.State(), placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             XCTFail("Progress block should not be called.")
-            }) { (image, error, cacheType, imageURL) -> Void in
-                XCTAssertNotNil(error)
-                XCTAssertEqual(error?.code, NSURLErrorCancelled)
+        }) { image, error, cacheType, imageURL in
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error?.code, NSURLErrorCancelled)
                 
-                expectation.fulfill()
+            expectation.fulfill()
         }
         delay(0.1) { 
             self.button.kf.cancelBackgroundImageDownloadTask()
@@ -160,9 +158,9 @@ class UIButtonExtensionTests: XCTestCase {
         let expectation = self.expectation(description: "wait for downloading image")
         
         let url: URL? = nil
-        button.kf.setBackgroundImage(with: url, for: UIControl.State(), placeholder: nil, options: nil, progressBlock: { (receivedSize, totalSize) -> Void in
+        button.kf.setBackgroundImage(with: url, for: UIControl.State(), placeholder: nil, options: nil, progressBlock: { receivedSize, totalSize in
             XCTFail("Progress block should not be called.")
-        }) { (image, error, cacheType, imageURL) -> Void in
+        }) { image, error, cacheType, imageURL in
             XCTAssertNil(image)
             XCTAssertNil(error)
             XCTAssertEqual(cacheType, CacheType.none)


### PR DESCRIPTION
1. trailing closure
2. Eliminate meaningless self-use
3. Eliminate meaningless associated values ​​parameter of enum