### PR TITLE
Fixes race condition for State of CacheCallbackCoordinator

### DIFF
--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -628,11 +628,22 @@ class CacheCallbackCoordinator {
     private let shouldWaitForCache: Bool
     private let shouldCacheOriginal: Bool
 
-    private (set) var state: State = .idle
+    private let stateQueue: DispatchQueue
+    private (set) var state: State {
+        set {
+            stateQueue.sync { threadSafeState = newValue }
+        }
+        get {
+            stateQueue.sync { threadSafeState }
+        }
+    }
+    private var threadSafeState: State = .idle
 
     init(shouldWaitForCache: Bool, shouldCacheOriginal: Bool) {
         self.shouldWaitForCache = shouldWaitForCache
         self.shouldCacheOriginal = shouldCacheOriginal
+        let stateQueueName = "com.onevcat.Kingfisher.KingfisherManager.stateQueue.\(UUID().uuidString)"
+        self.stateQueue = DispatchQueue(label: stateQueueName)
     }
 
     func apply(_ action: Action, trigger: () -> Void) {

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -627,22 +627,18 @@ class CacheCallbackCoordinator {
 
     private let shouldWaitForCache: Bool
     private let shouldCacheOriginal: Bool
-
     private let stateQueue: DispatchQueue
-    private (set) var state: State {
-        set {
-            stateQueue.sync { threadSafeState = newValue }
-        }
-        get {
-            stateQueue.sync { threadSafeState }
-        }
-    }
     private var threadSafeState: State = .idle
+
+    private (set) var state: State {
+        set { stateQueue.sync { threadSafeState = newValue } }
+        get { stateQueue.sync { threadSafeState } }
+    }
 
     init(shouldWaitForCache: Bool, shouldCacheOriginal: Bool) {
         self.shouldWaitForCache = shouldWaitForCache
         self.shouldCacheOriginal = shouldCacheOriginal
-        let stateQueueName = "com.onevcat.Kingfisher.KingfisherManager.stateQueue.\(UUID().uuidString)"
+        let stateQueueName = "com.onevcat.Kingfisher.CacheCallbackCoordinator.stateQueue.\(UUID().uuidString)"
         self.stateQueue = DispatchQueue(label: stateQueueName)
     }
 


### PR DESCRIPTION
I've enabled the thread sanitizer to check if everything was ok in my project, then I found an issue in this class.

To reproduce the issue, you need to make several calls to KingfisherManager, not sure if the options affect the reproducibility. Here is the code I am using:

```swift
let processor: RoundCornerImageProcessor = .init(cornerRadius: SpotlightManager.avatarTargetSize.width / 2.0,
                                                 targetSize: SpotlightManager.avatarTargetSize,
                                                 backgroundColor: .clear)

let options: [KingfisherOptionsInfoItem] = [.backgroundDecode,
                                            .downloadPriority(URLSessionTask.lowPriority),
                                            .callbackQueue(.dispatch(avatarQueue)),
                                            .processor(processor),
                                            .scaleFactor(UIScreen.main.scale),
                                            .cacheSerializer(FormatIndicatedCacheSerializer.png),
                                            .waitForCache,
                                            .diskCacheExpiration(.expired)]

KingfisherManager.shared.retrieveImage(with: imageURL, options: options) { result in
    switch result {
    case .success(let value):
        let pngData: Data? = value.image.pngData()
        searchableUser.attributeSet.thumbnailData = pngData
    case .failure:
        break
    }
}
```