### PR TITLE
Use `@State` for KFImage state management

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SwiftUIList.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SwiftUIList.swift
@@ -75,6 +75,7 @@ struct SwiftUIList : View {
                         }
                         .foregroundColor(.gray)
                     }
+                    .fade(duration: 1)
                     .cancelOnDisappear(true)
                     .aspectRatio(contentMode: .fit)
                     .cornerRadius(20)

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SwiftUIList.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SwiftUIList.swift
@@ -79,8 +79,6 @@ struct SwiftUIList : View {
                     .aspectRatio(contentMode: .fit)
                     .cornerRadius(20)
                     .frame(width: 300, height: 300)
-                    .opacity(done || alreadyCached ? 1.0 : 0.3)
-                    .animation(.linear(duration: 0.4))
 
                 Spacer()
             }.padding(.vertical, 12)

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SwiftUIView.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SwiftUIView.swift
@@ -32,6 +32,8 @@ struct SwiftUIView : View {
 
     @State private var index = 1
 
+    @State private var blackWhite = false
+
     var url: URL {
         URL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher-TestImages/master/DemoAppImage/Loading/kingfisher-\(self.index).jpg")!
     }
@@ -39,6 +41,8 @@ struct SwiftUIView : View {
     var body: some View {
         VStack {
             KFImage(url)
+                .cacheOriginalImage()
+                .setProcessor(blackWhite ? BlackWhiteProcessor() : DefaultImageProcessor())
                 .onSuccess { r in
                     print("suc: \(r)")
                 }
@@ -57,6 +61,9 @@ struct SwiftUIView : View {
             Button(action: {
                 self.index = (self.index % 10) + 1
             }) { Text("Next Image") }
+            Button(action: {
+                self.blackWhite.toggle()
+            }) { Text("Black & White") }
 
         }.navigationBarTitle(Text("Basic Image"), displayMode: .inline)
     }

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SwiftUIView.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SwiftUIView.swift
@@ -53,6 +53,8 @@ struct SwiftUIView : View {
                     Image(systemName: "arrow.2.circlepath.circle")
                         .font(.largeTitle)
                 }
+                .fade(duration: 1)
+                .forceTransition()
                 .resizable()
                 .frame(width: 300, height: 300)
                 .cornerRadius(20)

--- a/Sources/Extensions/ImageView+Kingfisher.swift
+++ b/Sources/Extensions/ImageView+Kingfisher.swift
@@ -383,7 +383,10 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         switch options.transition {
         case .none:
             return false
-        #if !os(macOS)
+        #if os(macOS)
+        case .fade: // Fade is only a placeholder for SwiftUI on macOS.
+            return false
+        #else
         default:
             if options.forceTransition { return true }
             if cacheType == .none { return true }

--- a/Sources/General/ImageSource/Source.swift
+++ b/Sources/General/ImageSource/Source.swift
@@ -80,6 +80,32 @@ public enum Source {
     }
 }
 
+extension Source: Hashable {
+    public static func == (lhs: Source, rhs: Source) -> Bool {
+        switch (lhs, rhs) {
+        case (.network(let r1), .network(let r2)):
+            return r1.cacheKey == r2.cacheKey && r1.downloadURL == r2.downloadURL
+        case (.provider(let p1), .provider(let p2)):
+            return p1.cacheKey == p2.cacheKey && p1.contentURL == p2.contentURL
+        case (.provider(_), .network(_)):
+            return false
+        case (.network(_), .provider(_)):
+            return false
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        switch self {
+        case .network(let r):
+            hasher.combine(r.cacheKey)
+            hasher.combine(r.downloadURL)
+        case .provider(let p):
+            hasher.combine(p.cacheKey)
+            hasher.combine(p.contentURL)
+        }
+    }
+}
+
 extension Source {
     var asResource: Resource? {
         guard case .network(let resource) = self else {

--- a/Sources/General/KF.swift
+++ b/Sources/General/KF.swift
@@ -333,14 +333,6 @@ extension KF.Builder {
     }
     #endif
 
-    /// Sets whether the image setting for an image view should happen with transition even when retrieved from cache.
-    /// - Parameter enabled: Enable the force transition or not.
-    /// - Returns: A `KF.Builder` with changes applied.
-    public func forceTransition(_ enabled: Bool = true) -> Self {
-        options.forceTransition = enabled
-        return self
-    }
-
     /// Sets whether keeping the existing image of image view while setting another image to it.
     /// - Parameter enabled: Whether the existing image should be kept.
     /// - Returns: A `KF.Builder` with changes applied.

--- a/Sources/General/KFOptionsSetter.swift
+++ b/Sources/General/KFOptionsSetter.swift
@@ -339,6 +339,15 @@ extension KFOptionSetter {
         options.lowDataModeSource = source
         return self
     }
+
+    /// Sets whether the image setting for an image view should happen with transition even when retrieved from cache.
+    /// - Parameter enabled: Enable the force transition or not.
+    /// - Returns: A `KF.Builder` with changes applied.
+    public func forceTransition(_ enabled: Bool = true) -> Self {
+        options.forceTransition = enabled
+        return self
+    }
+
 }
 
 // MARK: - Request Modifier

--- a/Sources/General/KFOptionsSetter.swift
+++ b/Sources/General/KFOptionsSetter.swift
@@ -45,15 +45,15 @@ extension KF.Builder: KFOptionSetter {
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 extension KFImage: KFOptionSetter {
     public var options: KingfisherParsedOptionsInfo {
-        get { binder.options }
-        nonmutating set { binder.options = newValue }
+        get { context.binder.options }
+        nonmutating set { context.binder.options = newValue }
     }
 
-    public var onFailureDelegate: Delegate<KingfisherError, Void> { binder.onFailureDelegate }
-    public var onSuccessDelegate: Delegate<RetrieveImageResult, Void> { binder.onSuccessDelegate }
-    public var onProgressDelegate: Delegate<(Int64, Int64), Void> { binder.onProgressDelegate }
+    public var onFailureDelegate: Delegate<KingfisherError, Void> { context.binder.onFailureDelegate }
+    public var onSuccessDelegate: Delegate<RetrieveImageResult, Void> { context.binder.onSuccessDelegate }
+    public var onProgressDelegate: Delegate<(Int64, Int64), Void> { context.binder.onProgressDelegate }
 
-    public var delegateObserver: AnyObject { binder }
+    public var delegateObserver: AnyObject { context.binder }
 }
 #endif
 

--- a/Sources/Image/ImageTransition.swift
+++ b/Sources/Image/ImageTransition.swift
@@ -24,6 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+import Foundation
 #if os(iOS) || os(tvOS)
 import UIKit
 
@@ -111,5 +112,7 @@ public enum ImageTransition {
 // Just a placeholder for compiling on macOS.
 public enum ImageTransition {
     case none
+    /// This is a placeholder on macOS now. It is for SwiftUI (KFImage) to identify the fade option only.
+    case fade(TimeInterval)
 }
 #endif

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -135,4 +135,16 @@ extension KFImage {
         }
     }
 }
+
+@available(iOSApplicationExtension 13.0, *)
+extension KFImage.ImageBinder: Hashable {
+    static func == (lhs: KFImage.ImageBinder, rhs: KFImage.ImageBinder) -> Bool {
+        return lhs === rhs
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(source)
+        hasher.combine(options.processor.identifier)
+    }
+}
 #endif

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -33,7 +33,7 @@ extension KFImage {
 
     /// Represents a binder for `KFImage`. It takes responsibility as an `ObjectBinding` and performs
     /// image downloading and progress reporting based on `KingfisherManager`.
-    class ImageBinder: ObservableObject {
+    class ImageBinder {
 
         let source: Source?
         var options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions)

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -136,7 +136,7 @@ extension KFImage {
     }
 }
 
-@available(iOSApplicationExtension 13.0, *)
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 extension KFImage.ImageBinder: Hashable {
     static func == (lhs: KFImage.ImageBinder, rhs: KFImage.ImageBinder) -> Bool {
         return lhs === rhs

--- a/Sources/SwiftUI/KFImage.swift
+++ b/Sources/SwiftUI/KFImage.swift
@@ -40,25 +40,10 @@ extension Image {
     }
 }
 
-/// A Kingfisher compatible SwiftUI `View` to load an image from a `Source`.
-/// Declaring a `KFImage` in a `View`'s body to trigger loading from the given `Source`.
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public struct KFImage: View {
 
-    // TODO: Replace `@ObservedObject` with `@StateObject` once we do not need to support iOS 13.
-    /// An image binder that manages loading and cancelling image related task.
-    @ObservedObject private(set) var binder: ImageBinder
-
-    @State private var loadingResult: Result<RetrieveImageResult, KingfisherError>?
-
-    // Acts as a placeholder when loading an image.
-    var placeholder: AnyView?
-
-    // Whether the download task should be cancelled when the view disappears.
-    var cancelOnDisappear: Bool = false
-
-    // Configurations should be performed on the image.
-    var configurations: [(Image) -> Image]
+    var context: Context
 
     /// Creates a Kingfisher compatible image view to load image from the given `Source`.
     /// - Parameter source: The image `Source` defining where to load the target image.
@@ -72,9 +57,8 @@ public struct KFImage: View {
     ///               for more.
     @available(*, deprecated, message: "Some options are not available in SwiftUI yet. Use `KFImage(source:isLoaded:)` to create a `KFImage` and configure the options through modifier instead.")
     public init(source: Source?, options: KingfisherOptionsInfo? = nil, isLoaded: Binding<Bool> = .constant(false)) {
-        let binder = ImageBinder(source: source, options: options, isLoaded: isLoaded)
-        self.binder = binder
-        configurations = []
+        let binder = KFImage.ImageBinder(source: source, options: options, isLoaded: isLoaded)
+        self.init(binder: binder)
     }
 
     /// Creates a Kingfisher compatible image view to load image from the given `URL`.
@@ -88,9 +72,11 @@ public struct KFImage: View {
     ///               `KFImage` and configure the options through modifier instead. See methods of `KFOptionSetter`
     ///               for more.
     @available(*, deprecated, message: "Some options are not available in SwiftUI yet. Use `KFImage(_:isLoaded:)` to create a `KFImage` and configure the options through modifier instead.")
-    public init(_ url: URL?, options: KingfisherOptionsInfo? = nil, isLoaded: Binding<Bool> = .constant(false)) {
+    init(_ url: URL?, options: KingfisherOptionsInfo? = nil, isLoaded: Binding<Bool> = .constant(false)) {
         self.init(source: url?.convertToSource(), options: options, isLoaded: isLoaded)
     }
+
+
 
     /// Creates a Kingfisher compatible image view to load image from the given `Source`.
     /// - Parameters:
@@ -100,9 +86,9 @@ public struct KFImage: View {
     ///               wrapped value from outside.
     public init(source: Source?, isLoaded: Binding<Bool> = .constant(false)) {
         let binder = ImageBinder(source: source, isLoaded: isLoaded)
-        self.binder = binder
-        configurations = []
+        self.init(binder: binder)
     }
+
 
     /// Creates a Kingfisher compatible image view to load image from the given `URL`.
     /// - Parameters:
@@ -114,9 +100,59 @@ public struct KFImage: View {
         self.init(source: url?.convertToSource(), isLoaded: isLoaded)
     }
 
-    /// Declares the content and behavior of this view.
-    public var body: some View {
+    init(binder: ImageBinder) {
+        self.context = Context(binder: binder)
+    }
 
+    public var body: some View {
+        KFImageRenderer(context)
+            .id(context.binder.source?.url?.absoluteString ?? "-1")
+    }
+}
+
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+extension KFImage {
+    struct Context {
+        var binder: ImageBinder
+        var configurations: [(Image) -> Image] = []
+        var cancelOnDisappear: Bool = false
+        var placeholder: AnyView? = nil
+
+        init(binder: ImageBinder) {
+            self.binder = binder
+        }
+    }
+}
+
+/// A Kingfisher compatible SwiftUI `View` to load an image from a `Source`.
+/// Declaring a `KFImage` in a `View`'s body to trigger loading from the given `Source`.
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+struct KFImageRenderer: View {
+
+    // TODO: Replace `@ObservedObject` with `@StateObject` once we do not need to support iOS 13.
+    /// An image binder that manages loading and cancelling image related task.
+    @ObservedObject private(set) var binder: KFImage.ImageBinder
+
+    @State private var loadingResult: Result<RetrieveImageResult, KingfisherError>?
+
+    // Acts as a placeholder when loading an image.
+    var placeholder: AnyView?
+
+    // Whether the download task should be cancelled when the view disappears.
+    let cancelOnDisappear: Bool
+
+    // Configurations should be performed on the image.
+    let configurations: [(Image) -> Image]
+
+    init(_ context: KFImage.Context) {
+        self.binder = context.binder
+        self.configurations = context.configurations
+        self.placeholder = context.placeholder
+        self.cancelOnDisappear = context.cancelOnDisappear
+    }
+
+    /// Declares the content and behavior of this view.
+    var body: some View {
         if case .success(let r) = loadingResult {
             configurations
                 .reduce(Image(crossPlatformImage: r.image)) {
@@ -159,7 +195,7 @@ extension KFImage {
     /// - Returns: A `KFImage` view that configures internal `Image` with `block`.
     public func configure(_ block: @escaping (Image) -> Image) -> KFImage {
         var result = self
-        result.configurations.append(block)
+        result.context.configurations.append(block)
         return result
     }
 
@@ -188,7 +224,7 @@ extension KFImage {
 struct KFImage_Previews : PreviewProvider {
     static var previews: some View {
         Group {
-            KFImage(URL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher/master/images/logo.png")!)
+            KFImage(source: .network(URL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher/master/images/logo.png")!))
                 .onSuccess { r in
                     print(r)
                 }

--- a/Sources/SwiftUI/KFImage.swift
+++ b/Sources/SwiftUI/KFImage.swift
@@ -199,18 +199,20 @@ struct KFImageRenderer: View {
         }
     }
 
+    private func shouldApplyFade(cacheType: CacheType) -> Bool {
+        binder.options.forceTransition || cacheType == .none
+    }
+
     private func fadeTransitionDuration(cacheType: CacheType) -> TimeInterval? {
-        if binder.options.forceTransition || cacheType == .none {
-            return binder.options.transition.fadeDuration
-        } else {
-            return nil
-        }
+        shouldApplyFade(cacheType: cacheType)
+            ? binder.options.transition.fadeDuration
+            : nil
     }
 }
 
 extension ImageTransition {
     // Only for fade effect in SwiftUI.
-    var fadeDuration: TimeInterval? {
+    fileprivate var fadeDuration: TimeInterval? {
         switch self {
         case .fade(let duration):
             return duration

--- a/Sources/SwiftUI/KFImage.swift
+++ b/Sources/SwiftUI/KFImage.swift
@@ -103,7 +103,7 @@ public struct KFImage: View {
 
     public var body: some View {
         KFImageRenderer(context)
-            .id(context.binder.source)
+            .id(context.binder)
     }
 }
 

--- a/Sources/SwiftUI/KFImage.swift
+++ b/Sources/SwiftUI/KFImage.swift
@@ -76,8 +76,6 @@ public struct KFImage: View {
         self.init(source: url?.convertToSource(), options: options, isLoaded: isLoaded)
     }
 
-
-
     /// Creates a Kingfisher compatible image view to load image from the given `Source`.
     /// - Parameters:
     ///   - source: The image `Source` defining where to load the target image.
@@ -88,7 +86,6 @@ public struct KFImage: View {
         let binder = ImageBinder(source: source, isLoaded: isLoaded)
         self.init(binder: binder)
     }
-
 
     /// Creates a Kingfisher compatible image view to load image from the given `URL`.
     /// - Parameters:
@@ -106,7 +103,7 @@ public struct KFImage: View {
 
     public var body: some View {
         KFImageRenderer(context)
-            .id(context.binder.source?.url?.absoluteString ?? "-1")
+            .id(context.binder.source)
     }
 }
 
@@ -129,9 +126,8 @@ extension KFImage {
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 struct KFImageRenderer: View {
 
-    // TODO: Replace `@ObservedObject` with `@StateObject` once we do not need to support iOS 13.
     /// An image binder that manages loading and cancelling image related task.
-    @ObservedObject private(set) var binder: KFImage.ImageBinder
+    private let binder: KFImage.ImageBinder
 
     @State private var loadingResult: Result<RetrieveImageResult, KingfisherError>?
 
@@ -163,7 +159,7 @@ struct KFImageRenderer: View {
                 if placeholder != nil {
                     placeholder
                 } else {
-                    Image(crossPlatformImage: .init())
+                    Color.clear
                 }
             }
             .onAppear { [weak binder = self.binder] in

--- a/Sources/SwiftUI/KFImage.swift
+++ b/Sources/SwiftUI/KFImage.swift
@@ -169,18 +169,14 @@ struct KFImageRenderer: View {
                     return
                 }
                 if !binder.loadingOrSucceeded {
-                    binder.start {
-                        self.loadingResult = $0
-                        switch $0 {
-                        case .success(let result):
+                    binder.start { result in
+                        self.loadingResult = result
+                        switch result {
+                        case .success(let value):
                             CallbackQueue.mainAsync.execute {
-                                if let duration = fadeTransitionDuration(cacheType: result.cacheType) {
-                                    withAnimation(.linear(duration: duration)) {
-                                        isLoaded = true
-                                    }
-                                } else {
-                                    isLoaded = true
-                                }
+                                let animation = fadeTransitionDuration(cacheType: value.cacheType)
+                                    .map { duration in Animation.linear(duration: duration) }
+                                withAnimation(animation) { isLoaded = true }
                             }
                         case .failure(_):
                             break

--- a/Sources/SwiftUI/KFImageOptions.swift
+++ b/Sources/SwiftUI/KFImageOptions.swift
@@ -125,5 +125,18 @@ extension KFImage {
         result.context.cancelOnDisappear = flag
         return result
     }
+
+    /// Sets a fade transition for the image task.
+    /// - Parameter duration: The duration of the fade transition.
+    /// - Returns: A `KFImage` with changes applied.
+    ///
+    /// Kingfisher will use the fade transition to animate the image in if it is downloaded from web.
+    /// The transition will not happen when the
+    /// image is retrieved from either memory or disk cache by default. If you need to do the transition even when
+    /// the image being retrieved from cache, also call `forceRefresh()` on the returned `KFImage`.
+    public func fade(duration: TimeInterval) -> KFImage {
+        context.binder.options.transition = .fade(duration)
+        return self
+    }
 }
 #endif

--- a/Sources/SwiftUI/KFImageOptions.swift
+++ b/Sources/SwiftUI/KFImageOptions.swift
@@ -113,7 +113,7 @@ extension KFImage {
     public func placeholder<Content: View>(@ViewBuilder _ content: () -> Content) -> KFImage {
         let v = content()
         var result = self
-        result.placeholder = AnyView(v)
+        result.context.placeholder = AnyView(v)
         return result
     }
 
@@ -122,7 +122,7 @@ extension KFImage {
     /// - Returns: A `KFImage` view that cancels downloading task when disappears.
     public func cancelOnDisappear(_ flag: Bool) -> KFImage {
         var result = self
-        result.cancelOnDisappear = flag
+        result.context.cancelOnDisappear = flag
         return result
     }
 }


### PR DESCRIPTION
This avoids the `@ObservedObject` resetting problem.