### PR TITLE
Clean expired disk cache when resign active also on macOS

### DIFF
--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -178,25 +178,32 @@ open class ImageCache {
         self.diskStorage = diskStorage
         let ioQueueName = "com.onevcat.Kingfisher.ImageCache.ioQueue.\(UUID().uuidString)"
         ioQueue = DispatchQueue(label: ioQueueName)
-        
+
+        let notifications: [(Notification.Name, Selector)]
         #if !os(macOS) && !os(watchOS)
         #if swift(>=4.2)
-        let notifications: [(Notification.Name, Selector)] = [
+        notifications = [
             (UIApplication.didReceiveMemoryWarningNotification, #selector(clearMemoryCache)),
             (UIApplication.willTerminateNotification, #selector(cleanExpiredDiskCache)),
             (UIApplication.didEnterBackgroundNotification, #selector(backgroundCleanExpiredDiskCache))
         ]
         #else
-        let notifications: [(Notification.Name, Selector)] = [
+        notifications = [
             (NSNotification.Name.UIApplicationDidReceiveMemoryWarning, #selector(clearMemoryCache)),
             (NSNotification.Name.UIApplicationWillTerminate, #selector(cleanExpiredDiskCache)),
             (NSNotification.Name.UIApplicationDidEnterBackground, #selector(backgroundCleanExpiredDiskCache))
         ]
         #endif
+        #elseif os(macOS)
+        notifications = [
+            (NSApplication.willResignActiveNotification, #selector(cleanExpiredDiskCache)),
+        ]
+        #else
+        notifications = []
+        #endif
         notifications.forEach {
             NotificationCenter.default.addObserver(self, selector: $0.1, name: $0.0, object: nil)
         }
-        #endif
     }
     
     /// Creates an `ImageCache` with a given `name`. Both `MemoryStorage` and `DiskStorage` will be created


### PR DESCRIPTION
macOS app using Kingfisher image cache may use large storage area (sometimes ~gigabytes), even if they are expired.
On iOS Kingfisher automatically clear expired disk caches by app lifecycle notifications and that is useful.
It would be nice if macOS apps clean expired disk caches when resign active.