### PR TITLE
Remove black border from KFImage

### DIFF
--- a/Sources/SwiftUI/KFImage.swift
+++ b/Sources/SwiftUI/KFImage.swift
@@ -96,7 +96,6 @@ public struct KFImage: View {
                     }
                 }
                 .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
-                .border(Color.black)
                 .onDisappear { [unowned binder = self.binder] in
                     if self.cancelOnDisappear { binder.cancel() }
                 }


### PR DESCRIPTION
This removes the border around KFImage. Here's an example of the issues the border causes
<img width="113" alt="Screen Shot 2019-09-26 at 4 35 39 pm" src="https://user-images.githubusercontent.com/2393781/65664396-96ad0a00-e07c-11e9-8962-8fa1f8247e3b.png">
