### PR TITLE
Fix prefetcher thread

### DIFF
--- a/Sources/Networking/ImagePrefetcher.swift
+++ b/Sources/Networking/ImagePrefetcher.swift
@@ -315,12 +315,20 @@ public class ImagePrefetcher: CustomStringConvertible {
     }
     
     private func reportProgress() {
+
+        if progressBlock == nil && progressSourceBlock == nil {
+            return
+        }
+
+        let skipped = self.skippedSources
+        let failed = self.failedSources
+        let completed = self.completedSources
         CallbackQueue.mainCurrentOrAsync.execute {
-            self.progressSourceBlock?(self.skippedSources, self.failedSources, self.completedSources)
+            self.progressSourceBlock?(skipped, failed, completed)
             self.progressBlock?(
-                self.skippedSources.compactMap { $0.asResource },
-                self.failedSources.compactMap { $0.asResource },
-                self.completedSources.compactMap { $0.asResource }
+                skipped.compactMap { $0.asResource },
+                failed.compactMap { $0.asResource },
+                completed.compactMap { $0.asResource }
             )
         }
     }
@@ -340,6 +348,11 @@ public class ImagePrefetcher: CustomStringConvertible {
     }
     
     private func handleComplete() {
+
+        if completionHandler == nil && completionSourceHandler == nil {
+            return
+        }
+        
         // The completion handler should be called on the main thread
         CallbackQueue.mainCurrentOrAsync.execute {
             self.completionSourceHandler?(self.skippedSources, self.failedSources, self.completedSources)

--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -47,8 +47,10 @@ public class SessionDataTask {
     public let task: URLSessionDataTask
     private var callbacksStore = [CancelToken: TaskCallback]()
 
-    var callbacks: Dictionary<SessionDataTask.CancelToken, SessionDataTask.TaskCallback>.Values {
-        return callbacksStore.values
+    var callbacks: [SessionDataTask.TaskCallback] {
+        lock.lock()
+        defer { lock.unlock() }
+        return Array(callbacksStore.values)
     }
 
     private var currentToken = 0

--- a/Sources/Networking/SessionDelegate.swift
+++ b/Sources/Networking/SessionDelegate.swift
@@ -248,6 +248,6 @@ extension SessionDelegate: URLSessionDataDelegate {
             return
         }
         remove(task)
-        sessionTask.onTaskDone.call((result, Array(sessionTask.callbacks)))
+        sessionTask.onTaskDone.call((result, sessionTask.callbacks))
     }
 }

--- a/Tests/KingfisherTests/ImagePrefetcherTests.swift
+++ b/Tests/KingfisherTests/ImagePrefetcherTests.swift
@@ -252,7 +252,7 @@ class ImagePrefetcherTests: XCTestCase {
         let cache = KingfisherManager.shared.cache
         let key = testKeys[0]
 
-        cache.store(testImage, forKey: key, callbackQueue: .mainAsync) { result in
+        cache.store(testImage, forKey: key) { result in
             try! cache.memoryStorage.remove(forKey: key)
             
             XCTAssertEqual(cache.imageCachedType(forKey: key), .disk)
@@ -307,12 +307,12 @@ class ImagePrefetcherTests: XCTestCase {
             group.enter()
             let prefetcher = ImagePrefetcher(
                 resources: testURLs,
-                options: [.waitForCache])
+                options: [.cacheMemoryOnly])
             { _, _, _ in group.leave() }
             prefetcher.start()
         }
         group.notify(queue: .main) { exp.fulfill() }
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testPrefetchSources() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,10 +20,7 @@ platform :ios do
   end
 
   lane :test do |options|
-    # Sometimes Travis CI would fail due to timeout. 
-    # Not sure why but just rerunning the test perfectly fixes it. :[
-    # Maybe it is related to some racing when running in CI, but it never reproducible in a local env.
-    _test(options) rescue _test(options)
+    _test(options)
   end
 
   private_lane :_test do |options|


### PR DESCRIPTION
This should fix the corrupted memory due to race condition introduced by Swift 5 compiler.

#1147 and #1148 should be fixed by these changes.