### PR TITLE
subclassing fix for ImageDownloader

### DIFF
--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -193,8 +193,17 @@ open class ImageDownloader {
         }
     }
 
+    // MARK: Dowloading Task
+    /// Downloads an image with a URL and option. Invoked internally by Kingfisher. Subclasses must invoke super.
+    ///
+    /// - Parameters:
+    ///   - url: Target URL.
+    ///   - options: The options could control download behavior. See `KingfisherOptionsInfo`.
+    ///   - completionHandler: Called when the download progress finishes. This block will be called in the queue
+    ///                        defined in `.callbackQueue` in `options` parameter.
+    /// - Returns: A downloading task. You could call `cancel` on it to stop the download task.
     @discardableResult
-    func downloadImage(
+    open func downloadImage(
         with url: URL,
         options: KingfisherParsedOptionsInfo,
         completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
@@ -312,7 +321,6 @@ open class ImageDownloader {
         return downloadTask
     }
 
-    // MARK: Dowloading Task
     /// Downloads an image with a URL and option.
     ///
     /// - Parameters:


### PR DESCRIPTION
The `open` variant of `downloadImage(...)` is never called by Kingfisher while the `internal` one is. This removes the legacy variant and allows for subclassing of the modern one.

Open to ideas to retain the `deprecated` `downloadImage(...)` method.