### PR TITLE
Added Writing options for diskStorage store operation

### DIFF
--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -122,11 +122,13 @@ public enum DiskStorage {
         ///   - key: The key to which the `value` will be stored. If there is already a value under the key,
         ///          the old value will be overwritten by `value`.
         ///   - expiration: The expiration policy used by this store action.
+        ///   - writeOptions: Data writing options used the new files.
         /// - Throws: An error during converting the value to a data format or during writing it to disk.
         public func store(
             value: T,
             forKey key: String,
-            expiration: StorageExpiration? = nil) throws
+            expiration: StorageExpiration? = nil,
+            writeOptions: Data.WritingOptions = []) throws
         {
             guard storageReady else {
                 throw KingfisherError.cacheError(reason: .diskStorageIsNotReady(cacheURL: directoryURL))
@@ -145,7 +147,7 @@ public enum DiskStorage {
 
             let fileURL = cacheFileURL(forKey: key)
             do {
-                try data.write(to: fileURL)
+                try data.write(to: fileURL, options: writeOptions)
             } catch {
                 throw KingfisherError.cacheError(
                     reason: .cannotCreateCacheFile(fileURL: fileURL, key: key, data: data, error: error)

--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -323,6 +323,7 @@ open class ImageCache {
                     processorIdentifier: identifier,
                     callbackQueue: callbackQueue,
                     expiration: options.diskCacheExpiration,
+                    writeOptions: options.diskStoreWriteOptions,
                     completionHandler: completionHandler)
             } else {
                 guard let completionHandler = completionHandler else { return }
@@ -408,12 +409,13 @@ open class ImageCache {
         processorIdentifier identifier: String = "",
         callbackQueue: CallbackQueue = .untouch,
         expiration: StorageExpiration? = nil,
+        writeOptions: Data.WritingOptions = [],
         completionHandler: ((CacheStoreResult) -> Void)? = nil)
     {
         let computedKey = key.computedKey(with: identifier)
         let result: CacheStoreResult
         do {
-            try self.diskStorage.store(value: data, forKey: computedKey, expiration: expiration)
+            try self.diskStorage.store(value: data, forKey: computedKey, expiration: expiration, writeOptions: writeOptions)
             result = CacheStoreResult(memoryCacheResult: .success(()), diskCacheResult: .success(()))
         } catch {
             let diskError: KingfisherError

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -193,7 +193,11 @@ public enum KingfisherOptionsInfoItem {
     /// Set this options will stop that flickering by keeping all loading in the same queue (typically the UI queue
     /// if you are using Kingfisher's extension methods to set an image), with a tradeoff of loading performance.
     case loadDiskFileSynchronously
-    
+
+    /// Options to control the writing of data to disk storage
+    /// If set, options will be passed the store operation for a new files.
+    case diskStoreWriteOptions(Data.WritingOptions)
+
     /// The expiration setting for memory cache. By default, the underlying `MemoryStorage.Backend` uses the
     /// expiration in its config for all items. If set, the `MemoryStorage.Backend` will use this associated
     /// value to overwrite the config setting for this caching item.
@@ -336,6 +340,7 @@ public struct KingfisherParsedOptionsInfo {
             case .onFailureImage(let value): onFailureImage = .some(value)
             case .alsoPrefetchToMemory: alsoPrefetchToMemory = true
             case .loadDiskFileSynchronously: loadDiskFileSynchronously = true
+            case .diskStoreWriteOptions(let options): diskStoreWriteOptions = options
             case .memoryCacheExpiration(let expiration): memoryCacheExpiration = expiration
             case .memoryCacheAccessExtendingExpiration(let expirationExtending): memoryCacheAccessExtendingExpiration = expirationExtending
             case .diskCacheExpiration(let expiration): diskCacheExpiration = expiration

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -293,6 +293,7 @@ public struct KingfisherParsedOptionsInfo {
     public var onFailureImage: Optional<KFCrossPlatformImage?> = .none
     public var alsoPrefetchToMemory = false
     public var loadDiskFileSynchronously = false
+    public var diskStoreWriteOptions: Data.WritingOptions = []
     public var memoryCacheExpiration: StorageExpiration? = nil
     public var memoryCacheAccessExtendingExpiration: ExpirationExtending = .cacheTime
     public var diskCacheExpiration: StorageExpiration? = nil


### PR DESCRIPTION
Straw-man proposal for providing more writing options for store operation as per discussion here https://github.com/onevcat/Kingfisher/discussions/1792.

**My question:**

I am wondering what would be the best way to pass any additional attributes to the `DiskStorage`? One of the requirements that we currently have for one of the projects - is to have `.complete`(FileProtectionType) protection as we need to ensure that any data we're storing on disk is encrypted at rest - at least when the device is locked.


**Proposed API:**

```swift
...
kf.setImage(with: url,
            placeholder: placeholder,
            options: [.diskStoreWriteOptions([.atomic, .completeFileProtection])])
...
```

Where new image resources for the `url` path will have `.atomic` & `.completeFileProtection` [writing options](https://developer.apple.com/documentation/foundation/nsdata/writingoptions).