### PR TITLE
Modify ImageDownloaderDelegate to accept URLReponse

### DIFF
--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -194,10 +194,10 @@ open class ImageDownloader {
             }
         }
         sessionDelegate.onDidDownloadData.delegate(on: self) { (self, task) in
-            guard let url = task.originalURL else {
+            guard let response = task.task.response else {
                 return task.mutableData
             }
-            return (self.delegate ?? self).imageDownloader(self, didDownload: task.mutableData, for: url)
+            return (self.delegate ?? self).imageDownloader(self, didDownload: task.mutableData, with: response)
         }
     }
 

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -194,7 +194,7 @@ open class ImageDownloader {
             }
         }
         sessionDelegate.onDidDownloadData.delegate(on: self) { (self, task) in
-            guard let response = task.task.response else {
+            guard task.originalURL != nil, let response = task.task.response else {
                 return task.mutableData
             }
             return (self.delegate ?? self).imageDownloader(self, didDownload: task.mutableData, with: response)

--- a/Sources/Networking/ImageDownloaderDelegate.swift
+++ b/Sources/Networking/ImageDownloaderDelegate.swift
@@ -69,7 +69,7 @@ public protocol ImageDownloaderDelegate: AnyObject {
     ///   decrypting or verification). If `nil` returned, the processing is interrupted and a `KingfisherError` with
     ///   `ResponseErrorReason.dataModifyingFailed` will be raised. You could use this fact to stop the image
     ///   processing flow if you find the data is corrupted or malformed.
-    func imageDownloader(_ downloader: ImageDownloader, didDownload data: Data, for url: URL) -> Data?
+    func imageDownloader(_ downloader: ImageDownloader, didDownload data: Data, with response: URLResponse) -> Data?
 
     /// Called when the `ImageDownloader` object successfully downloads and processes an image from specified URL.
     ///
@@ -121,7 +121,7 @@ extension ImageDownloaderDelegate {
     public func isValidStatusCode(_ code: Int, for downloader: ImageDownloader) -> Bool {
         return (200..<400).contains(code)
     }
-    public func imageDownloader(_ downloader: ImageDownloader, didDownload data: Data, for url: URL) -> Data? {
+    public func imageDownloader(_ downloader: ImageDownloader, didDownload data: Data, with response: URLResponse) -> Data? {
         return data
     }
 }

--- a/Sources/Networking/ImageDownloaderDelegate.swift
+++ b/Sources/Networking/ImageDownloaderDelegate.swift
@@ -70,6 +70,9 @@ public protocol ImageDownloaderDelegate: AnyObject {
     ///   `ResponseErrorReason.dataModifyingFailed` will be raised. You could use this fact to stop the image
     ///   processing flow if you find the data is corrupted or malformed.
     func imageDownloader(_ downloader: ImageDownloader, didDownload data: Data, with response: URLResponse) -> Data?
+  
+    @available(*, deprecated, message: "use `imageDownloader(_:didDownload:with:)` instead")
+    func imageDownloader(_ downloader: ImageDownloader, didDownload data: Data, for url: URL) -> Data?
 
     /// Called when the `ImageDownloader` object successfully downloads and processes an image from specified URL.
     ///
@@ -121,7 +124,13 @@ extension ImageDownloaderDelegate {
     public func isValidStatusCode(_ code: Int, for downloader: ImageDownloader) -> Bool {
         return (200..<400).contains(code)
     }
+  
     public func imageDownloader(_ downloader: ImageDownloader, didDownload data: Data, with response: URLResponse) -> Data? {
-        return data
+      guard let url = response.url else { return data }
+      return imageDownloader(downloader, didDownload: data, for: url)
+    }
+  
+    public func imageDownloader(_ downloader: ImageDownloader, didDownload data: Data, for url: URL) -> Data? {
+      return data
     }
 }


### PR DESCRIPTION
Changed `imageDownloader(_:didDownload:for:)` to `imageDownloader(_:didDownload:with:)` accepting the returned URLResponse from the request.

This allows modifying the image data (like decrypting) based on the response the server sends (for example a specific header)