### PR TITLE
Bug fix: setting properties through kf extension causes compiler error

### DIFF
--- a/Sources/General/Kingfisher.swift
+++ b/Sources/General/Kingfisher.swift
@@ -65,7 +65,7 @@ extension KingfisherCompatible {
     /// Gets a namespace holder for Kingfisher compatible types.
     public var kf: KingfisherWrapper<Self> {
         get { return KingfisherWrapper(self) }
-        set { }
+        nonmutating set { }
     }
 }
 

--- a/Sources/General/Kingfisher.swift
+++ b/Sources/General/Kingfisher.swift
@@ -56,16 +56,27 @@ public struct KingfisherWrapper<Base> {
     }
 }
 
-/// Represents a type which is compatible with Kingfisher. You can use `kf` property to get a
+/// Represents an object type that is compatible with Kingfisher. You can use `kf` property to get a
 /// value in the namespace of Kingfisher.
-public protocol KingfisherCompatible { }
+public protocol KingfisherCompatible: AnyObject { }
+
+/// Represents a value type that is compatible with Kingfisher. You can use `kf` property to get a
+/// value in the namespace of Kingfisher.
+public protocol KingfisherCompatibleValue {}
 
 extension KingfisherCompatible {
-    
     /// Gets a namespace holder for Kingfisher compatible types.
     public var kf: KingfisherWrapper<Self> {
         get { return KingfisherWrapper(self) }
-        nonmutating set { }
+        set { }
+    }
+}
+
+extension KingfisherCompatibleValue {
+    /// Gets a namespace holder for Kingfisher compatible types.
+    public var kf: KingfisherWrapper<Self> {
+        get { return KingfisherWrapper(self) }
+        set { }
     }
 }
 

--- a/Sources/Image/ImageFormat.swift
+++ b/Sources/Image/ImageFormat.swift
@@ -51,7 +51,7 @@ public enum ImageFormat {
 }
 
 
-extension Data: KingfisherCompatible {}
+extension Data: KingfisherCompatibleValue {}
 
 // MARK: - Misc Helpers
 extension KingfisherWrapper where Base == Data {

--- a/Sources/Utility/SizeExtensions.swift
+++ b/Sources/Utility/SizeExtensions.swift
@@ -26,7 +26,7 @@
 
 import CoreGraphics
 
-extension CGSize: KingfisherCompatible {}
+extension CGSize: KingfisherCompatibleValue {}
 extension KingfisherWrapper where Base == CGSize {
     
     /// Returns a size by resizing the `base` size to a target size under a given content mode.

--- a/Sources/Utility/String+MD5.swift
+++ b/Sources/Utility/String+MD5.swift
@@ -27,7 +27,7 @@
 import Foundation
 import CommonCrypto
 
-extension String: KingfisherCompatible { }
+extension String: KingfisherCompatibleValue { }
 extension KingfisherWrapper where Base == String {
     var md5: String {
         guard let data = base.data(using: .utf8) else {


### PR DESCRIPTION
In the current master branch (and I believe, Kingfisher 5 generally), attempting to set Kingfisher attributes through the `kf` variable of `KingfisherCompatible` causes a compiler error:

```swift
class TestView: UIImageView {
    func setUp() {
        kf.indicatorType = .activity  // Error: cannot assign to property: 'self' is immutable
    }
}
```

The reason for this is subtle. The `KingfisherCompatible` protocol is not class-specific, so it could be conformed to by a struct. Setters are implicitly `mutating`. And structs are allowed to reassign `self` inside of any mutating method. 

However, class instances do not allow the assignment of `self`. So when `KingfisherCompatible` is adopted by a class entity, the compiler does not allow access to the setter.

I know this sounds wacky; more details [here](https://forums.swift.org/t/bug-known-protocol-extension-with-settable-computed-property/21687) and [here](https://forums.swift.org/t/why-can-we-not-mutate-mutable-members-on-a-reference-type/21619), verified by a couple of Swift devs.

There are a couple of possible solutions. `KingfisherCompatible` could derive from `AnyObject`, which is the current version of the old `class protocol` construct. Or you can explicitly mark the setter as `nonmutating`, which seems like the better option here since it actually does nothing.