### PR TITLE
Fix stack overflow regression with ImagePrefetcher

### DIFF
--- a/Sources/Networking/ImagePrefetcher.swift
+++ b/Sources/Networking/ImagePrefetcher.swift
@@ -310,17 +310,19 @@ public class ImagePrefetcher {
     }
     
     func reportCompletionOrStartNext() {
-        if let resource = self.pendingSources.popFirst() {
-            startPrefetching(resource)
-        } else {
-            guard tasks.isEmpty else { return }
-            handleComplete()
+        CallbackQueue.mainAsync.execute {
+            if let resource = self.pendingSources.popFirst() {
+                self.startPrefetching(resource)
+            } else {
+                guard self.tasks.isEmpty else { return }
+                self.handleComplete()
+            }
         }
     }
     
     func handleComplete() {
         // The completion handler should be called on the main thread
-        DispatchQueue.main.safeAsync {
+        CallbackQueue.mainCurrentOrAsync.execute {
             self.completionSourceHandler?(self.skippedSources, self.failedSources, self.completedSources)
             self.completionHandler?(
                 self.skippedSources.compactMap { $0.asResource },


### PR DESCRIPTION
Fix stack overflow when prefetching large number of images that were already previously cached to disk. A regression to version 3.3.0.

Also improve consistency for dispatching to queues using the newer CallbackQueue enum.