### PR TITLE
Optimize MD5 String By `reduce` Function

### DIFF
--- a/Sources/Utility/String+MD5.swift
+++ b/Sources/Utility/String+MD5.swift
@@ -44,6 +44,6 @@ extension KingfisherWrapper where Base == String {
         }
         #endif
         
-        return digest.map { String(format: "%02x", $0) }.joined()
+        return digest.reduce(into: "") { $0 += String(format: "%02x", $1) }
     }
 }


### PR DESCRIPTION
I have a question，in "String+MD5.swift"，use “reduce” func may be better than use “map” and “joined” to create MD5 string by an [UInt8]，"map" may be cause space complexity O(n) ，it create a temp array [String]，Or are there other benefits to using "map" and "joined"?