### PR TITLE
support be compile with no use_framework! in podfile

### DIFF
--- a/Kingfisher.podspec
+++ b/Kingfisher.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/onevcat/Kingfisher.git", :tag => s.version }
   s.source_files  = ["Sources/**/*.swift", "Sources/Kingfisher.h"]
+  s.private_header_files = "Sources/Kingfisher.h"
 
   s.requires_arc = true
   s.frameworks = "CFNetwork", "Accelerate"


### PR DESCRIPTION
kingfisher can't be build to static library in `swift` and `Objective-C` mixed project, the error is shown below picture

![iShot2021-01-29 20.42.16.png](https://i.loli.net/2021/01/29/8XaQsyBFdYp3If2.png)

set "Kingfisher.h" private that will not be in umbrella then can support to compile with no `use_framework!`

-------

## Chinese：
在混编环境中不开启`use_framework!`的情况下如果直接引入`Kingfisher`，在伞文件中会报出如上图中的错误（头文件找不到）。

这个问题一般出现在`OC`与`Swift`共存的`pod`中;

`source_files`中的文件默认为`public`的，`public`的`OC`头文件会自动被放到伞文件中，然后在不开启`use_framework`的环境中编译就会报错，所以我把这个`OC`的头文件标记为`private`了，目的是不让`Kingfisher.h`这个头文件出现在`umbrella`文件中，这样在不打开`use_framework`的环境下（即把`kingfisher`编译为静态库）也能正常编译通过了