### PR TITLE
Updates for Xcode 11 beta 4

### DIFF
--- a/Sources/Extensions/NSButton+Kingfisher.swift
+++ b/Sources/Extensions/NSButton+Kingfisher.swift
@@ -24,7 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 
 import AppKit
 

--- a/Sources/General/Deprecated.swift
+++ b/Sources/General/Deprecated.swift
@@ -24,7 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if canImport(AppKit) && !targetEnvironment(UIKitForMac)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 #elseif canImport(UIKit)
 import UIKit

--- a/Sources/Image/ImageDrawing.swift
+++ b/Sources/Image/ImageDrawing.swift
@@ -26,7 +26,7 @@
 
 import Accelerate
 
-#if canImport(AppKit) && !targetEnvironment(UIKitForMac)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 #endif
 #if canImport(UIKit)

--- a/Sources/Image/ImageProcessor.swift
+++ b/Sources/Image/ImageProcessor.swift
@@ -27,7 +27,7 @@
 import Foundation
 import CoreGraphics
 
-#if canImport(AppKit) && !targetEnvironment(UIKitForMac)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 #endif
 

--- a/Sources/Utility/ExtensionHelpers.swift
+++ b/Sources/Utility/ExtensionHelpers.swift
@@ -32,7 +32,7 @@ extension Float {
     }
 }
 
-#if canImport(AppKit) && !targetEnvironment(UIKitForMac)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 extension NSBezierPath {
     convenience init(roundedRect rect: NSRect, topLeftRadius: CGFloat, topRightRadius: CGFloat,

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -31,6 +31,7 @@
 //  The name and characters used in the demo of this software are property of their
 //  respective owners.
 
+#if canImport(UIKit)
 import UIKit
 import ImageIO
 
@@ -568,3 +569,4 @@ extension Array {
         return indices ~= index ? self[index] : nil
     }
 }
+#endif

--- a/Sources/Views/Indicator.swift
+++ b/Sources/Views/Indicator.swift
@@ -24,7 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#if canImport(AppKit) && !targetEnvironment(UIKitForMac)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 public typealias IndicatorView = NSView
 #else
@@ -120,6 +120,8 @@ final class ActivityIndicator: Indicator {
         #else
             #if os(tvOS)
                 let indicatorStyle = UIActivityIndicatorView.Style.white
+            #elseif targetEnvironment(macCatalyst)
+                let indicatorStyle = UIActivityIndicatorView.Style.medium
             #else
                 let indicatorStyle = UIActivityIndicatorView.Style.gray
             #endif


### PR DESCRIPTION
Minor changes introduced in Xcode 11 beta 4:

- `UIKitForMac` target environment is now called `macCatalyst`
- `UIActivityIndicatorView.Style.gray` has been renamed to `UIActivityIndicatorView.Style.medium` on Catalyst
-  `AnimatedImageView` needed `#if canImport(UIKit)` in order to import UIKit: [diff](https://github.com/onevcat/Kingfisher/compare/onevcat:80c0f2c...marcosgriselli:9c24f25#diff-632f8a05a77c7a6a3a289dcd86ae5b2dR34). Not sure if I was doing something wrong on my side for this one. 

I'm currently playing with a Catalyst project with beta 4 so I'm able to test anything that's needed.