### PR TITLE
Remove SDK root to make Carthage build for macOS

### DIFF
--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -971,7 +971,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_PACKAGE_TYPE = BNDL;
-				SDKROOT = iphoneos;
+				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "watchsimulator iphonesimulator appletvsimulator watchos appletvos iphoneos macosx";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -1026,7 +1026,7 @@
 				LD_DYLIB_INSTALL_NAME = "@rpath";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				PRODUCT_BUNDLE_PACKAGE_TYPE = BNDL;
-				SDKROOT = iphoneos;
+				SDKROOT = "";
 				SUPPORTED_PLATFORMS = "watchsimulator iphonesimulator appletvsimulator watchos appletvos iphoneos macosx";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";


### PR DESCRIPTION
This should fix #1412 

But it would prevent the Catalyst demo to compile since the Xcode would not specify correct iOS SDK root for the frameworks used in a macOS Catalyst project.