### PR TITLE
Avoid memory shortage when memory is not released in time when a larg…

### DIFF
--- a/Sources/Cache/FormatIndicatedCacheSerializer.swift
+++ b/Sources/Cache/FormatIndicatedCacheSerializer.swift
@@ -72,11 +72,13 @@ public struct FormatIndicatedCacheSerializer: CacheSerializer {
     public func data(with image: Image, original: Data?) -> Data? {
         
         func imageData(withFormat imageFormat: ImageFormat) -> Data? {
-            switch imageFormat {
-            case .PNG: return image.kf.pngRepresentation()
-            case .JPEG: return image.kf.jpegRepresentation(compressionQuality: 1.0)
-            case .GIF: return image.kf.gifRepresentation()
-            case .unknown: return nil
+            return autoreleasepool { () -> Data? in
+                switch imageFormat {
+                case .PNG: return image.kf.pngRepresentation()
+                case .JPEG: return image.kf.jpegRepresentation(compressionQuality: 1.0)
+                case .GIF: return image.kf.gifRepresentation()
+                case .unknown: return nil
+                }
             }
         }
         

--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -235,15 +235,17 @@ extension KingfisherWrapper where Base: Image {
     ///                     converted in the PNG representation.
     /// - Returns: The output data representing.
     public func data(format: ImageFormat) -> Data? {
-        let data: Data?
-        switch format {
-        case .PNG: data = pngRepresentation()
-        case .JPEG: data = jpegRepresentation(compressionQuality: 1.0)
-        case .GIF: data = gifRepresentation()
-        case .unknown: data = normalized.kf.pngRepresentation()
+        return autoreleasepool { () -> Data? in
+            let data: Data?
+            switch format {
+            case .PNG: data = pngRepresentation()
+            case .JPEG: data = jpegRepresentation(compressionQuality: 1.0)
+            case .GIF: data = gifRepresentation()
+            case .unknown: data = normalized.kf.pngRepresentation()
+            }
+            
+            return data
         }
-
-        return data
     }
 }
 


### PR DESCRIPTION
When a large number of network images are loaded in a short time, there is not enough memory. When the images are serialized, the memory is not released in time.