### PR TITLE
Add an option for disabling encryption for a cache file name

### DIFF
--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -196,7 +196,7 @@ public enum DiskStorage {
         }
 
         func cacheFileName(forKey key: String) -> String {
-            if self.config.useEncryptionForCacheFileName {
+            if config.usesHashedFileName {
                 let hashedKey = key.kf.md5
                 if let ext = config.pathExtension {
                     return "\(hashedKey).\(ext)"
@@ -317,8 +317,8 @@ extension DiskStorage {
         /// Default is `nil`, means that the cache file does not contain a file extension.
         public var pathExtension: String? = nil
 
-        /// Default is `true`, means that md5 encryption will be used for creation the cache file name.
-        public var useEncryptionForCacheFileName: Bool = true
+        /// Default is `true`, means that the cache file name will be hashed before storing.
+        public var usesHashedFileName = true
 
         let name: String
         let fileManager: FileManager

--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -196,11 +196,18 @@ public enum DiskStorage {
         }
 
         func cacheFileName(forKey key: String) -> String {
-            let hashedKey = key.kf.md5
-            if let ext = config.pathExtension {
-                return "\(hashedKey).\(ext)"
+            if self.config.useEncryptionForCacheFileName {
+                let hashedKey = key.kf.md5
+                if let ext = config.pathExtension {
+                    return "\(hashedKey).\(ext)"
+                }
+                return hashedKey
+            } else {
+                if let ext = config.pathExtension {
+                    return "\(key).\(ext)"
+                }
+                return key
             }
-            return hashedKey
         }
 
         func allFileURLs(for propertyKeys: [URLResourceKey]) throws -> [URL] {
@@ -309,6 +316,9 @@ extension DiskStorage {
         /// The preferred extension of cache item. It will be appended to the file name as its extension.
         /// Default is `nil`, means that the cache file does not contain a file extension.
         public var pathExtension: String? = nil
+
+        /// Default is `true`, means that md5 encryption will be used for creation the cache file name.
+        public var useEncryptionForCacheFileName: Bool = true
 
         let name: String
         let fileManager: FileManager

--- a/Tests/KingfisherTests/DiskStorageTests.swift
+++ b/Tests/KingfisherTests/DiskStorageTests.swift
@@ -156,6 +156,20 @@ class DiskStorageTests: XCTestCase {
         XCTAssertTrue(urls.count > 0)
     }
 
+    func testConfigUsesHashedFileName() {
+        let key = "test"
+
+        // hashed fileName
+        storage.config.usesHashedFileName = true
+        let hashedFileName = storage.cacheFileName(forKey: key)
+        XCTAssertNotEqual(hashedFileName, key)
+
+        // fileName without hash
+        storage.config.usesHashedFileName = false
+        let originalFileName = storage.cacheFileName(forKey: key)
+        XCTAssertEqual(originalFileName, key)
+    }
+
     func testFileMetaOrder() {
         let urls = [URL(string: "test1")!, URL(string: "test2")!, URL(string: "test3")!]
 

--- a/Tests/KingfisherTests/DiskStorageTests.swift
+++ b/Tests/KingfisherTests/DiskStorageTests.swift
@@ -163,6 +163,8 @@ class DiskStorageTests: XCTestCase {
         storage.config.usesHashedFileName = true
         let hashedFileName = storage.cacheFileName(forKey: key)
         XCTAssertNotEqual(hashedFileName, key)
+        // validation md5 hash of the key
+        XCTAssertEqual(hashedFileName, key.kf.md5)
 
         // fileName without hash
         storage.config.usesHashedFileName = false


### PR DESCRIPTION
This option allows disabling md5 encryption for creation cache file name in DiskStorage.