### PR TITLE
Pass scale property when creating animated image on iOS

### DIFF
--- a/Sources/Image.swift
+++ b/Sources/Image.swift
@@ -285,7 +285,7 @@ extension Kingfisher where Base: Image {
                 guard let (images, gifDuration) = decode(from: imageSource, for: options) else { return nil }
                 image = onlyFirstFrame ? images.first : Kingfisher<Image>.animated(with: images, forDuration: duration <= 0.0 ? gifDuration : duration)
             } else {
-                image = Image(data: data)
+                image = Image(data: data, scale: scale)
                 image?.kf.imageSource = ImageSource(ref: imageSource)
             }
             image?.kf.animatedImageData = data

--- a/Tests/KingfisherTests/ImageExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageExtensionTests.swift
@@ -68,7 +68,15 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertEqual(image!.kf.duration, 0.8, accuracy: 0.001, "The image duration should be 0.8s")
 #endif
     }
-    
+
+#if os(iOS) || os(tvOS)
+    func testScaleForGIFImage() {
+        let image = Kingfisher<Image>.animated(with: testImageGIFData, scale: 2.0, duration: 0.0, preloadAll: false, onlyFirstFrame: false)
+        XCTAssertNotNil(image, "The image should be initiated.")
+        XCTAssertEqual(image!.scale, 2.0, "should have correct scale")
+    }
+#endif
+
     func testGIFRepresentation() {
         let image = Kingfisher<Image>.animated(with: testImageGIFData, preloadAll: false)!
         let data = image.kf.gifRepresentation()


### PR DESCRIPTION
In this PR I am passing `scale` property to `UIImage`s `init` method when the animated image is being created. This is needed to get gifs of proper size when loading from `NSDataAsset`.
