### PR TITLE
Modified for convention

### DIFF
--- a/Sources/Utility/CallbackQueue.swift
+++ b/Sources/Utility/CallbackQueue.swift
@@ -71,7 +71,7 @@ extension DispatchQueue {
     // This method will dispatch the `block` to self.
     // If `self` is the main queue, and current thread is main thread, the block
     // will be invoked immediately instead of being dispatched.
-    func safeAsync(_ block: @escaping ()->()) {
+    func safeAsync(_ block: @escaping () -> Void) {
         if self === DispatchQueue.main && Thread.isMainThread {
             block()
         } else {

--- a/Tests/KingfisherTests/KingfisherTestHelper.swift
+++ b/Tests/KingfisherTests/KingfisherTestHelper.swift
@@ -99,7 +99,7 @@ func clearCaches(_ caches: [ImageCache]) {
     }
 }
 
-func delay(_ time: Double, block: @escaping ()->()) {
+func delay(_ time: Double, block: @escaping () -> Void) {
     DispatchQueue.main.asyncAfter(deadline: .now() + time) { block() }
 }
 


### PR DESCRIPTION
Usually return nothing is written as () -> Void.

However, in some places, it is written as ()->() expression.

How about editing for conventions?
