### PR TITLE
Add `clearCache`, `cleanExpiredCache` function

### DIFF
--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -623,7 +623,7 @@ open class ImageCache {
         cleanExpiredDiskCache(completion: handler)
     }
 
-    /// Clears the expired images from disk storage. This is an async operation.
+    /// Clears the expired images from disk storage.
     open func cleanExpiredMemoryCache() {
         memoryStorage.removeExpired()
     }

--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -588,6 +588,15 @@ open class ImageCache {
     }
 
     // MARK: Cleaning
+    /// Clears the memory & disk storage of this cache. This is an async operation.
+    ///
+    /// - Parameter handler: A closure which is invoked when the cache clearing operation finishes.
+    ///                      This `handler` will be called from the main queue.
+    public func clearCache(completion handler: (() -> Void)? = nil) {
+        clearMemoryCache()
+        clearDiskCache(completion: handler)
+    }
+    
     /// Clears the memory storage of this cache.
     @objc public func clearMemoryCache() {
         try? memoryStorage.removeAll()
@@ -597,7 +606,7 @@ open class ImageCache {
     ///
     /// - Parameter handler: A closure which is invoked when the cache clearing operation finishes.
     ///                      This `handler` will be called from the main queue.
-    open func clearDiskCache(completion handler: (()->())? = nil) {
+    open func clearDiskCache(completion handler: (() -> Void)? = nil) {
         ioQueue.async {
             do {
                 try self.diskStorage.removeAll()
@@ -606,6 +615,12 @@ open class ImageCache {
                 DispatchQueue.main.async { handler() }
             }
         }
+    }
+    
+    /// Clears the expired images from memory & disk storage. This is an async operation.
+    open func cleanExpiredCache(completion handler: (() -> Void)? = nil) {
+        cleanExpiredMemoryCache()
+        cleanExpiredDiskCache(completion: handler)
     }
 
     /// Clears the expired images from disk storage. This is an async operation.


### PR DESCRIPTION
Hi~ 👋 I'm glad to contribute toward `Kingfisher`

1. Add `clearCache`, `clenExpiredCache` function
`clearCache` -> Erase the cache data in memory and disk
`cleanExpiredCache` -> Erase the expired cache data in memory and disk

The inspiration for this idea came from [SDWebImage](https://github.com/SDWebImage/SDWebImage/blob/40023d566878027bc5780121e3435396785ffb96/SDWebImage/Core/SDImageCache.m#L845)
```swift
SDImageCache.shared.clearCache(.all)
```

2. Modify incorrect comment of `cleanExpiredMemoryCache`
`cleanExpiredMemoryCache` works synchronously, but comment says asynchronous