### PR TITLE
Fix unconstraint size

### DIFF
--- a/Sources/Extensions/ImageView+Kingfisher.swift
+++ b/Sources/Extensions/ImageView+Kingfisher.swift
@@ -356,6 +356,17 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
                     equalTo: base.centerXAnchor, constant: newIndicator.centerOffset.x).isActive = true
                 view.centerYAnchor.constraint(
                     equalTo: base.centerYAnchor, constant: newIndicator.centerOffset.y).isActive = true
+
+                switch newIndicator.sizeStrategy(in: base) {
+                case .intrinsicSize:
+                    break
+                case .full:
+                    view.heightAnchor.constraint(equalTo: base.heightAnchor, constant: 0).isActive = true
+                    view.widthAnchor.constraint(equalTo: base.widthAnchor, constant: 0).isActive = true
+                case .size(let size):
+                    view.heightAnchor.constraint(equalToConstant: size.height).isActive = true
+                    view.widthAnchor.constraint(equalToConstant: size.width).isActive = true
+                }
                 
                 newIndicator.view.isHidden = true
             }

--- a/Sources/Views/Indicator.swift
+++ b/Sources/Views/Indicator.swift
@@ -67,6 +67,14 @@ public protocol Indicator {
     
     /// The indicator view which would be added to the super view.
     var view: IndicatorView { get }
+
+    func sizeStrategy(in imageView: KFCrossPlatformImageView) -> IndicatorSizeStrategy
+}
+
+public enum IndicatorSizeStrategy {
+    case intrinsicSize
+    case full
+    case size(CGSize)
 }
 
 extension Indicator {
@@ -74,6 +82,10 @@ extension Indicator {
     /// Default implementation of `centerOffset` of `Indicator`. The default value is `.zero`, means that there is
     /// no offset for the indicator view.
     public var centerOffset: CGPoint { return .zero }
+
+    public func sizeStrategy(in imageView: KFCrossPlatformImageView) -> IndicatorSizeStrategy {
+        return .full
+    }
 }
 
 // Displays a NSProgressIndicator / UIActivityIndicatorView
@@ -112,6 +124,10 @@ final class ActivityIndicator: Indicator {
             #endif
             activityIndicatorView.isHidden = true
         }
+    }
+
+    func sizeStrategy(in imageView: KFCrossPlatformImageView) -> IndicatorSizeStrategy {
+        return .intrinsicSize
     }
 
     init() {

--- a/Sources/Views/Indicator.swift
+++ b/Sources/Views/Indicator.swift
@@ -68,6 +68,8 @@ public protocol Indicator {
     /// The indicator view which would be added to the super view.
     var view: IndicatorView { get }
 
+    /// The size strategy used when adding the indicator to image view.
+    /// - Parameter imageView: The super view of indicator.
     func sizeStrategy(in imageView: KFCrossPlatformImageView) -> IndicatorSizeStrategy
 }
 
@@ -83,6 +85,9 @@ extension Indicator {
     /// no offset for the indicator view.
     public var centerOffset: CGPoint { return .zero }
 
+
+    /// Default implementation of `centerOffset` of `Indicator`. The default value is `.full`, means that the indicator
+    /// will pin to the same height and width as the image view.
     public func sizeStrategy(in imageView: KFCrossPlatformImageView) -> IndicatorSizeStrategy {
         return .full
     }


### PR DESCRIPTION
This fixes #1296 which turns out to be a regression of recent refactoring for the customized indicator.