### PR TITLE
allow custom hashing of file names

### DIFF
--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -259,8 +259,8 @@ public enum DiskStorage {
         }
 
         func cacheFileName(forKey key: String) -> String {
-            if config.usesHashedFileName {
-                let hashedKey = key.kf.md5
+            if config.usesHashedFileName, let fileNameHashProvider = config.fileNameHashProvider {
+                let hashedKey = fileNameHashProvider(key)
                 if let ext = config.pathExtension {
                     return "\(hashedKey).\(ext)"
                 }
@@ -382,6 +382,11 @@ extension DiskStorage {
 
         /// Default is `true`, means that the cache file name will be hashed before storing.
         public var usesHashedFileName = true
+
+        /// Default is an md5 hash
+        public var fileNameHashProvider: ((String) -> String)? = { string in
+            return string.kf.md5
+        }
 
         let name: String
         let fileManager: FileManager

--- a/Tests/KingfisherTests/DiskStorageTests.swift
+++ b/Tests/KingfisherTests/DiskStorageTests.swift
@@ -178,7 +178,27 @@ class DiskStorageTests: XCTestCase {
         XCTAssertTrue(urls.count > 0)
     }
 
-    func testConfigUsesHashedFileName() {
+    func testCustomConfigUsesHashedFileNamed() {
+        let key = "test"
+
+        // hashed fileName
+        storage.config.usesHashedFileName = true
+        storage.config.fileNameHashProvider = { string in
+            return "hashed:\(key)"
+        }
+
+        let hashedFileName = storage.cacheFileName(forKey: key)
+        XCTAssertNotEqual(hashedFileName, key)
+        // validation custom hash of the key
+        XCTAssertEqual(hashedFileName, "hashed:\(key)")
+
+        // fileName without hash
+        storage.config.usesHashedFileName = false
+        let originalFileName = storage.cacheFileName(forKey: key)
+        XCTAssertEqual(originalFileName, key)
+    }
+
+    func testDefaultConfigUsesHashedFileName() {
         let key = "test"
 
         // hashed fileName


### PR DESCRIPTION
Hello!  Firstly, thanks for creating and keeping this library maintained.  We've been using it over at DuckDuckGo since we built version 7 of our Privacy Browser.  https://github.com/duckduckgo/iOS

Long story short, this PR adds the ability to set a custom hashing function, but keeps all current defaults in place. I decided to add it as an extra property to the config rather than replace `config.usesHashedFileName` so that it stays backwards compatible.

The longer version is that we have been improving our favicon support and adding a simple (slightly native) implementation.  We decided to key against domain (as we try 3 different locations for images) and using sha256 with a salt for the file name, but I struggled to see how to do that with the latest version.

Please ket me know what you think! 

Thanks!
