### PR TITLE
Move the inline init to an explicit initializer

### DIFF
--- a/Sources/Image/ImageProgressive.swift
+++ b/Sources/Image/ImageProgressive.swift
@@ -262,11 +262,15 @@ private final class ImageProgressiveDecoder {
 private final class ImageProgressiveSerialQueue {
     typealias ClosureCallback = ((@escaping () -> Void)) -> Void
     
-    private let queue: DispatchQueue = .init(label: "com.onevcat.Kingfisher.ImageProgressive.SerialQueue")
+    private let queue: DispatchQueue
     private var items: [DispatchWorkItem] = []
     private var notify: (() -> Void)?
     private var lastTime: TimeInterval?
     var count: Int { return items.count }
+
+    init() {
+        self.queue = DispatchQueue(label: "com.onevcat.Kingfisher.ImageProgressive.SerialQueue")
+    }
     
     func add(minimum interval: TimeInterval, closure: @escaping ClosureCallback) {
         let completion = { [weak self] in


### PR DESCRIPTION
It might be a workaround for #1449 

I myself can never reproduce it, and the crash log indicates it is an issue in Swift or iOS. So I do not know how it can work or not.