### PR TITLE
Cancel moved to avoid crash

### DIFF
--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -101,9 +101,6 @@ public class SessionDataTask {
         guard let callback = removeCallback(token) else {
             return
         }
-        if callbacksStore.count == 0 {
-            task.cancel()
-        }
         onCallbackCancelled.call((token, callback))
     }
 

--- a/Sources/Networking/SessionDelegate.swift
+++ b/Sources/Networking/SessionDelegate.swift
@@ -72,6 +72,7 @@ class SessionDelegate: NSObject {
             // No other callbacks waiting, we can clear the task now.
             if !task.containsCallbacks {
                 let dataTask = task.task
+                dataTask.cancel()
                 self.remove(dataTask)
             }
         }


### PR DESCRIPTION
I maintain a couple of apps that uses your library to great success.
However there are an annoying crash that happens in both apps - even though the actual implementation of cancelling download tasks is very different in the apps.

A simple way it can be replicated would be to do this:
`func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
        if let cell = cell as? TestCell {
            cell.imageView.kf.cancelDownloadTask()
        }
    }`

In that case - if you have a long list - so you can get your scrolling velocity high and maintain that velocity it will eventually crash.

From my debugging the cause seems to be that since the underlying _URLSessionDataTask_ is cancelled prior to the callback then it can actually have become nil when we are later using the task in the callback.

I have tested this solution in both my apps and the crash has disappeared and I have seen no side-effects from this change.

It seems that since I actually began the investigation of this, an issue (https://github.com/onevcat/Kingfisher/issues/1511) has been opened from a different user regarding the same problem I have tried to solve here. At least, when inspecting their crash logs it looks very similar to what I experience in my apps where it crashes in _SessionDelegate.remove()_ by _URLRequest._unconditionallyBridgeFromObjectiveC(_:)_

Let me know what you think.