### PR TITLE
fix issue with image modifier not working on provider provided images

### DIFF
--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -305,8 +305,9 @@ public class KingfisherManager {
                         return
                     }
 
+                    let finalImage = options.imageModifier?.modify(image) ?? image
                     options.callbackQueue.execute {
-                        let result = ImageLoadingResult(image: image, url: nil, originalData: data)
+                        let result = ImageLoadingResult(image: finalImage, url: nil, originalData: data)
                         completionHandler(.success(result))
                     }
                 }


### PR DESCRIPTION
Issue: 
When using a ImageProvider, imageModifier is not applied to the provider provided image. ImageModifier does apply to subsequent access from the cache.

Not sure if this is the best way fixing this issue. Let me know.