### PR TITLE
Use `|>` for better precedence

### DIFF
--- a/Sources/Image/Filter.swift
+++ b/Sources/Image/Filter.swift
@@ -55,7 +55,7 @@ extension CIImageProcessor {
         case .image(let image):
             return image.kf.apply(filter)
         case .data:
-            return (DefaultImageProcessor.default >> self).process(item: item, options: options)
+            return (DefaultImageProcessor.default |> self).process(item: item, options: options)
         }
     }
 }

--- a/Sources/Image/ImageProcessor.swift
+++ b/Sources/Image/ImageProcessor.swift
@@ -262,7 +262,7 @@ public struct BlendImageProcessor: ImageProcessor {
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.image(withBlendMode: blendMode, alpha: alpha, backgroundColor: backgroundColor)
         case .data:
-            return (DefaultImageProcessor.default >> self).process(item: item, options: options)
+            return (DefaultImageProcessor.default |> self).process(item: item, options: options)
         }
     }
 }
@@ -414,7 +414,7 @@ public struct RoundCornerImageProcessor: ImageProcessor {
                             roundingCorners: roundingCorners,
                             backgroundColor: backgroundColor)
         case .data:
-            return (DefaultImageProcessor.default >> self).process(item: item, options: options)
+            return (DefaultImageProcessor.default |> self).process(item: item, options: options)
         }
     }
 }
@@ -494,7 +494,7 @@ public struct ResizingImageProcessor: ImageProcessor {
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.resize(to: referenceSize, for: targetContentMode)
         case .data:
-            return (DefaultImageProcessor.default >> self).process(item: item, options: options)
+            return (DefaultImageProcessor.default |> self).process(item: item, options: options)
         }
     }
 }
@@ -533,7 +533,7 @@ public struct BlurImageProcessor: ImageProcessor {
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.blurred(withRadius: radius)
         case .data:
-            return (DefaultImageProcessor.default >> self).process(item: item, options: options)
+            return (DefaultImageProcessor.default |> self).process(item: item, options: options)
         }
     }
 }
@@ -576,7 +576,7 @@ public struct OverlayImageProcessor: ImageProcessor {
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.overlaying(with: overlay, fraction: fraction)
         case .data:
-            return (DefaultImageProcessor.default >> self).process(item: item, options: options)
+            return (DefaultImageProcessor.default |> self).process(item: item, options: options)
         }
     }
 }
@@ -613,7 +613,7 @@ public struct TintImageProcessor: ImageProcessor {
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.tinted(with: tint)
         case .data:
-            return (DefaultImageProcessor.default >> self).process(item: item, options: options)
+            return (DefaultImageProcessor.default |> self).process(item: item, options: options)
         }
     }
 }
@@ -667,7 +667,7 @@ public struct ColorControlsProcessor: ImageProcessor {
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.adjusted(brightness: brightness, contrast: contrast, saturation: saturation, inputEV: inputEV)
         case .data:
-            return (DefaultImageProcessor.default >> self).process(item: item, options: options)
+            return (DefaultImageProcessor.default |> self).process(item: item, options: options)
         }
     }
 }
@@ -752,7 +752,7 @@ public struct CroppingImageProcessor: ImageProcessor {
         case .image(let image):
             return image.kf.scaled(to: options.scaleFactor)
                         .kf.crop(to: size, anchorOn: anchor)
-        case .data: return (DefaultImageProcessor.default >> self).process(item: item, options: options)
+        case .data: return (DefaultImageProcessor.default |> self).process(item: item, options: options)
         }
     }
 }
@@ -808,7 +808,15 @@ public struct DownsamplingImageProcessor: ImageProcessor {
 ///   - left: The first processor.
 ///   - right: The second processor.
 /// - Returns: The concatenated processor.
+@available(*, deprecated,
+message: "Will be removed soon. Use `|>` instead.",
+renamed: "|>")
 public func >>(left: ImageProcessor, right: ImageProcessor) -> ImageProcessor {
+    return left.append(another: right)
+}
+
+infix operator |>: AdditionPrecedence
+public func |>(left: ImageProcessor, right: ImageProcessor) -> ImageProcessor {
     return left.append(another: right)
 }
 

--- a/Tests/KingfisherTests/ImageProcessorTests.swift
+++ b/Tests/KingfisherTests/ImageProcessorTests.swift
@@ -45,4 +45,16 @@ class ImageProcessorTests: XCTestCase {
         XCTAssertEqual(resultFromImage!.size, CGSize(width: 40, height: 40))
 
     }
+
+    func testProcessorConcating() {
+        let p1 = BlurImageProcessor(blurRadius: 10)
+        let p2 = RoundCornerImageProcessor(cornerRadius: 10)
+        let p3 = TintImageProcessor(tint: .blue)
+
+        let two = p1 |> p2
+        let three = p1 |> p2 |> p3
+
+        XCTAssertNotNil(two)
+        XCTAssertNotNil(three)
+    }
 }


### PR DESCRIPTION
This fixes #1319 