### PR TITLE
Force iOS v14 in order to compile

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
     name: "Kingfisher",
-    platforms: [.iOS(.v10), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v3)],
+    platforms: [.iOS(.v14), .macOS(.v10_12), .tvOS(.v10), .watchOS(.v3)],
     products: [
         .library(name: "Kingfisher", targets: ["Kingfisher"])
     ],


### PR DESCRIPTION
Hi, 

I was trying the StateObject branch but encounter issues when compiling with xcodebuild. The Package.swift needed to be updated in order to work.

FYI: There's still a warning related to the Info.plist file but compilation works anyway

```
found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
[16:19:34]: ▸     /Users/netbe/Library/Developer/Xcode/DerivedData/Luce-gntixnwxpyznsygtuscsasjvlyxc/SourcePackages/checkouts/Kingfisher/Sources/Info.plist
[16:19:35]: ▸ ignoring declared target(s) 'swift-nio-zlib-support' in the system package
```