### PR TITLE
Avoid racing for accessing originalRequest

### DIFF
--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -186,7 +186,7 @@ open class ImageDownloader {
             }
         }
         sessionDelegate.onDidDownloadData.delegate(on: self) { (self, task) in
-            guard let url = task.task.originalRequest?.url else {
+            guard let url = task.originalURL else {
                 return task.mutableData
             }
             return (self.delegate ?? self).imageDownloader(self, didDownload: task.mutableData, for: url)

--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -41,6 +41,10 @@ public class SessionDataTask {
     /// Downloaded raw data of current task.
     public private(set) var mutableData: Data
 
+    // This is a copy of `task.originalRequest?.url`. It is for getting a race-safe behavior for a pitfall on iOS 13.
+    // Ref: https://github.com/onevcat/Kingfisher/issues/1511
+    let originalURL: URL?
+
     /// The underlying download task. It is only for debugging purpose when you encountered an error. You should not
     /// modify the content of this task or start it yourself.
     public let task: URLSessionDataTask
@@ -70,6 +74,7 @@ public class SessionDataTask {
 
     init(task: URLSessionDataTask) {
         self.task = task
+        self.originalURL = task.originalRequest?.url
         mutableData = Data()
     }
 

--- a/Tests/KingfisherTests/RetryStrategyTests.swift
+++ b/Tests/KingfisherTests/RetryStrategyTests.swift
@@ -146,11 +146,13 @@ class RetryStrategyTests: XCTestCase {
         var blockCalled: [Bool] = []
         let source = Source.network(URL(string: "url")!)
         let retry = DelayRetryStrategy(maxRetryCount: 3, retryInterval: .seconds(0))
+
+        let task = URLSession.shared.dataTask(with: URL(string: "url")!)
+
         let context1 = RetryContext(
             source: source,
-            error: .requestError(reason: .taskCancelled(task: .init(task: .init()), token: .init()))
+            error: .requestError(reason: .taskCancelled(task: .init(task: task), token: .init()))
         )
-
         retry.retry(context: context1) { decision in
             guard case RetryDecision.stop = decision else {
                 XCTFail("The decision should be `stop` if user cancelled the task.")


### PR DESCRIPTION
This patch adds/adjusts some lock behaviors. This should help to avoid racing for accessing originalRequest properties and fix #1511