### PR TITLE
Reduce synchronous I/O when checking `ImageCache.isCached`

### DIFF
--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -228,7 +228,7 @@ public enum DiskStorage {
         /// the `cacheKey` of an image `Source`. It is the computed key with processor identifier considered.
         public func cacheFileURL(forKey key: String) -> URL {
             let fileName = cacheFileName(forKey: key)
-            return directoryURL.appendingPathComponent(fileName)
+            return directoryURL.appendingPathComponent(fileName, isDirectory: false)
         }
 
         func cacheFileName(forKey key: String) -> String {


### PR DESCRIPTION
We use `ImageCache.isCached` on the main thread in our application and we noticed that it would sporadically cause the main thread to hang on I/O. Some investigation showed that this was due to 2 things.

1. A straight-up bug when building the file URL in `DiskStorage` which uses a variant of `URLByAppendingPathComponent:` that does disk I/O to figure out if the path it's building is for a directory or a file. In our case we know it's a file and this is completely unnecessary and we can simply use `URLByAppendingPathComponent:isDirectory:` and avoid this. 
2. While KingFisher's ultimate source-of-truth on whether an image is cached or not is whether the file exists on disk, it is possible to cheaply put an in-memory hash table check before doing so that filters out most unnecessary trips to the file system without changing the underlying semantics. Note that this should be carefully reviewed before merging as I am unsure if that structure needs to be synchronized(it currently isn't).