### PR TITLE
Add extension to handle NSTextAttachment as KingfisherCompatible

### DIFF
--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		4BD821692189FD330084CC21 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD821662189FD330084CC21 /* SessionDataTask.swift */; };
 		4BD8216A2189FD330084CC21 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD821662189FD330084CC21 /* SessionDataTask.swift */; };
 		AE1D6776DC6183B84B561961 /* libPods-KingfisherTests-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 124FABC032484C46AC221D0C /* libPods-KingfisherTests-tvOS.a */; };
+		B567067922E5C75E008A8979 /* NSTextAttachment+Kingfisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B567067822E5C75E008A8979 /* NSTextAttachment+Kingfisher.swift */; };
+		B567067A22E5C75E008A8979 /* NSTextAttachment+Kingfisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B567067822E5C75E008A8979 /* NSTextAttachment+Kingfisher.swift */; };
+		B567067C22E5C96E008A8979 /* NSTextAttachment+Kingfisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B567067822E5C75E008A8979 /* NSTextAttachment+Kingfisher.swift */; };
 		C9286407228584EB00257182 /* ImageProgressive.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9286406228584EB00257182 /* ImageProgressive.swift */; };
 		C9286408228584EB00257182 /* ImageProgressive.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9286406228584EB00257182 /* ImageProgressive.swift */; };
 		C9286409228584EB00257182 /* ImageProgressive.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9286406228584EB00257182 /* ImageProgressive.swift */; };
@@ -304,6 +307,7 @@
 		4BD821662189FD330084CC21 /* SessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDataTask.swift; sourceTree = "<group>"; };
 		6CD5C0134AA4B1C0892E7319 /* Pods-KingfisherTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KingfisherTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-KingfisherTests/Pods-KingfisherTests.release.xcconfig"; sourceTree = "<group>"; };
 		7204D40BEFEA059FA25864C4 /* Pods-KingfisherTests-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KingfisherTests-macOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-KingfisherTests-macOS/Pods-KingfisherTests-macOS.debug.xcconfig"; sourceTree = "<group>"; };
+		B567067822E5C75E008A8979 /* NSTextAttachment+Kingfisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTextAttachment+Kingfisher.swift"; sourceTree = "<group>"; };
 		C9286406228584EB00257182 /* ImageProgressive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProgressive.swift; sourceTree = "<group>"; };
 		C959EEE7228940FE00467A10 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		CCDD057F8DA8D24EE701CF98 /* libPods-KingfisherTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-KingfisherTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -530,6 +534,7 @@
 				D12AB6AD215D2BB50013BA68 /* NSButton+Kingfisher.swift */,
 				D12AB6AE215D2BB50013BA68 /* UIButton+Kingfisher.swift */,
 				D12AB6AF215D2BB50013BA68 /* WKInterfaceImage+Kingfisher.swift */,
+				B567067822E5C75E008A8979 /* NSTextAttachment+Kingfisher.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1114,6 +1119,7 @@
 				D1A37BD9215D2DBA009B39B7 /* ImagePrefetcher.swift in Sources */,
 				D1A37BDB215D2DBA009B39B7 /* Box.swift in Sources */,
 				D1A1CC9C219FAB4B00263AD8 /* Source.swift in Sources */,
+				B567067C22E5C96E008A8979 /* NSTextAttachment+Kingfisher.swift in Sources */,
 				D1A37BDC215D2DBA009B39B7 /* Indicator.swift in Sources */,
 				4B8E2919216F3F7F0095FAD1 /* ImageDownloaderDelegate.swift in Sources */,
 				D114F36E215D2D0B00A01349 /* String+MD5.swift in Sources */,
@@ -1188,6 +1194,7 @@
 				C9286408228584EB00257182 /* ImageProgressive.swift in Sources */,
 				D12AB6DD215D2BB50013BA68 /* ImageProcessor.swift in Sources */,
 				D12AB6D5215D2BB50013BA68 /* Image.swift in Sources */,
+				B567067A22E5C75E008A8979 /* NSTextAttachment+Kingfisher.swift in Sources */,
 				D12AB729215D2BB50013BA68 /* String+MD5.swift in Sources */,
 				4B8E2918216F3F7F0095FAD1 /* ImageDownloaderDelegate.swift in Sources */,
 				D12AB705215D2BB50013BA68 /* Kingfisher.swift in Sources */,
@@ -1287,6 +1294,7 @@
 				C9286407228584EB00257182 /* ImageProgressive.swift in Sources */,
 				D12AB6DC215D2BB50013BA68 /* ImageProcessor.swift in Sources */,
 				D12AB6D4215D2BB50013BA68 /* Image.swift in Sources */,
+				B567067922E5C75E008A8979 /* NSTextAttachment+Kingfisher.swift in Sources */,
 				D12AB728215D2BB50013BA68 /* String+MD5.swift in Sources */,
 				4B8E2917216F3F7F0095FAD1 /* ImageDownloaderDelegate.swift in Sources */,
 				D12AB704215D2BB50013BA68 /* Kingfisher.swift in Sources */,

