### PR TITLE
support version6 to build with xcode13

### DIFF
--- a/Kingfisher.podspec
+++ b/Kingfisher.podspec
@@ -38,4 +38,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.frameworks = "CFNetwork", "Accelerate"
   s.weak_frameworks = "SwiftUI", "Combine"
+  s.xcconfig = { 'EXCLUDED_ARCHS' => 'armv7' }
 end


### PR DESCRIPTION
*Swift libraries may fail to build for iOS targets that use armv7. (74120874)
*Increase the platform dependency of the package to v12 or later.

so we just remove armv7，rather than increase iOS Version
arm64 is used since the iPhone 5S and later～