### PR TITLE
Experimental: Support Project Catalyst

### DIFF
--- a/Sources/General/Deprecated.swift
+++ b/Sources/General/Deprecated.swift
@@ -24,7 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(UIKitForMac)
 import AppKit
 #elseif canImport(UIKit)
 import UIKit

--- a/Sources/Image/ImageDrawing.swift
+++ b/Sources/Image/ImageDrawing.swift
@@ -26,7 +26,7 @@
 
 import Accelerate
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(UIKitForMac)
 import AppKit
 #endif
 #if canImport(UIKit)

--- a/Sources/Image/ImageProcessor.swift
+++ b/Sources/Image/ImageProcessor.swift
@@ -27,7 +27,7 @@
 import Foundation
 import CoreGraphics
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(UIKitForMac)
 import AppKit
 #endif
 

--- a/Sources/Utility/ExtensionHelpers.swift
+++ b/Sources/Utility/ExtensionHelpers.swift
@@ -32,7 +32,7 @@ extension Float {
     }
 }
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(UIKitForMac)
 import AppKit
 extension NSBezierPath {
     convenience init(roundedRect rect: NSRect, topLeftRadius: CGFloat, topRightRadius: CGFloat,

--- a/Sources/Views/Indicator.swift
+++ b/Sources/Views/Indicator.swift
@@ -24,7 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(UIKitForMac)
 import AppKit
 public typealias IndicatorView = NSView
 #else


### PR DESCRIPTION
According to the official documentation (https://developer.apple.com/documentation/uikit/creating_a_mac_version_of_your_ipad_app),

```swift
#if !targetEnvironment(UIKitForMac)
// Code to exclude from Mac.
#endif
```

These AND conditions are added to support the compilation for Project Catalyst