### PR TITLE
Use processing queue to fetch data in KingfisherManager

### DIFF
--- a/Sources/General/ImageSource/ImageDataProvider.swift
+++ b/Sources/General/ImageSource/ImageDataProvider.swift
@@ -89,8 +89,10 @@ public struct LocalFileImageDataProvider: ImageDataProvider {
     /// The key used in cache.
     public var cacheKey: String
 
-    public func data(handler: (Result<Data, Error>) -> Void) {
-        handler(Result(catching: { try Data(contentsOf: fileURL) }))
+    public func data(handler:@escaping (Result<Data, Error>) -> Void) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            handler(Result(catching: { try Data(contentsOf: fileURL) }))
+        }
     }
 
     /// The URL of the local file on the disk.

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -344,35 +344,33 @@ public class KingfisherManager {
         completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)?)
     {
         guard let  completionHandler = completionHandler else { return }
-        (options.processingQueue ?? self.processingQueue).execute {
-            provider.data { result in
-                switch result {
-                case .success(let data):
-                    (options.processingQueue ?? self.processingQueue).execute {
-                        let processor = options.processor
-                        let processingItem = ImageProcessItem.data(data)
-                        guard let image = processor.process(item: processingItem, options: options) else {
-                            options.callbackQueue.execute {
-                                let error = KingfisherError.processorError(
-                                    reason: .processingFailed(processor: processor, item: processingItem))
-                                completionHandler(.failure(error))
-                            }
-                            return
-                        }
-                        
+        provider.data { result in
+            switch result {
+            case .success(let data):
+                (options.processingQueue ?? self.processingQueue).execute {
+                    let processor = options.processor
+                    let processingItem = ImageProcessItem.data(data)
+                    guard let image = processor.process(item: processingItem, options: options) else {
                         options.callbackQueue.execute {
-                            let result = ImageLoadingResult(image: image, url: nil, originalData: data)
-                            completionHandler(.success(result))
+                            let error = KingfisherError.processorError(
+                                reason: .processingFailed(processor: processor, item: processingItem))
+                            completionHandler(.failure(error))
                         }
+                        return
                     }
-                case .failure(let error):
+
                     options.callbackQueue.execute {
-                        let error = KingfisherError.imageSettingError(
-                            reason: .dataProviderError(provider: provider, error: error))
-                        completionHandler(.failure(error))
+                        let result = ImageLoadingResult(image: image, url: nil, originalData: data)
+                        completionHandler(.success(result))
                     }
-                    
                 }
+            case .failure(let error):
+                options.callbackQueue.execute {
+                    let error = KingfisherError.imageSettingError(
+                        reason: .dataProviderError(provider: provider, error: error))
+                    completionHandler(.failure(error))
+                }
+
             }
         }
     }


### PR DESCRIPTION
I'm using Kingfisher to provide thumbnails for a collection view browsing interface for images on my local drive.
The images are large .heic images (typically 40mb)

Setting the async image using the following:

```
imageView?.kf.setImage(with: self.photoItem?.thumbUrl,
                               options:ImageBrowserViewItem.imageProcessorOptions)
```

results in significant blocking on the main thread while `provider.data {}` is called. 
The user interface becomes unusable for significant periods of time. Obviously this is exactly what `kf.setImage` is trying to avoid

all I have done is push the provider.data onto the processingQueue which seems to do the job nicely.

I haven't run tests as none appear in the XCode interface when I open the package. If there is a simple way to run them manually, then it would be great to have some details in contributing.md

thank you
