### PR TITLE
Feature/from cache than refresh

### DIFF
--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -173,7 +173,7 @@ public class KingfisherManager {
                 options: options,
                 completionHandler: completionHandler)
             
-            if loadedFromCache && !options.fromCacheThanRefresh {
+            if loadedFromCache && !options.fromCacheThenRefresh {
                 return nil
             }
             

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -173,7 +173,7 @@ public class KingfisherManager {
                 options: options,
                 completionHandler: completionHandler)
             
-            if loadedFromCache {
+            if loadedFromCache && !options.fromCacheThanRefresh {
                 return nil
             }
             

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -94,6 +94,9 @@ public enum KingfisherOptionsInfoItem {
     /// not in cache, the image retrieving will fail with an error.
     case onlyFromCache
     
+    /// If set, Kingfisher will try to retrieve the image from cache first and set. Then it will try to fire a download task for the resource and refresh image.
+    case fromCacheThanRefresh
+    
     /// Decode the image in background thread before using. It will decode the downloaded image data and do a off-screen
     /// rendering to extract pixel information in background. This can speed up display, but will cost more time to
     /// prepare the image for using.
@@ -233,6 +236,7 @@ public struct KingfisherParsedOptionsInfo {
     public var cacheMemoryOnly = false
     public var waitForCache = false
     public var onlyFromCache = false
+    public var fromCacheThanRefresh = false
     public var backgroundDecode = false
     public var preloadAllAnimationData = false
     public var callbackQueue: CallbackQueue = .mainCurrentOrAsync
@@ -267,6 +271,7 @@ public struct KingfisherParsedOptionsInfo {
             case .cacheMemoryOnly: cacheMemoryOnly = true
             case .waitForCache: waitForCache = true
             case .onlyFromCache: onlyFromCache = true
+            case .fromCacheThanRefresh: fromCacheThanRefresh = true
             case .backgroundDecode: backgroundDecode = true
             case .preloadAllAnimationData: preloadAllAnimationData = true
             case .callbackQueue(let value): callbackQueue = value

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -95,7 +95,8 @@ public enum KingfisherOptionsInfoItem {
     case onlyFromCache
     
     /// If set, Kingfisher will try to retrieve the image from cache first and set. Then it will try to fire a download task for the resource and refresh image.
-    case fromCacheThanRefresh
+    /// This is useful when you want to display a changeable image behind the same url at the same app session and use cache if internet issues.
+    case fromCacheThenRefresh
     
     /// Decode the image in background thread before using. It will decode the downloaded image data and do a off-screen
     /// rendering to extract pixel information in background. This can speed up display, but will cost more time to
@@ -236,7 +237,7 @@ public struct KingfisherParsedOptionsInfo {
     public var cacheMemoryOnly = false
     public var waitForCache = false
     public var onlyFromCache = false
-    public var fromCacheThanRefresh = false
+    public var fromCacheThenRefresh = false
     public var backgroundDecode = false
     public var preloadAllAnimationData = false
     public var callbackQueue: CallbackQueue = .mainCurrentOrAsync
@@ -271,7 +272,7 @@ public struct KingfisherParsedOptionsInfo {
             case .cacheMemoryOnly: cacheMemoryOnly = true
             case .waitForCache: waitForCache = true
             case .onlyFromCache: onlyFromCache = true
-            case .fromCacheThanRefresh: fromCacheThanRefresh = true
+            case .fromCacheThenRefresh: fromCacheThenRefresh = true
             case .backgroundDecode: backgroundDecode = true
             case .preloadAllAnimationData: preloadAllAnimationData = true
             case .callbackQueue(let value): callbackQueue = value

--- a/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
+++ b/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
@@ -52,7 +52,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertFalse(options.keepCurrentImageWhileLoading)
         XCTAssertFalse(options.onlyLoadFirstFrame)
         XCTAssertFalse(options.cacheOriginalImage)
-        XCTAssertFalse(options.fromCacheThanRefresh)
+        XCTAssertFalse(options.fromCacheThenRefresh)
     }
     
     func testSetOptionsShouldParseCorrectly() {
@@ -90,7 +90,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
             .keepCurrentImageWhileLoading,
             .onlyLoadFirstFrame,
             .cacheOriginalImage,
-            .fromCacheThanRefresh
+            .fromCacheThenRefresh
         ])
         
         XCTAssertTrue(options.targetCache === cache)
@@ -126,7 +126,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertTrue(options.keepCurrentImageWhileLoading)
         XCTAssertTrue(options.onlyLoadFirstFrame)
         XCTAssertTrue(options.cacheOriginalImage)
-        XCTAssertTrue(options.fromCacheThanRefresh)
+        XCTAssertTrue(options.fromCacheThenRefresh)
     }
     
     func testOptionCouldBeOverwritten() {

--- a/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
+++ b/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
@@ -52,6 +52,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertFalse(options.keepCurrentImageWhileLoading)
         XCTAssertFalse(options.onlyLoadFirstFrame)
         XCTAssertFalse(options.cacheOriginalImage)
+        XCTAssertFalse(options.fromCacheThanRefresh)
     }
     
     func testSetOptionsShouldParseCorrectly() {
@@ -88,7 +89,8 @@ class KingfisherOptionsInfoTests: XCTestCase {
             .imageModifier(modifier),
             .keepCurrentImageWhileLoading,
             .onlyLoadFirstFrame,
-            .cacheOriginalImage
+            .cacheOriginalImage,
+            .fromCacheThanRefresh
         ])
         
         XCTAssertTrue(options.targetCache === cache)
@@ -124,6 +126,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertTrue(options.keepCurrentImageWhileLoading)
         XCTAssertTrue(options.onlyLoadFirstFrame)
         XCTAssertTrue(options.cacheOriginalImage)
+        XCTAssertTrue(options.fromCacheThanRefresh)
     }
     
     func testOptionCouldBeOverwritten() {


### PR DESCRIPTION
Add options for get image first from cache and then refresh image (download from source). This is useful when you want to display a changeable image behind the same url at the same app session and use cache if no internet.