### PR TITLE
Add .onFailureImage(Image) option to set default image when loading request will be failed

### DIFF
--- a/Sources/Extensions/ImageView+Kingfisher.swift
+++ b/Sources/Extensions/ImageView+Kingfisher.swift
@@ -134,6 +134,9 @@ extension KingfisherClass where Base: ImageView {
                         )
                         #endif
                     case .failure:
+                        if let image = options.onFailureImage {
+                            self.base.image = image
+                        }
                         completionHandler?(result)
                     }
                 }

--- a/Sources/Extensions/NSButton+Kingfisher.swift
+++ b/Sources/Extensions/NSButton+Kingfisher.swift
@@ -88,6 +88,9 @@ extension KingfisherClass where Base: NSButton {
                         self.base.image = value.image
                         completionHandler?(result)
                     case .failure:
+                        if let image = options.onFailureImage {
+                            self.base.image = image
+                        }
                         completionHandler?(result)
                     }
                 }
@@ -165,6 +168,9 @@ extension KingfisherClass where Base: NSButton {
                         self.base.alternateImage = value.image
                         completionHandler?(result)
                     case .failure:
+                        if let image = options.onFailureImage {
+                            self.base.alternateImage = image
+                        }
                         completionHandler?(result)
                     }
                 }

--- a/Sources/Extensions/UIButton+Kingfisher.swift
+++ b/Sources/Extensions/UIButton+Kingfisher.swift
@@ -94,6 +94,9 @@ extension KingfisherClass where Base: UIButton {
                         self.base.setImage(value.image, for: state)
                         completionHandler?(result)
                     case .failure:
+                        if let image = options.onFailureImage {
+                            self.base.setImage(image, for: state)
+                        }
                         completionHandler?(result)
                     }
                 }
@@ -178,6 +181,9 @@ extension KingfisherClass where Base: UIButton {
                         self.base.setBackgroundImage(value.image, for: state)
                         completionHandler?(result)
                     case .failure:
+                        if let image = options.onFailureImage {
+                            self.base.setBackgroundImage(image, for: state)
+                        }
                         completionHandler?(result)
                     }
                 }

--- a/Sources/Extensions/WKInterfaceImage+Kingfisher.swift
+++ b/Sources/Extensions/WKInterfaceImage+Kingfisher.swift
@@ -84,6 +84,9 @@ extension KingfisherClass where Base: WKInterfaceImage {
                         self.base.setImage(value.image)
                         completionHandler?(result)
                     case .failure:
+                        if let image = options.onFailureImage {
+                            self.base.setImage(image)
+                        }
                         completionHandler?(result)
                     }
                 }

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -176,6 +176,11 @@ public enum KingfisherOptionsInfoItem {
     /// resource, instead of downloading it again. You can use `.originalCache` to specify a cache or the original
     /// images if neccessary.
     case cacheOriginalImage
+    
+    /// If set and a downloading error occurred Kingfisher will set provided image
+    /// in place of requested one. It's useful when you don't want to show placeholder
+    /// during loading time but wants to use some default image when requests will be failed.
+    case onFailureImage(Image)
 }
 
 precedencegroup ItemComparisonPrecedence {
@@ -212,6 +217,7 @@ func <== (lhs: KingfisherOptionsInfoItem, rhs: KingfisherOptionsInfoItem) -> Boo
     case (.keepCurrentImageWhileLoading, .keepCurrentImageWhileLoading): return true
     case (.onlyLoadFirstFrame, .onlyLoadFirstFrame): return true
     case (.cacheOriginalImage, .cacheOriginalImage): return true
+    case (.onFailureImage(_), .onFailureImage(_)): return true
     default: return false
     }
 }
