### PR TITLE
Fix a bug on iOS 13 swiftUI

### DIFF
--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -109,7 +109,7 @@ extension KFImage {
                             let r = RetrieveImageResult(
                                 image: image, cacheType: value.cacheType, source: value.source, originalSource: value.originalSource
                             )
-                            CallbackQueue.mainCurrentOrAsync.execute {
+                            CallbackQueue.mainAsync.execute {
                                 done(.success(r))
                             }
 
@@ -119,7 +119,7 @@ extension KFImage {
                             }
                         case .failure(let error):
                             self.loadingOrSucceeded = false
-                            CallbackQueue.mainCurrentOrAsync.execute {
+                            CallbackQueue.mainAsync.execute {
                                 done(.failure(error))
                             }
                             CallbackQueue.mainAsync.execute {


### PR DESCRIPTION
Using the mainCurrentOrAsync queue causes the current warning on iOS 13
"Modifying state during view update, this will cause undefined behavior"
This seems to hapen if the image is already loaded and the callback is called immediately during the view render.

Using mainAsync lets the view view finish its rendering before modifying its state