### PR TITLE
Use dynamic framework for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ let package = Package(
     name: "Kingfisher",
     platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v3)],
     products: [
-        .library(name: "Kingfisher", targets: ["Kingfisher"]),
-        .library(name: "KingfisherSwiftUI", targets: ["KingfisherSwiftUI"])
+        .library(name: "Kingfisher", type: .dynamic, targets: ["Kingfisher"]),
+        .library(name: "KingfisherSwiftUI", type: .dynamic, targets: ["KingfisherSwiftUI"])
     ],
     targets: [
         .target(


### PR DESCRIPTION
This converts Kingfisher/KingfisherSwiftUI to a dynamic framework when building with SPM. It should fix #1418 