### PR TITLE
Fix DownsamplingImageProcessor example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ With the powerful options, you can do hard tasks with Kingfisher in a simple way
 
 ```swift
 let url = URL(string: "https://example.com/high_resolution_image.png")
-let processor = DownsamplingImageProcessor(size: imageView.size)
+let processor = DownsamplingImageProcessor(size: imageView.bounds.size)
              >> RoundCornerImageProcessor(cornerRadius: 20)
 imageView.kf.indicatorType = .activity
 imageView.kf.setImage(


### PR DESCRIPTION
`UIView` doesn't have a `size` property.

You can get a view's size with `UIView.bounds.size` -- I assume that's what was intended here.