### PR TITLE
Use weak image for image binder to prevent unintended holding

### DIFF
--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -40,7 +40,10 @@ extension KFImage {
 
         var downloadTask: DownloadTask?
 
-        var loadingOrSucceeded: Bool = false
+        var loadingOrSucceeded: Bool {
+            return downloadTask != nil || loadedImage != nil
+        }
+        var loading = false
 
         let onFailureDelegate = Delegate<KingfisherError, Void>()
         let onSuccessDelegate = Delegate<RetrieveImageResult, Void>()
@@ -78,8 +81,6 @@ extension KFImage {
 
             guard !loadingOrSucceeded else { return }
 
-            loadingOrSucceeded = true
-
             guard let source = source else {
                 CallbackQueue.mainCurrentOrAsync.execute {
                     self.onFailureDelegate.call(KingfisherError.imageSettingError(reason: .emptySource))
@@ -114,7 +115,6 @@ extension KFImage {
                                 self.onSuccessDelegate.call(value)
                             }
                         case .failure(let error):
-                            self.loadingOrSucceeded = false
                             CallbackQueue.mainCurrentOrAsync.execute {
                                 done(.failure(error))
                             }

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -43,7 +43,6 @@ extension KFImage {
         var loadingOrSucceeded: Bool {
             return downloadTask != nil || loadedImage != nil
         }
-        var loading = false
 
         let onFailureDelegate = Delegate<KingfisherError, Void>()
         let onSuccessDelegate = Delegate<RetrieveImageResult, Void>()

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -48,7 +48,7 @@ extension KFImage {
 
         var isLoaded: Binding<Bool>
 
-        var loadedImage: KFCrossPlatformImage? = nil
+        weak var loadedImage: KFCrossPlatformImage? = nil
 
         @available(*, deprecated, message: "The `options` version is deprecated And will be removed soon.")
         init(source: Source?, options: KingfisherOptionsInfo? = nil, isLoaded: Binding<Bool>) {


### PR DESCRIPTION
Partial fix for #1638