@@ -394,5 +400,15 @@ public extension Collection where Iterator.Element == KingfisherOptionsInfoItem 
     /// Whether the options contains `.cacheOriginalImage`.
     public var cacheOriginalImage: Bool {
         return contains { $0 <== .cacheOriginalImage }
+    }
+    
+    public var onFailureImage: Image? {
+        if let item = lastMatchIgnoringAssociatedValue(.onFailureImage(Image())),
+            case .onFailureImage(let image) = item
+        {
+            return image
+        }
+        
+        return nil
     }
 }

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -177,10 +177,10 @@ public enum KingfisherOptionsInfoItem {
     /// images if neccessary.
     case cacheOriginalImage
     
-    /// If set and a downloading error occurred Kingfisher will set provided image
+    /// If set and a downloading error occurred Kingfisher will set provided image (or empty)
     /// in place of requested one. It's useful when you don't want to show placeholder
     /// during loading time but wants to use some default image when requests will be failed.
-    case onFailureImage(Image)
+    case onFailureImage(Image?)
 }
 
 precedencegroup ItemComparisonPrecedence {
@@ -402,13 +402,14 @@ public extension Collection where Iterator.Element == KingfisherOptionsInfoItem 
         return contains { $0 <== .cacheOriginalImage }
     }
     
-    public var onFailureImage: Image? {
+    /// Use provided or empty image when download image request will failed.
+    public var onFailureImage: Optional<Image?> {
         if let item = lastMatchIgnoringAssociatedValue(.onFailureImage(Image())),
             case .onFailureImage(let image) = item
         {
-            return image
+            return .some(image)
         }
         
-        return nil
+        return .none
     }
 }

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -573,6 +573,20 @@ class ImageViewExtensionTests: XCTestCase {
 
         waitForExpectations(timeout: 1, handler: nil)
     }
+    
+    func testSettingNonWorkingImageWithFailureImage() {
+        let expectation = self.expectation(description: "wait for downloading image")
+        let url = testURLs[0]
+        stub(url, errorCode: 404)
+
+        imageView.kf.setImage(with: url, options: [.onFailureImage(testImage)]) { (result) -> Void in
+            XCTAssertNil(result.value)
+            expectation.fulfill()
+        }
+        XCTAssertNil(imageView.image)
+        waitForExpectations(timeout: 5, handler: nil)
+        XCTAssertEqual(testImage, imageView.image)
+    }
 }
 
 extension View: Placeholder {}

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -587,6 +587,20 @@ class ImageViewExtensionTests: XCTestCase {
         waitForExpectations(timeout: 5, handler: nil)
         XCTAssertEqual(testImage, imageView.image)
     }
+    
+    func testSettingNonWorkingImageWithEmptyFailureImage() {
+        let expectation = self.expectation(description: "wait for downloading image")
+        let url = testURLs[0]
+        stub(url, errorCode: 404)
+        
+        imageView.kf.setImage(with: url, placeholder: testImage, options: [.onFailureImage(nil)]) { (result) -> Void in
+            XCTAssertNil(result.value)
+            expectation.fulfill()
+        }
+        XCTAssertEqual(testImage, imageView.image)
+        waitForExpectations(timeout: 5, handler: nil)
+        XCTAssertNil(imageView.image)
+    }
 }
 
 extension View: Placeholder {}

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -601,6 +601,20 @@ class ImageViewExtensionTests: XCTestCase {
         waitForExpectations(timeout: 5, handler: nil)
         XCTAssertNil(imageView.image)
     }
+    
+    func testSettingNonWorkingImageWithoutFailureImage() {
+        let expectation = self.expectation(description: "wait for downloading image")
+        let url = testURLs[0]
+        stub(url, errorCode: 404)
+        
+        imageView.kf.setImage(with: url, placeholder: testImage) { (result) -> Void in
+            XCTAssertNil(result.value)
+            expectation.fulfill()
+        }
+        XCTAssertEqual(testImage, imageView.image)
+        waitForExpectations(timeout: 5, handler: nil)
+        XCTAssertEqual(testImage, imageView.image)
+    }
 }
 
 extension View: Placeholder {}

