### PR TITLE
Start loading when evaluating view

### DIFF
--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -76,12 +76,12 @@ extension KFImage {
 
                         CallbackQueue.mainCurrentOrAsync.execute {
                             self.downloadTask = nil
+                            self.loading = false
                         }
                         
                         switch result {
                         case .success(let value):
                             CallbackQueue.mainCurrentOrAsync.execute {
-                                self.loading = false
                                 self.loadedImage = value.image
                                 let animation = context.fadeTransitionDuration(cacheType: value.cacheType)
                                     .map { duration in Animation.linear(duration: duration) }

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -37,8 +37,8 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
     let context: KFImage.Context<HoldingView>
     
     var body: some View {
-        
-        ZStack {
+        binder.start(context: context)
+        return ZStack {
             context.configurations
                 .reduce(HoldingView.created(from: binder.loadedImage, context: context)) {
                     current, config in config(current)
@@ -50,14 +50,6 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
                         view
                     } else {
                         Color.clear
-                    }
-                }
-                .onAppear { [weak binder = self.binder] in
-                    guard let binder = binder else {
-                        return
-                    }
-                    if !binder.loadingOrSucceeded {
-                        binder.start(context: context)
                     }
                 }
                 .onDisappear { [weak binder = self.binder] in


### PR DESCRIPTION
This fixes #1821 

Currently the loading will not start until the `onAppear` of the placeholder shown, which is too late for a sync loading from disk or memory. It causes an unwanted flickering. This PR moves the loading starting earlier to the beginning of `KFImageRenderer.body`. The loading method call (and its states in `ImageBinder`) is protected by the main thread, so it would not actually run more than once, which should be pretty light.

Also added a `loading` property to prevent situations that image loading without an actual downloading process (say, applying a processor to a cached image). Before this fix, it will be recognized as "not `loadingOrSucceeded`" and triggers multiple start loading behaviors since the `body` will be evaluated for multiple times.