### PR TITLE
Bring back macOS 10.11 into the game

### DIFF
--- a/Demo/Kingfisher-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Kingfisher-Demo.xcodeproj/project.pbxproj
@@ -696,6 +696,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Demo/Kingfisher-macOS-Demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.onevcat.Kingfisher-OSX-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -715,6 +716,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Demo/Kingfisher-macOS-Demo/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.onevcat.Kingfisher-OSX-Demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -1369,6 +1369,7 @@
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				OTHER_SWIFT_FLAGS = "-Xfrontend -warn-long-expression-type-checking=150";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.onevcat.Kingfisher-macOS";
 				PRODUCT_NAME = Kingfisher;
@@ -1397,6 +1398,7 @@
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.onevcat.Kingfisher-macOS";
 				PRODUCT_NAME = Kingfisher;
 				SDKROOT = macosx;

--- a/Sources/Cache/MemoryStorage.swift
+++ b/Sources/Cache/MemoryStorage.swift
@@ -72,10 +72,16 @@ public enum MemoryStorage {
                 self.keys.remove(obj.key)
             }
 
-            cleanTimer = .scheduledTimer(withTimeInterval: config.cleanInterval, repeats: true) { [weak self] _ in
-                guard let self = self else { return }
-                self.removeExpired()
-            }
+            cleanTimer = .scheduledTimer(timeInterval: config.cleanInterval,
+                                         target: self,
+                                         selector: #selector(cleanTimerFire(_:)),
+                                         userInfo: nil,
+                                         repeats: true)
+        }
+
+        @objc
+        private func cleanTimerFire(_ timer: Timer) {
+            removeExpired()
         }
 
         func removeExpired() {


### PR DESCRIPTION
This PR restores macOS 10.11 compatibility.

The deployment target has been set both in the macOS framework target and the demo application.
The code has also been [fixed](https://github.com/onevcat/Kingfisher/commit/86e3d9fda4dffcd17137ac5762c86ad791661786) for build to succeed.