### PR TITLE
Fix SwiftUI link

### DIFF
--- a/Kingfisher.podspec
+++ b/Kingfisher.podspec
@@ -38,4 +38,5 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.frameworks = "CFNetwork", "Accelerate"
+  s.weak_frameworks = "SwiftUI", "Combine"
 end


### PR DESCRIPTION
After upgrading to Kingfisher 6, our app got crashed on iOS 12 device. (ipa was archived in Xcode 12.3) 

Here is the log:

![Screen Shot 2021-01-29 at 11 05 35](https://user-images.githubusercontent.com/11192474/106226367-f5ab0200-6221-11eb-9423-bb1ee23b236f.png)

It seems like Xcode did not handle this correctly, and got "strong" link to SwiftUI. This bug [should have fixed in Xcode 11.1](https://stackoverflow.com/a/60198305), but somehow triggered with Kingfisher 6.

It is good to have an more explicit declaration on podspec file, to tell Xcode should weakly link to SwiftUI and Combine. I test it on my device and it works fine.