### PR TITLE
Use built in Result type on Swift 5

### DIFF
--- a/Sources/Utility/Result.swift
+++ b/Sources/Utility/Result.swift
@@ -26,6 +26,7 @@
 
 import Foundation
 
+#if swift(<5)
 /// A value that represents either a success or failure, capturing associated
 /// values in both cases.
 public enum Result<Success, Failure> {
@@ -189,6 +190,7 @@ extension Result : CustomDebugStringConvertible {
         return output
     }
 }
+#endif
 
 // Deprecated
 extension Result {

--- a/Sources/Utility/Result.swift
+++ b/Sources/Utility/Result.swift
@@ -26,7 +26,9 @@
 
 import Foundation
 
-#if swift(<5)
+#if swift(>=4.3)
+/// Result type already built-in
+#else
 /// A value that represents either a success or failure, capturing associated
 /// values in both cases.
 public enum Result<Success, Failure> {


### PR DESCRIPTION
I think that it's good time to hide custom Result type declaration for Swift 5 clients and switch to built-in type. For Swift 4.2 and older it will be still visible.