--- a/Tests/KingfisherTests/NSButtonExtensionTests.swift
+++ b/Tests/KingfisherTests/NSButtonExtensionTests.swift
@@ -158,5 +158,35 @@ class NSButtonExtensionTests: XCTestCase {
         
         waitForExpectations(timeout: 1, handler: nil)
     }
+    
+    func testSettingNonWorkingImageWithFailureImage() {
+        let expectation = self.expectation(description: "wait for downloading image")
+        let url = testURLs[0]
+        stub(url, errorCode: 404)
+        
+        button.kf.setImage(with: url, options: [.onFailureImage(testImage)]) { (result) -> Void in
+            XCTAssertNil(result.value)
+            expectation.fulfill()
+        }
+        
+        XCTAssertNil(button.image)
+        waitForExpectations(timeout: 5, handler: nil)
+        XCTAssertEqual(testImage, button.image)
+    }
+    
+    func testSettingNonWorkingAlternateImageWithFailureImage() {
+        let expectation = self.expectation(description: "wait for downloading image")
+        let url = testURLs[0]
+        stub(url, errorCode: 404)
+        
+        button.kf.setAlternateImage(with: url, options: [.onFailureImage(testImage)]) { (result) -> Void in
+            XCTAssertNil(result.value)
+            expectation.fulfill()
+        }
+        
+        XCTAssertNil(button.alternateImage)
+        waitForExpectations(timeout: 5, handler: nil)
+        XCTAssertEqual(testImage, button.alternateImage)
+    }
 
 }

--- a/Tests/KingfisherTests/UIButtonExtensionTests.swift
+++ b/Tests/KingfisherTests/UIButtonExtensionTests.swift
@@ -161,4 +161,34 @@ class UIButtonExtensionTests: XCTestCase {
         
         waitForExpectations(timeout: 1, handler: nil)
     }
+    
+    func testSettingNonWorkingImageWithFailureImage() {
+        let expectation = self.expectation(description: "wait for downloading image")
+        let url = testURLs[0]
+        stub(url, errorCode: 404)
+        let state = UIControl.State()
+        
+        button.kf.setImage(with: url, for: state, options: [.onFailureImage(testImage)]) { (result) -> Void in
+            XCTAssertNil(result.value)
+            expectation.fulfill()
+        }
+        XCTAssertNil(button.image(for: state))
+        waitForExpectations(timeout: 5, handler: nil)
+        XCTAssertEqual(testImage, button.image(for: state))
+    }
+    
+    func testSettingNonWorkingBackgroundImageWithFailureImage() {
+        let expectation = self.expectation(description: "wait for downloading image")
+        let url = testURLs[0]
+        stub(url, errorCode: 404)
+        let state = UIControl.State()
+        
+        button.kf.setBackgroundImage(with: url, for: state, options: [.onFailureImage(testImage)]) { (result) -> Void in
+            XCTAssertNil(result.value)
+            expectation.fulfill()
+        }
+        XCTAssertNil(button.backgroundImage(for: state))
+        waitForExpectations(timeout: 5, handler: nil)
+        XCTAssertEqual(testImage, button.backgroundImage(for: state))
+    }
 }


### PR DESCRIPTION
**Use case**
Let's assume that we have an app with a list of users, with the following conditions:
* Each user could have an avatar, but we have also users without it.
* We don't wont to have empty gaps in UI for users without an avatar.
* We know how to create avatar URL for given user, but we are not sure if it will work properly or return 404 response.
* We would like to use the default image for users without an avatar.

**Could we use placeholder property?**
Nope. Because with placeholder user will see blinking placeholder image changing to the proper avatar (for the existing ones).

**Changelog**
☑️ Add `.onFailureImage(Image)` option to KingfisherOptionsInfo
☑️ Add support for this option in ImageView, UIButton, NSButton and WKInterfaceImage extensions
☑️ Add test cases to iOS & MacOS test suites