### PR TITLE
Update code for Xcode 11 SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
     name: "Kingfisher",
-    platforms: [.iOS("10.0"), .macOS("10.12"), .tvOS("10.0"), .watchOS("3.0")],
+    platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v3)],
     products: [
         .library(name: "Kingfisher", targets: ["Kingfisher"])
     ],

--- a/Sources/Extensions/NSButton+Kingfisher.swift
+++ b/Sources/Extensions/NSButton+Kingfisher.swift
@@ -24,7 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(macOS)
+#if canImport(AppKit)
 
 import AppKit
 

--- a/Sources/Extensions/UIButton+Kingfisher.swift
+++ b/Sources/Extensions/UIButton+Kingfisher.swift
@@ -24,6 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if canImport(UIKit)
 import UIKit
 
 extension KingfisherWrapper where Base: UIButton {
@@ -390,3 +391,4 @@ extension KingfisherWrapper where Base: UIButton {
         return nil
     }
 }
+#endif

--- a/Sources/Extensions/WKInterfaceImage+Kingfisher.swift
+++ b/Sources/Extensions/WKInterfaceImage+Kingfisher.swift
@@ -24,7 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if os(watchOS)
+#if canImport(WatchKit)
 
 import WatchKit
 


### PR DESCRIPTION
As described in issue #1221 iOS app is unable to build because AppKit, UIKit and WatchKit wasn't conditionally imported in source files. I added `canImport` when it was necessary.

I need to add `platforms` to `Package.swift` to tell Xcode that it can use iOS 10 as development target for Kingfisher and fix a lot of "not available" errors.