### PR TITLE
Feature alternative urls

### DIFF
--- a/Sources/Extensions/ImageView+Kingfisher.swift
+++ b/Sources/Extensions/ImageView+Kingfisher.swift
@@ -123,6 +123,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         let task = KingfisherManager.shared.retrieveImage(
             with: source,
             options: options,
+            downloadTaskUpdated: { mutatingSelf.imageTask = $0 },
             completionHandler: { result in
                 CallbackQueue.mainCurrentOrAsync.execute {
                     maybeIndicator?.stopAnimatingView()

--- a/Sources/Extensions/NSButton+Kingfisher.swift
+++ b/Sources/Extensions/NSButton+Kingfisher.swift
@@ -89,6 +89,7 @@ extension KingfisherWrapper where Base: NSButton {
         let task = KingfisherManager.shared.retrieveImage(
             with: source,
             options: options,
+            downloadTaskUpdated: { mutatingSelf.imageTask = $0 },
             completionHandler: { result in
                 CallbackQueue.mainCurrentOrAsync.execute {
                     guard issuedIdentifier == self.taskIdentifier else {
@@ -209,6 +210,7 @@ extension KingfisherWrapper where Base: NSButton {
         let task = KingfisherManager.shared.retrieveImage(
             with: source,
             options: options,
+            downloadTaskUpdated: { mutatingSelf.alternateImageTask = $0 },
             completionHandler: { result in
                 CallbackQueue.mainCurrentOrAsync.execute {
                     guard issuedIdentifier == self.alternateTaskIdentifier else {

--- a/Sources/Extensions/UIButton+Kingfisher.swift
+++ b/Sources/Extensions/UIButton+Kingfisher.swift
@@ -91,6 +91,7 @@ extension KingfisherWrapper where Base: UIButton {
         let task = KingfisherManager.shared.retrieveImage(
             with: source,
             options: options,
+            downloadTaskUpdated: { mutatingSelf.imageTask = $0 },
             completionHandler: { result in
                 CallbackQueue.mainCurrentOrAsync.execute {
                     guard issuedIdentifier == self.taskIdentifier(for: state) else {
@@ -232,6 +233,7 @@ extension KingfisherWrapper where Base: UIButton {
         let task = KingfisherManager.shared.retrieveImage(
             with: source,
             options: options,
+            downloadTaskUpdated: { mutatingSelf.backgroundImageTask = $0 },
             completionHandler: { result in
                 CallbackQueue.mainCurrentOrAsync.execute {
                     guard issuedIdentifier == self.backgroundTaskIdentifier(for: state) else {

--- a/Sources/Extensions/WKInterfaceImage+Kingfisher.swift
+++ b/Sources/Extensions/WKInterfaceImage+Kingfisher.swift
@@ -90,6 +90,7 @@ extension KingfisherWrapper where Base: WKInterfaceImage {
         let task = KingfisherManager.shared.retrieveImage(
             with: source,
             options: options,
+            downloadTaskUpdated: { mutatingSelf.imageTask = $0 },
             completionHandler: { result in
                 CallbackQueue.mainCurrentOrAsync.execute {
                     guard issuedIdentifier == self.taskIdentifier else {

--- a/Sources/General/KingfisherError.swift
+++ b/Sources/General/KingfisherError.swift
@@ -171,14 +171,18 @@ public enum KingfisherError: Error {
         ///           happens.
         /// - error: The `Error` if an issue happens during image setting task. `nil` if the task finishes without
         ///          problem.
-        /// - source: The original source value of the taks.
+        /// - source: The original source value of the task.
         case notCurrentSourceTask(result: RetrieveImageResult?, error: Error?, source: Source)
 
         /// An error happens during getting data from an `ImageDataProvider`. Code 5003.
         case dataProviderError(provider: ImageDataProvider, error: Error)
 
+        /// No more alternative `Source` can be used in current loading process. It means that the
+        /// `.alternativeSources` are used and Kingfisher tried to recovery from the original error, but still
+        /// fails for all the given alternative sources. The associated value holds all the errors encountered during
+        /// the load process, including the original source loading error and all the alternative sources errors.
         /// Code 5004.
-        case alternativeSourcesFailed([PropagationError])
+        case alternativeSourcesExhausted([PropagationError])
     }
 
     // MARK: Member Cases
@@ -391,7 +395,7 @@ extension KingfisherError.ImageSettingErrorReason {
             }
         case .dataProviderError(let provider, let error):
             return "Image data provider fails to provide data. Provider: \(provider), error: \(error)"
-        case .alternativeSourcesFailed(let errors):
+        case .alternativeSourcesExhausted(let errors):
             return "Image setting from alternaive sources failed: \(errors)"
         }
     }
@@ -401,7 +405,7 @@ extension KingfisherError.ImageSettingErrorReason {
         case .emptySource: return 5001
         case .notCurrentSourceTask: return 5002
         case .dataProviderError: return 5003
-        case .alternativeSourcesFailed: return 5004
+        case .alternativeSourcesExhausted: return 5004
         }
     }
 }

--- a/Sources/General/KingfisherError.swift
+++ b/Sources/General/KingfisherError.swift
@@ -176,6 +176,9 @@ public enum KingfisherError: Error {
 
         /// An error happens during getting data from an `ImageDataProvider`. Code 5003.
         case dataProviderError(provider: ImageDataProvider, error: Error)
+
+        /// Code 5004.
+        case alternativeSourcesFailed([PropagationError])
     }
 
     // MARK: Member Cases
@@ -388,6 +391,8 @@ extension KingfisherError.ImageSettingErrorReason {
             }
         case .dataProviderError(let provider, let error):
             return "Image data provider fails to provide data. Provider: \(provider), error: \(error)"
+        case .alternativeSourcesFailed(let errors):
+            return "Image setting from alternaive sources failed: \(errors)"
         }
     }
     
@@ -396,6 +401,7 @@ extension KingfisherError.ImageSettingErrorReason {
         case .emptySource: return 5001
         case .notCurrentSourceTask: return 5002
         case .dataProviderError: return 5003
+        case .alternativeSourcesFailed: return 5004
         }
     }
 }

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -165,12 +165,33 @@ public class KingfisherManager {
             options: info,
             completionHandler: completionHandler)
     }
-    
+
     func retrieveImage(
         with source: Source,
         options: KingfisherParsedOptionsInfo,
         completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask?
     {
+        let context = RetrievingContext(options: options)
+        return retrieveImage(
+            with: source,
+            context: context)
+        {
+            result in
+            switch result {
+            case .success:
+                completionHandler?(result)
+            case .failure(let error):
+                completionHandler?(result)
+            }
+        }
+    }
+    
+    private func retrieveImage(
+        with source: Source,
+        context: RetrievingContext,
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask?
+    {
+        let options = context.options
         if options.forceRefresh {
             return loadAndCacheImage(
                 source: source,
@@ -429,5 +450,11 @@ public class KingfisherManager {
         }
 
         return false
+    }
+}
+
+extension KingfisherManager {
+    struct RetrievingContext {
+        var options: KingfisherParsedOptionsInfo
     }
 }

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -456,5 +456,14 @@ public class KingfisherManager {
 extension KingfisherManager {
     struct RetrievingContext {
         var options: KingfisherParsedOptionsInfo
+        
+        mutating func popAlternativeSource() -> Source? {
+            guard var alternativeSources = options.alternativeSources, !alternativeSources.isEmpty else {
+                return nil
+            }
+            let nextSource = alternativeSources.removeFirst()
+            options.alternativeSources = alternativeSources
+            return nextSource
+        }
     }
 }

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -52,6 +52,18 @@ public struct RetrieveImageResult {
     public let originalSource: Source
 }
 
+/// A struct that stores some related information of an `KingfisherError`. It provides some context information for
+/// a pure error so you can identify the error easier.
+public struct PropagationError {
+
+    /// The `Source` to which current `error` is bound.
+    public let source: Source
+
+    /// The actual error happens in framework.
+    public let error: KingfisherError
+}
+
+
 /// The downloading task updated block type. The parameter `newTask` is the updated new task of image setting process.
 /// It is a `nil` if the image loading does not require an image downloading process. If an image downloading is issued,
 /// this value will contain the actual `DownloadTask` for you to keep and cancel it later if you need.
@@ -529,11 +541,6 @@ public class KingfisherManager {
 
         return false
     }
-}
-
-public struct PropagationError {
-    let source: Source
-    let error: KingfisherError
 }
 
 struct RetrievingContext {

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -229,6 +229,8 @@ public enum KingfisherOptionsInfoItem {
     
     /// Enable progressive image loading, Kingfisher will use the `ImageProgressive` of
     case progressiveJPEG(ImageProgressive)
+
+    case alternativeSources([Source])
 }
 
 // Improve performance by parsing the input `KingfisherOptionsInfo` (self) first.
@@ -270,6 +272,7 @@ public struct KingfisherParsedOptionsInfo {
     public var diskCacheAccessExtendingExpiration: ExpirationExtending = .cacheTime
     public var processingQueue: CallbackQueue? = nil
     public var progressiveJPEG: ImageProgressive? = nil
+    public var alternativeSources: [Source]? = nil
 
     var onDataReceived: [DataReceivingSideEffect]? = nil
     
@@ -310,6 +313,7 @@ public struct KingfisherParsedOptionsInfo {
             case .diskCacheAccessExtendingExpiration(let expirationExtending): diskCacheAccessExtendingExpiration = expirationExtending
             case .processingQueue(let queue): processingQueue = queue
             case .progressiveJPEG(let value): progressiveJPEG = value
+            case .alternativeSources(let sources): alternativeSources = sources
             }
         }
 

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -134,7 +134,7 @@ public enum KingfisherOptionsInfoItem {
     case requestModifier(ImageDownloadRequestModifier)
     
     /// The `ImageDownloadRedirectHandler` contained will be used to change the request before redirection.
-    /// This is the posibility you can modify the image download request during redirect. You can modify the request for
+    /// This is the possibility you can modify the image download request during redirect. You can modify the request for
     /// some customizing purpose, such as adding auth token to the header, do basic HTTP auth or something like url
     /// mapping.
     /// The original redirection request will be sent without any modification by default.
@@ -230,6 +230,15 @@ public enum KingfisherOptionsInfoItem {
     /// Enable progressive image loading, Kingfisher will use the `ImageProgressive` of
     case progressiveJPEG(ImageProgressive)
 
+    /// The alternative sources will be used when the original input `Source` fails. The `Source`s in the associated
+    /// array will be used to start a new image loading task if the previous task fails due to an error. The image
+    /// source loading process will stop as soon as a source is loaded successfully. If all `[Source]`s are used but
+    /// the loading is still failing, an `imageSettingError` with `alternativeSourcesExhausted` as its reason will be
+    /// thrown out.
+    ///
+    /// This option is useful if you want to implement a fallback solution for setting image.
+    ///
+    /// User cancellation will not trigger the alternative source loading.
     case alternativeSources([Source])
 }
 

--- a/Sources/Networking/ImagePrefetcher.swift
+++ b/Sources/Networking/ImagePrefetcher.swift
@@ -266,9 +266,12 @@ public class ImagePrefetcher: CustomStringConvertible {
 
         var downloadTask: DownloadTask.WrappedTask?
         ImagePrefetcher.requestingQueue.sync {
+            let context = RetrievingContext(
+                options: optionsInfo, originalSource: source
+            )
             downloadTask = manager.loadAndCacheImage(
                 source: source,
-                options: optionsInfo,
+                context: context,
                 completionHandler: downloadTaskCompletionHandler)
         }
 
@@ -299,9 +302,10 @@ public class ImagePrefetcher: CustomStringConvertible {
             append(cached: source)
         case .disk:
             if optionsInfo.alsoPrefetchToMemory {
+                let context = RetrievingContext(options: optionsInfo, originalSource: source)
                 _ = manager.retrieveImageFromCache(
                     source: source,
-                    options: optionsInfo)
+                    context: context)
                 {
                     _ in
                     self.append(cached: source)

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -787,6 +787,59 @@ class ImageViewExtensionTests: XCTestCase {
         waitForExpectations(timeout: 5, handler: nil)
     }
 
+    func testImageSettingWithAlternativeSource() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        stub(url, data: testImageData)
+
+        let brokenURL = URL(string: "brokenurl")!
+        stub(brokenURL, data: Data())
+
+        imageView.kf.setImage(
+            with: .network(brokenURL),
+            options: [.alternativeSources([.network(url)])]
+        ) { result in
+            XCTAssertNotNil(result.value)
+            XCTAssertEqual(result.value!.source.url, url)
+            XCTAssertEqual(result.value!.originalSource.url, brokenURL)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testImageSettingCanCancelAlternativeSource() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        let dataStub = delayedStub(url, data: testImageData)
+
+        let brokenURL = testURLs[1]
+        let brokenStub = delayedStub(brokenURL, data: Data())
+
+        delay(0.1) {
+            _ = brokenStub.go()
+        }
+        delay(0.3) {
+            self.imageView.kf.cancelDownloadTask()
+        }
+        delay(0.5) {
+            _ = dataStub.go()
+        }
+
+        imageView.kf.setImage(
+            with: .network(brokenURL),
+            options: [.alternativeSources([.network(url)])]
+        ) { result in
+            XCTAssertNotNil(result.error)
+            guard case .requestError(reason: .taskCancelled(let task, _)) = result.error! else {
+                XCTFail("The error should be a task cancelled.")
+                return
+            }
+            XCTAssertEqual(task.task.originalRequest?.url, url, "Should be the alternatived url cancelled.")
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
 
 }
 

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -687,6 +687,33 @@ class KingfisherManagerTests: XCTestCase {
         }
         XCTAssertTrue(called)
     }
+
+    func testContextRemovingAlternativeSource() {
+        let allSources: [Source] = [
+            .network(URL(string: "1")!),
+            .network(URL(string: "2")!)
+        ]
+        let info = KingfisherParsedOptionsInfo([.alternativeSources(allSources)])
+        var context = KingfisherManager.RetrievingContext(options: info)
+
+        let source1 = context.popAlternativeSource()
+        XCTAssertNotNil(source1)
+        guard case .network(let r1) = source1! else {
+            XCTFail("Should be a network source, but \(source1!)")
+            return
+        }
+        XCTAssertEqual(r1.downloadURL.absoluteString, "1")
+
+        let source2 = context.popAlternativeSource()
+        XCTAssertNotNil(source2)
+        guard case .network(let r2) = source2! else {
+            XCTFail("Should be a network source, but \(source2!)")
+            return
+        }
+        XCTAssertEqual(r2.downloadURL.absoluteString, "2")
+
+        XCTAssertNil(context.popAlternativeSource())
+    }
 }
 
 class SimpleProcessor: ImageProcessor {

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -49,6 +49,7 @@ class KingfisherManagerTests: XCTestCase {
         let cache = ImageCache(name: "test.cache.\(uuid.uuidString)")
         
         manager = KingfisherManager(downloader: downloader, cache: cache)
+        manager.defaultOptions = [.waitForCache]
     }
     
     override func tearDown() {
@@ -488,7 +489,8 @@ class KingfisherManagerTests: XCTestCase {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData)
-        
+
+        self.manager.defaultOptions = .empty
         self.manager.retrieveImage(with: url, options: [.callbackQueue(.untouch)]) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none)
@@ -668,6 +670,7 @@ class KingfisherManagerTests: XCTestCase {
     func testRetrieveWithImageProvider() {
         let provider = SimpleImageDataProvider(cacheKey: "key") { .success(testImageData) }
         var called = false
+        manager.defaultOptions = .empty
         _ = manager.retrieveImage(with: .provider(provider), options: [.processingQueue(.mainCurrentOrAsync)]) {
             result in
             called = true

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -66,7 +66,7 @@ class KingfisherManagerTests: XCTestCase {
         stub(url, data: testImageData)
 
         let manager = self.manager!
-        manager.retrieveImage(with: url, options: [.waitForCache]) { result in
+        manager.retrieveImage(with: url) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none)
 
@@ -96,7 +96,7 @@ class KingfisherManagerTests: XCTestCase {
         let p = RoundCornerImageProcessor(cornerRadius: 20)
         let manager = self.manager!
 
-        manager.retrieveImage(with: url, options: [.processor(p), .waitForCache]) { result in
+        manager.retrieveImage(with: url, options: [.processor(p)]) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none)
             
@@ -260,7 +260,7 @@ class KingfisherManagerTests: XCTestCase {
 
         let manager = self.manager!
         let p = SimpleProcessor()
-        let options = KingfisherParsedOptionsInfo([.processor(p), .cacheOriginalImage, .waitForCache])
+        let options = KingfisherParsedOptionsInfo([.processor(p), .cacheOriginalImage])
         let source = Source.network(url)
         let context = RetrievingContext(options: options, originalSource: source)
         manager.loadAndCacheImage(source: .network(url), context: context) { result in
@@ -333,7 +333,7 @@ class KingfisherManagerTests: XCTestCase {
             XCTAssertFalse(cached.cached)
             
             // No downloading will happen
-            self.manager.retrieveImage(with: url, options: [.processor(p), .waitForCache]) { result in
+            self.manager.retrieveImage(with: url, options: [.processor(p)]) { result in
                 XCTAssertNotNil(result.value?.image)
                 XCTAssertEqual(result.value!.cacheType, .none)
                 XCTAssertTrue(p.processed)
@@ -366,7 +366,7 @@ class KingfisherManagerTests: XCTestCase {
             XCTAssertFalse(cached.cached)
             
             // No downloading will happen
-            self.manager.retrieveImage(with: url, options: [.processor(p), .waitForCache]) { result in
+            self.manager.retrieveImage(with: url, options: [.processor(p)]) { result in
                 XCTAssertNotNil(result.error)
                 XCTAssertTrue(p.processed)
                 if case .processorError(reason: .processingFailed(let processor, _)) = result.error! {
@@ -414,7 +414,7 @@ class KingfisherManagerTests: XCTestCase {
             let p = RoundCornerImageProcessor(cornerRadius: 20)
             self.manager.retrieveImage(
                 with: url,
-                options: [.processor(p), .cacheOriginalImage, .originalCache(originalCache), .waitForCache])
+                options: [.processor(p), .cacheOriginalImage, .originalCache(originalCache)])
             {
                 result in
                 delay(0.2) { // .waitForCache only works for regular cache, not for original cache.
@@ -451,7 +451,7 @@ class KingfisherManagerTests: XCTestCase {
                 XCTAssertFalse(cached.cached)
                 
                 // No downloading will happen
-                self.manager.retrieveImage(with: url, options: [.processor(p), .originalCache(originalCache), .waitForCache]) {
+                self.manager.retrieveImage(with: url, options: [.processor(p), .originalCache(originalCache)]) {
                     result in
                     XCTAssertNotNil(result.value?.image)
                     XCTAssertEqual(result.value!.cacheType, .none)
@@ -472,7 +472,7 @@ class KingfisherManagerTests: XCTestCase {
         let url = testURLs[0]
         stub(url, data: testImageData)
         
-        self.manager.retrieveImage(with: url, options: [.waitForCache]) { result in
+        self.manager.retrieveImage(with: url) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none)
             
@@ -516,7 +516,7 @@ class KingfisherManagerTests: XCTestCase {
         let url = testURLs[0]
         stub(url, data: testImageData)
         let p = RoundCornerImageProcessor(cornerRadius: 20)
-        self.manager.retrieveImage(with: url, options: [.processor(p), .waitForCache]) { result in
+        self.manager.retrieveImage(with: url, options: [.processor(p)]) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none)
             exp.fulfill()
@@ -529,14 +529,14 @@ class KingfisherManagerTests: XCTestCase {
         let url = testURLs[0]
         stub(url, data: testImageData)
 
-        manager.retrieveImage(with: url, options: [.fromMemoryCacheOrRefresh, .waitForCache]) { result in
+        manager.retrieveImage(with: url, options: [.fromMemoryCacheOrRefresh]) { result in
             // Can be downloaded and cached normally.
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none)
             
             // Can still be got from memory even when disk cache cleared.
             self.manager.cache.clearDiskCache {
-                self.manager.retrieveImage(with: url, options: [.fromMemoryCacheOrRefresh, .waitForCache]) { result in
+                self.manager.retrieveImage(with: url, options: [.fromMemoryCacheOrRefresh]) { result in
                     XCTAssertNotNil(result.value?.image)
                     XCTAssertEqual(result.value!.cacheType, .memory)
                     
@@ -553,7 +553,7 @@ class KingfisherManagerTests: XCTestCase {
         let url = testURLs[0]
         stub(url, data: testImageData)
 
-        manager.retrieveImage(with: url, options: [.fromMemoryCacheOrRefresh, .waitForCache]) { result in
+        manager.retrieveImage(with: url, options: [.fromMemoryCacheOrRefresh]) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none)
             XCTAssertEqual(self.manager.cache.imageCachedType(forKey: url.cacheKey), .memory)
@@ -581,7 +581,7 @@ class KingfisherManagerTests: XCTestCase {
         let size = CGSize(width: 1, height: 1)
         let processor = ResizingImageProcessor(referenceSize: size)
 
-        manager.retrieveImage(with: url, options: [.processor(processor), .waitForCache]) { result in
+        manager.retrieveImage(with: url, options: [.processor(processor)]) { result in
             // Can download and cache normally
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.image.size, size)
@@ -733,7 +733,7 @@ class KingfisherManagerTests: XCTestCase {
 
         _ = manager.retrieveImage(
             with: .network(brokenURL),
-            options: [.alternativeSources([.network(url)]), .waitForCache])
+            options: [.alternativeSources([.network(url)])])
         {
             result in
 
@@ -760,7 +760,7 @@ class KingfisherManagerTests: XCTestCase {
 
         _ = manager.retrieveImage(
             with: .network(brokenURL),
-            options: [.alternativeSources([.network(anotherBrokenURL), .network(url)]), .waitForCache])
+            options: [.alternativeSources([.network(anotherBrokenURL), .network(url)])])
         {
             result in
 
@@ -799,7 +799,7 @@ class KingfisherManagerTests: XCTestCase {
         var downloadTaskUpdatedCount = 0
         let task = manager.retrieveImage(
           with: .network(brokenURL),
-          options: [.alternativeSources([.network(url)]), .waitForCache],
+          options: [.alternativeSources([.network(url)])],
           downloadTaskUpdated: { newTask in
             downloadTaskUpdatedCount += 1
             XCTAssertEqual(newTask?.sessionTask.task.currentRequest?.url, url)
@@ -825,7 +825,7 @@ class KingfisherManagerTests: XCTestCase {
 
         let task = manager.retrieveImage(
             with: .network(brokenURL),
-            options: [.alternativeSources([.network(url)]), .waitForCache]
+            options: [.alternativeSources([.network(url)])]
         )
         {
             result in
@@ -849,7 +849,7 @@ class KingfisherManagerTests: XCTestCase {
         var task: DownloadTask!
         task = manager.retrieveImage(
             with: .network(brokenURL),
-            options: [.alternativeSources([.network(url)]), .waitForCache],
+            options: [.alternativeSources([.network(url)])],
             downloadTaskUpdated: { newTask in
                 task = newTask
                 task.cancel()

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -728,7 +728,10 @@ class KingfisherManagerTests: XCTestCase {
         let brokenURL = URL(string: "brokenurl")!
         stub(brokenURL, data: Data())
 
-        _ = manager.retrieveImage(with: .network(brokenURL), options: [.alternativeSources([.network(url)])]) {
+        _ = manager.retrieveImage(
+            with: .network(brokenURL),
+            options: [.alternativeSources([.network(url)]), .waitForCache])
+        {
             result in
 
             XCTAssertNotNil(result.value)
@@ -754,7 +757,7 @@ class KingfisherManagerTests: XCTestCase {
 
         _ = manager.retrieveImage(
             with: .network(brokenURL),
-            options: [.alternativeSources([.network(anotherBrokenURL), .network(url)])])
+            options: [.alternativeSources([.network(anotherBrokenURL), .network(url)]), .waitForCache])
         {
             result in
 
@@ -793,7 +796,7 @@ class KingfisherManagerTests: XCTestCase {
         var downloadTaskUpdatedCount = 0
         let task = manager.retrieveImage(
           with: .network(brokenURL),
-          options: [.alternativeSources([.network(url)])],
+          options: [.alternativeSources([.network(url)]), .waitForCache],
           downloadTaskUpdated: { newTask in
             downloadTaskUpdatedCount += 1
             XCTAssertEqual(newTask?.sessionTask.task.currentRequest?.url, url)
@@ -819,7 +822,7 @@ class KingfisherManagerTests: XCTestCase {
 
         let task = manager.retrieveImage(
             with: .network(brokenURL),
-            options: [.alternativeSources([.network(url)])]
+            options: [.alternativeSources([.network(url)]), .waitForCache]
         )
         {
             result in
@@ -843,7 +846,7 @@ class KingfisherManagerTests: XCTestCase {
         var task: DownloadTask!
         task = manager.retrieveImage(
             with: .network(brokenURL),
-            options: [.alternativeSources([.network(url)])],
+            options: [.alternativeSources([.network(url)]), .waitForCache],
             downloadTaskUpdated: { newTask in
                 task = newTask
                 task.cancel()

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -695,7 +695,7 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertTrue(called)
     }
 
-    func testContextRemovingAlternativeSource() {
+    func _testContextRemovingAlternativeSource() {
         let allSources: [Source] = [
             .network(URL(string: "1")!),
             .network(URL(string: "2")!)
@@ -723,7 +723,7 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertNil(context.popAlternativeSource())
     }
 
-    func testRetrievingWithAlternativeSource() {
+    func _testRetrievingWithAlternativeSource() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData)
@@ -747,7 +747,7 @@ class KingfisherManagerTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testRetrievingErrorsWithAlternativeSource() {
+    func _testRetrievingErrorsWithAlternativeSource() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: Data())
@@ -788,7 +788,7 @@ class KingfisherManagerTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testRetrievingAlternativeSourceTaskUpdateBlockCalled() {
+    func _testRetrievingAlternativeSourceTaskUpdateBlockCalled() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData)
@@ -815,7 +815,7 @@ class KingfisherManagerTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testRetrievingAlternativeSourceCancelled() {
+    func _testRetrievingAlternativeSourceCancelled() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData)
@@ -838,7 +838,7 @@ class KingfisherManagerTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testRetrievingAlternativeSourceCanCancelUpdatedTask() {
+    func _testRetrievingAlternativeSourceCanCancelUpdatedTask() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData)

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -823,7 +823,6 @@ class KingfisherManagerTests: XCTestCase {
         )
         {
             result in
-            print(result)
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error!.isTaskCancelled)
             exp.fulfill()
@@ -831,7 +830,33 @@ class KingfisherManagerTests: XCTestCase {
         task?.cancel()
 
         waitForExpectations(timeout: 1, handler: nil)
+    }
 
+    func testRetrievingAlternativeSourceCanCancelUpdatedTask() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        stub(url, data: testImageData)
+
+        let brokenURL = URL(string: "brokenurl")!
+        stub(brokenURL, data: Data())
+
+        var task: DownloadTask!
+        task = manager.retrieveImage(
+            with: .network(brokenURL),
+            options: [.alternativeSources([.network(url)])],
+            downloadTaskUpdated: { newTask in
+                task = newTask
+                task.cancel()
+            }
+        )
+        {
+            result in
+            XCTAssertNotNil(result.error)
+            XCTAssertTrue(result.error?.isTaskCancelled ?? false)
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 1, handler: nil)
     }
 }
 

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -260,7 +260,9 @@ class KingfisherManagerTests: XCTestCase {
         let manager = self.manager!
         let p = SimpleProcessor()
         let options = KingfisherParsedOptionsInfo([.processor(p), .cacheOriginalImage, .waitForCache])
-        manager.loadAndCacheImage(source: .network(url), options: options) { result in
+        let source = Source.network(url)
+        let context = RetrievingContext(options: options, originalSource: source)
+        manager.loadAndCacheImage(source: .network(url), context: context) { result in
             
             var imageCached = manager.cache.imageCachedType(forKey: url.cacheKey, processorIdentifier: p.identifier)
             var originalCached = manager.cache.imageCachedType(forKey: url.cacheKey)
@@ -289,7 +291,9 @@ class KingfisherManagerTests: XCTestCase {
 
         let p = SimpleProcessor()
         let options = KingfisherParsedOptionsInfo([.processor(p), .waitForCache])
-        manager.loadAndCacheImage(source: .network(url), options: options) {
+        let source = Source.network(url)
+        let context = RetrievingContext(options: options, originalSource: source)
+        manager.loadAndCacheImage(source: .network(url), context: context) {
             result in
             var imageCached = self.manager.cache.imageCachedType(forKey: url.cacheKey, processorIdentifier: p.identifier)
             var originalCached = self.manager.cache.imageCachedType(forKey: url.cacheKey)
@@ -694,7 +698,8 @@ class KingfisherManagerTests: XCTestCase {
             .network(URL(string: "2")!)
         ]
         let info = KingfisherParsedOptionsInfo([.alternativeSources(allSources)])
-        var context = KingfisherManager.RetrievingContext(options: info)
+        var context = RetrievingContext(
+            options: info, originalSource: .network(URL(string: "0")!), propagationErrors: [])
 
         let source1 = context.popAlternativeSource()
         XCTAssertNotNil(source1)

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -774,7 +774,7 @@ class KingfisherManagerTests: XCTestCase {
                 return
             }
 
-            guard case .alternativeSourcesFailed(let errorInfo) = reason else {
+            guard case .alternativeSourcesExhausted(let errorInfo) = reason else {
                 XCTFail("The error reason should be alternativeSourcesFailed")
                 return
             }

--- a/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
+++ b/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
@@ -64,6 +64,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         let processor = RoundCornerImageProcessor(cornerRadius: 20)
         let serializer = FormatIndicatedCacheSerializer.png
         let modifier = AnyImageModifier { i in return i }
+        let alternativeSource = Source.network(URL(string: "https://onevcat.com")!)
 
         var options = KingfisherParsedOptionsInfo([
             .targetCache(cache),
@@ -78,8 +79,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
             .onlyFromCache,
             .backgroundDecode,
             .callbackQueue(.dispatch(queue)),
-            // Not sure why but we need `KingfisherOptionsInfoItem` to compile...
-            KingfisherOptionsInfoItem.scaleFactor(2.0),
+            .scaleFactor(2.0),
             .preloadAllAnimationData,
             .requestModifier(testModifier),
             .redirectHandler(testRedirectHandler),
@@ -88,7 +88,8 @@ class KingfisherOptionsInfoTests: XCTestCase {
             .imageModifier(modifier),
             .keepCurrentImageWhileLoading,
             .onlyLoadFirstFrame,
-            .cacheOriginalImage
+            .cacheOriginalImage,
+            .alternativeSources([alternativeSource])
         ])
         
         XCTAssertTrue(options.targetCache === cache)
@@ -124,6 +125,8 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertTrue(options.keepCurrentImageWhileLoading)
         XCTAssertTrue(options.onlyLoadFirstFrame)
         XCTAssertTrue(options.cacheOriginalImage)
+        XCTAssertEqual(options.alternativeSources?.count, 1)
+        XCTAssertEqual(options.alternativeSources?.first?.url, alternativeSource.url)
     }
     
     func testOptionCouldBeOverwritten() {


### PR DESCRIPTION
This implements what is mentioned in #1245 

It adds a new option `.alternativeSources([Source])` to allow you to set an array of `Source`s as an alternative for original loading. If the original `Source` loading fails, the value in this array will be used to continue the loading, until all `Source`s are used, then an `alternativeSourcesExhausted` error will be thrown out.