### PR TITLE
Fixes incorrect `@available` for a flavour of `setImage`

### DIFF
--- a/Sources/General/KF.swift
+++ b/Sources/General/KF.swift
@@ -223,7 +223,7 @@ extension KF.Builder {
     ///   - listItem: The list item which loads the task and should be set with the image.
     /// - Returns: A task represents the image downloading, if initialized.
     ///            This value is `nil` if the image is being loaded from cache.
-    @available(iOSApplicationExtension 14.0, *)
+    @available(iOS 14.0, *)
     @discardableResult
     public func set(to listItem: CPListItem) -> DownloadTask? {
         let placeholderImage = placeholder as? KFCrossPlatformImage ?? nil


### PR DESCRIPTION
I ran into some issues compiling `master` related to some recent CarPlay merges due to this error:

```
Kingfisher/Sources/General/KF.swift:230:28: 'setImage(with:placeholder:parsedOptions:progressBlock:completionHandler:)' is only available in iOS 14.0 or newer
```

Context:

- Xcode 13
- iOS 14+ target app & app extension
- M1 dev box

I noticed [you fixed this elsewhere](https://github.com/onevcat/Kingfisher/commit/2bec5cd9f046ceee21e7965b8367c43073905c27) recently and I think it applies here too.

Thank you for Kingfisher!

(distant relative of #1827)