### PR TITLE
Add imageFrameCount

### DIFF
--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -43,12 +43,18 @@ import CoreGraphics
 import ImageIO
 
 private var animatedImageDataKey: Void?
+private var imageFrameCountKey: Void?
 
 // MARK: - Image Properties
 extension KingfisherWrapper where Base: KFCrossPlatformImage {
     private(set) var animatedImageData: Data? {
         get { return getAssociatedObject(base, &animatedImageDataKey) }
         set { setRetainedAssociatedObject(base, &animatedImageDataKey, newValue) }
+    }
+    
+    public var imageFrameCount: Int? {
+        get { return getAssociatedObject(base, &imageFrameCountKey) }
+        set { setRetainedAssociatedObject(base, &imageFrameCountKey, newValue) }
     }
     
     #if os(macOS)
@@ -291,6 +297,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             kf?.duration = animatedImage.duration
         }
         image?.kf.animatedImageData = data
+        image?.kf.imageFrameCount = Int(CGImageSourceGetCount(imageSource))
         return image
         #else
         
@@ -314,6 +321,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             kf?.animatedImageData = data
         }
         
+        image?.kf.imageFrameCount = Int(CGImageSourceGetCount(imageSource))
         return image
         #endif
     }

--- a/Tests/KingfisherTests/ImageExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageExtensionTests.swift
@@ -54,6 +54,7 @@ class ImageExtensionTests: XCTestCase {
         let options = ImageCreatingOptions()
         let image = KingfisherWrapper<KFCrossPlatformImage>.image(data: testImageJEPGData, options: options)
         XCTAssertNotNil(image)
+        XCTAssertNil(image?.kf.imageFrameCount)
         XCTAssertTrue(image!.renderEqual(to: KFCrossPlatformImage(data: testImageJEPGData)!))
     }
     
@@ -62,8 +63,7 @@ class ImageExtensionTests: XCTestCase {
         let image = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageGIFData, options: options)
         XCTAssertNotNil(image)
         #if os(iOS) || os(tvOS)
-        let count = CGImageSourceGetCount(image!.kf.imageSource!)
-        XCTAssertEqual(count, 8)
+        XCTAssertEqual(image!.kf.imageFrameCount!, 8)
         #else
         XCTAssertEqual(image!.kf.images!.count, 8)
         XCTAssertEqual(image!.kf.duration, 0.8, accuracy: 0.001)
@@ -99,8 +99,7 @@ class ImageExtensionTests: XCTestCase {
         let image = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageSingleFrameGIFData, options: options)
         XCTAssertNotNil(image)
         #if os(iOS) || os(tvOS)
-        let count = CGImageSourceGetCount(image!.kf.imageSource!)
-        XCTAssertEqual(count, 1)
+        XCTAssertEqual(image!.kf.imageFrameCount!, 1)
         #else
         XCTAssertEqual(image!.kf.images!.count, 1)
         XCTAssertEqual(image!.kf.duration, Double.infinity)


### PR DESCRIPTION
Refs. #1645

## What it does

This PR adds the property `imageFrameCount` to the a `KFCrossPlatformImage`. This property is an optional _Int_ and it's set by default when an animated image is created. Since the `KFCrossPlatformImage` already stores an `imageSource` we can retrieve easily the frame count and store it.

This property is the equivalent of `animatedImageFrameCount` used in `SDAnimatedImage`

I didn't set the property as read only to give the possibility to custom processors to also set the value.

## How to test

- Unit test should be 🟢  