### PR TITLE
Fix xcframework binary crach in Swift 5.2 compiler

### DIFF
--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -418,7 +418,21 @@ public class KingfisherManager {
             let task = downloader.downloadImage(
                 with: resource.downloadURL, options: options, completionHandler: _cacheImage
             )
-            return task.map(DownloadTask.WrappedTask.download)
+
+
+            // The code below is neat, but it fails the Swift 5.2 compiler when `BUILD_LIBRARY_FOR_DISTRIBUTION` is
+            // turned on. I believe it is a bug in the compiler. But let's fallback to a traditional style before the
+            // bug can be fixed in Swift.
+            //
+            // https://github.com/onevcat/Kingfisher/issues/1436
+            //
+            // return task.map(DownloadTask.WrappedTask.download)
+
+            if let task = task {
+                return .download(task)
+            } else {
+                return nil
+            }
 
         case .provider(let provider):
             provideImage(provider: provider, options: options, completionHandler: _cacheImage)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -109,7 +109,7 @@ platform :ios do
     
     # Xcode 11.4 causes a crash in the final xcframework
     # https://github.com/onevcat/Kingfisher/issues/1436
-    xcversion(version: "11.3.1")
+    xcversion(version: "~> 11.4")
     FileUtils.rm_rf '../build'
     
     frameworks = []


### PR DESCRIPTION
This should fix #1436 