### PR TITLE
Expose AnimatedImageView fields to allow consumers to observe GIF progress

### DIFF
--- a/Sources/Image/GIFAnimatedImage.swift
+++ b/Sources/Image/GIFAnimatedImage.swift
@@ -70,7 +70,7 @@ public struct ImageCreatingOptions {
 
 // Represents the decoding for a GIF image. This class extracts frames from an `imageSource`, then
 // hold the images for later use.
-class GIFAnimatedImage {
+public class GIFAnimatedImage {
     let images: [KFCrossPlatformImage]
     let duration: TimeInterval
     
@@ -98,7 +98,7 @@ class GIFAnimatedImage {
     }
     
     // Calculates frame duration for a gif frame out of the kCGImagePropertyGIFDictionary dictionary.
-    static func getFrameDuration(from gifInfo: [String: Any]?) -> TimeInterval {
+    public static func getFrameDuration(from gifInfo: [String: Any]?) -> TimeInterval {
         let defaultFrameDuration = 0.1
         guard let gifInfo = gifInfo else { return defaultFrameDuration }
         
@@ -111,7 +111,7 @@ class GIFAnimatedImage {
     }
 
     // Calculates frame duration at a specific index for a gif from an `imageSource`.
-    static func getFrameDuration(from imageSource: CGImageSource, at index: Int) -> TimeInterval {
+    public static func getFrameDuration(from imageSource: CGImageSource, at index: Int) -> TimeInterval {
         guard let properties = CGImageSourceCopyPropertiesAtIndex(imageSource, index, nil)
             as? [String: Any] else { return 0.0 }
 

--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -47,7 +47,7 @@ private var imageFrameCountKey: Void?
 
 // MARK: - Image Properties
 extension KingfisherWrapper where Base: KFCrossPlatformImage {
-    public private(set) var animatedImageData: Data? {
+    private(set) var animatedImageData: Data? {
         get { return getAssociatedObject(base, &animatedImageDataKey) }
         set { setRetainedAssociatedObject(base, &animatedImageDataKey, newValue) }
     }

--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -90,7 +90,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     var duration: TimeInterval { return base.duration }
     var size: CGSize { return base.size }
     
-    private(set) var imageSource: CGImageSource? {
+    public private(set) var imageSource: CGImageSource? {
         get { return getAssociatedObject(base, &imageSourceKey) }
         set { setRetainedAssociatedObject(base, &imageSourceKey, newValue) }
     }

--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -47,7 +47,7 @@ private var imageFrameCountKey: Void?
 
 // MARK: - Image Properties
 extension KingfisherWrapper where Base: KFCrossPlatformImage {
-    private(set) var animatedImageData: Data? {
+    public private(set) var animatedImageData: Data? {
         get { return getAssociatedObject(base, &animatedImageDataKey) }
         set { setRetainedAssociatedObject(base, &animatedImageDataKey, newValue) }
     }

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -573,12 +573,19 @@ extension AnimatedImageView {
         }
 
         private func incrementCurrentFrameIndex() {
+            let wasLastFrame = isLastFrame
             currentFrameIndex = increment(frameIndex: currentFrameIndex)
             if isLastFrame {
                 currentRepeatCount += 1
                 if isReachMaxRepeatCount {
                     isFinished = true
+
+                    // Notify the delegate here because the animation is stopping.
+                    delegate?.animator(self, didPlayAnimationLoops: currentRepeatCount)
                 }
+            } else if wasLastFrame {
+
+                // Notify the delegate that the loop completed
                 delegate?.animator(self, didPlayAnimationLoops: currentRepeatCount)
             }
         }


### PR DESCRIPTION
I'm working on a feature for my app that shows a progress bar below gifs and videos.
In order to animate the bar I need to know a couple more things about the animated image view and gif that aren't currently exposed.

The only functional change here is calling didPlayAnimationLoops *after* the loop completes (unless it plays to the end and stops). I believe this is what consumers would expect (at least, it's what I expected). This is necessary because I need to restart the progress bar animation when the gif loops back to the beginning, and currently this delegate method is being called while the gif is still showing the last frame.