--- a/Sources/Extensions/NSTextAttachment+Kingfisher.swift
+++ b/Sources/Extensions/NSTextAttachment+Kingfisher.swift
@@ -35,7 +35,7 @@ extension KingfisherWrapper where Base: NSTextAttachment {
 
     // MARK: Setting Image
 
-    /// Sets an image to the image view with a source.
+    /// Sets an image to the text attachment with a source.
     ///
     /// - Parameters:
     ///   - source: The `Source` object contains information about the image.
@@ -130,7 +130,7 @@ extension KingfisherWrapper where Base: NSTextAttachment {
         return task
     }
 
-    /// Sets an image to the image view with a requested resource.
+    /// Sets an image to the text attachment with a requested resource.
     ///
     /// - Parameters:
     ///   - resource: The `Resource` object contains information about the image.
@@ -165,7 +165,7 @@ extension KingfisherWrapper where Base: NSTextAttachment {
 
     // MARK: Cancelling Image
 
-    /// Cancel the image download task bounded to the image view if it is running.
+    /// Cancel the image download task bounded to the text attachment if it is running.
     /// Nothing will happen if the downloading has already finished.
     public func cancelDownloadTask() {
         imageTask?.cancel()
@@ -192,14 +192,5 @@ extension KingfisherWrapper where Base: NSTextAttachment {
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
         set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
-    }
-}
-
-extension KingfisherWrapper where Base: NSTextAttachment {
-    /// Gets the image URL bound to this image view.
-    @available(*, deprecated, message: "Use `taskIdentifier` instead to identify a setting task.")
-    public private(set) var webURL: URL? {
-        get { return nil }
-        set { }
     }
 }

--- a/Sources/Extensions/NSTextAttachment+Kingfisher.swift
+++ b/Sources/Extensions/NSTextAttachment+Kingfisher.swift
@@ -1,0 +1,205 @@
+//
+//  NSTextAttachment+Kingfisher.swift
+//  Kingfisher
+//
+//  Created by Benjamin Briggs on 22/07/2019.
+//
+//  Copyright (c) 2019 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+extension KingfisherWrapper where Base: NSTextAttachment {
+
+    // MARK: Setting Image
+
+    /// Sets an image to the image view with a source.
+    ///
+    /// - Parameters:
+    ///   - source: The `Source` object contains information about the image.
+    ///   - placeholder: A placeholder to show while retrieving the image from the given `resource`.
+    ///   - options: An options set to define image setting behaviors. See `KingfisherOptionsInfo` for more.
+    ///   - progressBlock: Called when the image downloading progress gets updated. If the response does not contain an
+    ///                    `expectedContentLength`, this block will not be called.
+    ///   - completionHandler: Called when the image retrieved and set finished.
+    /// - Returns: A task represents the image downloading.
+    ///
+    /// - Note:
+    ///
+    /// Internally, this method will use `KingfisherManager` to get the requested source
+    /// Since this method will perform UI changes, you must call it from the main thread.
+    /// Both `progressBlock` and `completionHandler` will be also executed in the main thread.
+    ///
+    @discardableResult
+    public func setImage(
+        with source: Source?,
+        placeholder: Image? = nil,
+        options: KingfisherOptionsInfo? = nil,
+        progressBlock: DownloadProgressBlock? = nil,
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
+    {
+        var mutatingSelf = self
+        guard let source = source else {
+            base.image = placeholder
+            mutatingSelf.taskIdentifier = nil
+            completionHandler?(.failure(KingfisherError.imageSettingError(reason: .emptySource)))
+            return nil
+        }
+
+        var options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions + (options ?? .empty))
+        if !options.keepCurrentImageWhileLoading {
+            base.image = placeholder
+        }
+
+        let issuedIdentifier = Source.Identifier.next()
+        mutatingSelf.taskIdentifier = issuedIdentifier
+
+        if let block = progressBlock {
+            options.onDataReceived = (options.onDataReceived ?? []) + [ImageLoadingProgressSideEffect(block)]
+        }
+
+        if let provider = ImageProgressiveProvider(options, refresh: { image in
+            self.base.image = image
+        }) {
+            options.onDataReceived = (options.onDataReceived ?? []) + [provider]
+        }
+
+        options.onDataReceived?.forEach {
+            $0.onShouldApply = { issuedIdentifier == self.taskIdentifier }
+        }
+
+        let task = KingfisherManager.shared.retrieveImage(
+            with: source,
+            options: options,
+            completionHandler: { result in
+                CallbackQueue.mainCurrentOrAsync.execute {
+                    guard issuedIdentifier == self.taskIdentifier else {
+                        let reason: KingfisherError.ImageSettingErrorReason
+                        do {
+                            let value = try result.get()
+                            reason = .notCurrentSourceTask(result: value, error: nil, source: source)
+                        } catch {
+                            reason = .notCurrentSourceTask(result: nil, error: error, source: source)
+                        }
+                        let error = KingfisherError.imageSettingError(reason: reason)
+                        completionHandler?(.failure(error))
+                        return
+                    }
+
+                    mutatingSelf.imageTask = nil
+                    mutatingSelf.taskIdentifier = nil
+
+                    switch result {
+                    case .success(let value):
+                        self.base.image = value.image
+                        completionHandler?(result)
+
+                    case .failure:
+                        if let image = options.onFailureImage {
+                            self.base.image = image
+                        }
+                        completionHandler?(result)
+                    }
+                }
+        }
+        )
+
+        mutatingSelf.imageTask = task
+        return task
+    }
+
+    /// Sets an image to the image view with a requested resource.
+    ///
+    /// - Parameters:
+    ///   - resource: The `Resource` object contains information about the image.
+    ///   - placeholder: A placeholder to show while retrieving the image from the given `resource`.
+    ///   - options: An options set to define image setting behaviors. See `KingfisherOptionsInfo` for more.
+    ///   - progressBlock: Called when the image downloading progress gets updated. If the response does not contain an
+    ///                    `expectedContentLength`, this block will not be called.
+    ///   - completionHandler: Called when the image retrieved and set finished.
+    /// - Returns: A task represents the image downloading.
+    ///
+    /// - Note:
+    ///
+    /// Internally, this method will use `KingfisherManager` to get the requested resource, from either cache
+    /// or network. Since this method will perform UI changes, you must call it from the main thread.
+    /// Both `progressBlock` and `completionHandler` will be also executed in the main thread.
+    ///
+    @discardableResult
+    public func setImage(
+        with resource: Resource?,
+        placeholder: Image? = nil,
+        options: KingfisherOptionsInfo? = nil,
+        progressBlock: DownloadProgressBlock? = nil,
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
+    {
+        return setImage(
+            with: resource.map { .network($0) },
+            placeholder: placeholder,
+            options: options,
+            progressBlock: progressBlock,
+            completionHandler: completionHandler)
+    }
+
+    // MARK: Cancelling Image
+
+    /// Cancel the image download task bounded to the image view if it is running.
+    /// Nothing will happen if the downloading has already finished.
+    public func cancelDownloadTask() {
+        imageTask?.cancel()
+    }
+}
+
+private var taskIdentifierKey: Void?
+private var imageTaskKey: Void?
+
+// MARK: Properties
+extension KingfisherWrapper where Base: NSTextAttachment {
+
+    public private(set) var taskIdentifier: Source.Identifier.Value? {
+        get {
+            let box: Box<Source.Identifier.Value>? = getAssociatedObject(base, &taskIdentifierKey)
+            return box?.value
+        }
+        set {
+            let box = newValue.map { Box($0) }
+            setRetainedAssociatedObject(base, &taskIdentifierKey, box)
+        }
+    }
+
+    private var imageTask: DownloadTask? {
+        get { return getAssociatedObject(base, &imageTaskKey) }
+        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+    }
+}
+
+extension KingfisherWrapper where Base: NSTextAttachment {
+    /// Gets the image URL bound to this image view.
+    @available(*, deprecated, message: "Use `taskIdentifier` instead to identify a setting task.")
+    public private(set) var webURL: URL? {
+        get { return nil }
+        set { }
+    }
+}

--- a/Sources/General/Kingfisher.swift
+++ b/Sources/General/Kingfisher.swift
@@ -84,6 +84,7 @@ extension Image: KingfisherCompatible { }
 #if !os(watchOS)
 extension ImageView: KingfisherCompatible { }
 extension Button: KingfisherCompatible { }
+extension NSTextAttachment: KingfisherCompatible { }
 #else
 extension WKInterfaceImage: KingfisherCompatible { }
 #endif


### PR DESCRIPTION
This will allow using Kingfisher on NSTextAttachment in an attributed label. I've followed the same format for other extensions that add compliance for KingfisherCompatible.

We can now add a image to a label using Kingfishers cache like this
```
// Create a label
let label = UILabel()

// Create a attributed string
let attributedText = NSMutableAttributedString(string: "some string")

// Create the text attachment
let textAttachment = NSTextAttachment()

// Set the size of the attachment
let capHeight = label?.font.capHeight ?? 0
textAttachment.bounds = CGRect(x: 0, y: -1, width: capHeight + 2, height: capHeight + 2)

// Request the image from Kingfisher
textAttachment.kf.setImage(with: url)

// Add the text attachment to the beging of the text attributedText
attributedText.replaceCharacters(in: NSRange(), with: NSAttributedString(attachment: textAttachment))

// set the attributedText on the label
label.attributedText = attributedText
```
