### PR TITLE
Wrap KFImage to a ZStack

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/LazyVStackDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/LazyVStackDemo.swift
@@ -25,14 +25,23 @@
 //  THE SOFTWARE.
 
 import SwiftUI
+import Kingfisher
 
 @available(iOS 14.0, *)
 struct LazyVStackDemo: View {
+    @State private var singleImage = false
+    
     var body: some View {
         ScrollView {
+            // Checking for #1839
+            Toggle("Single Image", isOn: $singleImage).padding()
             LazyVStack {
                 ForEach(1..<700) { i in
-                    ImageCell(index: i).frame(width: 300, height: 300)
+                    if singleImage {
+                        KFImage.url(ImageLoader.roseImage(index: 1))
+                    } else {
+                        ImageCell(index: i).frame(width: 300, height: 300)
+                    }
                 }
             }
         }.navigationBarTitle(Text("Lazy Stack"), displayMode: .inline)

--- a/Sources/SwiftUI/KFImageProtocol.swift
+++ b/Sources/SwiftUI/KFImageProtocol.swift
@@ -38,8 +38,11 @@ public protocol KFImageProtocol: View, KFOptionSetter {
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension KFImageProtocol {
     public var body: some View {
-        KFImageRenderer<HoldingView>(context: context)
-            .id(context)
+        ZStack {
+            KFImageRenderer<HoldingView>(
+                context: context
+            ).id(context)
+        }
     }
     
     /// Creates a Kingfisher compatible image view to load image from the given `Source`.


### PR DESCRIPTION
to prevent multiple child view issue when shown in a lazy container.

This should fix #1839 