### PR TITLE
SwiftUI: Overwrite KFImage appear animation

### DIFF
--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -79,7 +79,10 @@ extension KFImage {
                                 self.loadedImage = value.image
                                 let animation = context.fadeTransitionDuration(cacheType: value.cacheType)
                                     .map { duration in Animation.linear(duration: duration) }
-                                withAnimation(animation) { self.loaded = true }
+                                
+                                var transaction = Transaction(animation: animation)
+                                transaction.disablesAnimations = true
+                                withTransaction(transaction) { self.loaded = true }
                             }
 
                             CallbackQueue.mainAsync.execute {

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -76,13 +76,15 @@ extension KFImage {
                         case .success(let value):
 
                             CallbackQueue.mainCurrentOrAsync.execute {
-                                self.loadedImage = value.image
                                 let animation = context.fadeTransitionDuration(cacheType: value.cacheType)
                                     .map { duration in Animation.linear(duration: duration) }
                                 
                                 var transaction = Transaction(animation: animation)
                                 transaction.disablesAnimations = true
-                                withTransaction(transaction) { self.loaded = true }
+                                withTransaction(transaction) {
+                                    self.loadedImage = value.image
+                                    self.loaded = true
+                                }
                             }
 
                             CallbackQueue.mainAsync.execute {


### PR DESCRIPTION
**Problem:**
With pull request #1767 you fixed some animation issues, but also created a new one (at least for my use case). When you have a KFImage view with an animation modifier somewhere in the tree, this animation is also applied when the image was loaded. In ImageBinder a `withAnimation`-block is used to animate the appearance when needed, but a `withAnimation`-block doesn't overwrite any animation set in any parent of KFImage. This leads especially to weird animations when the image is loaded from cache and therefore no animation should happen, which happens anyway.
Also ImageBinder sets `loadedImage` directly which also often causes scaling animations when the `resizable()` modifier is applied to KFImage.

**_Failed solution_**: This seems like the trivial solution, but doesn't quite work: Set the animation modifier with `animation(nil)` like this:
```
List(objects) { object in
       HStack {
             KFImage(object.url)
                  .resizable()
                  .animation(nil)

             Text(object.title)
       }
}
.animation(.easeInOut)
```
This fixes the problem of having unwanted animations when the image inside KFImage is loaded, but also destroys the animation when e.g. two objects in the list get switched. In this example, the text would animate as expected in SwiftUI, but the image would just switch instantly. So this would completely disable the animation behaviour of these images (a wrapper with animation enabled doesn't help there).


**Proposed Solution**:
Instead of using a `withAnimation`-block in ImageBinder when the image was successfully loaded, I used a transaction block as follows:
```
var transaction = Transaction(animation: animation)
transaction.disablesAnimations = true
withTransaction(transaction) {
      self.loadedImage = value.image
      self.loaded = true
}
```
By using the `disableAnimations` property, you can actually overwrite the animation set on the view and have a guarantee to use the given one. The naming of `disableAnimations` is actually a bit confusing, because it only disables animations defined in the view hierarchy. I guess a better name would be `overwriteAnimations`. Therefore when using e.g. `animation = nil`, it is guaranteed there won't be any animation, while `withAnimation` doesn't do that. I also included setting the `loadedImage` inside the block, which prevents the weird scaling animations when the image is loaded.


**Things to consider:**
Developers may want to have custom animations when the image is loaded, which would only be possible via the internal `ImageTransition`, which currently only supports a linear fade, after this request and animation modifiers wouldn't affect any animations initiated by Kingfisher itself. So it would enable having different animations for image appearance and anything else in your app.
I think this way of handling animations is a better approach, but maybe you have a different taste or a better idea to solve this problem.