### PR TITLE
Fixed animated image view for iOS 13 and below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 -----
 
+## [Unreleased]
+
+#### Fix
+
+* Fix `AnimatedImageView` crashing on iOS 13 and below. [#1804]
+
+---
+
 ## [7.0.0-beta.3 - Version 7](https://github.com/onevcat/Kingfisher/releases/tag/7.0.0-beta.3) (2021-08-29)
 
 #### Add

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -230,7 +230,11 @@ open class AnimatedImageView: UIImageView {
         if let currentFrame = animator?.currentFrameImage {
             layer.contents = currentFrame.cgImage
         } else {
-            super.display(layer)
+            if #available(iOS 15.0, *) {
+                super.display(layer)
+            } else {
+                layer.contents = image?.cgImage
+            }
         }
     }
     


### PR DESCRIPTION
closes #1804 

The `AnimatedImageView` is crashing on iOS 13 and below. (See issue)
This fix is branching iOS 15 off, so that it will work for < iOS 13 and > iOS 13.