### PR TITLE
Use fileURLWithPath instead of string for URL init

### DIFF
--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -239,7 +239,7 @@ open class ImageCache {
         var diskConfig = DiskStorage.Config(
             name: name,
             sizeLimit: 0,
-            directory: path.flatMap { URL(string: $0) }
+            directory: path.flatMap { URL(fileURLWithPath: $0) }
         )
         if let closure = diskCachePathClosure {
             diskConfig.cachePathBlock = closure


### PR DESCRIPTION
If use string for URL init, the disk storage is invalid because FileMeta is nil and can not get image data by Data(contentsOf: fileURL)