### PR TITLE
Updating KFOptionSetter with diskStoreWriteOptions

### DIFF
--- a/Sources/General/KFOptionsSetter.swift
+++ b/Sources/General/KFOptionsSetter.swift
@@ -237,6 +237,18 @@ extension KFOptionSetter {
         return self
     }
 
+    /// Sets writing options for an original image on a first write
+    /// - Parameter writingOptions: Options to control the writing of data to a disk storage.
+    /// - Returns: A `Self` value with changes applied.
+    /// If set, options will be passed the store operation for a new files.
+    ///
+    /// This is useful if you want to implement file enctyption on first write - eg [.completeFileProtection]
+    ///
+    public func diskStoreWriteOptions(_ writingOptions: Data.WritingOptions) -> Self {
+        options.diskStoreWriteOptions = writingOptions
+        return self
+    }
+
     /// Sets whether the disk storage loading should happen in the same calling queue.
     /// - Parameter enabled: Whether the disk storage loading should happen in the same calling queue.
     /// - Returns: A `Self` value with changes applied.

--- a/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
+++ b/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
@@ -52,6 +52,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertFalse(options.keepCurrentImageWhileLoading)
         XCTAssertFalse(options.onlyLoadFirstFrame)
         XCTAssertFalse(options.cacheOriginalImage)
+        XCTAssertEqual(options.diskStoreWriteOptions, [])
     }
     
     func testSetOptionsShouldParseCorrectly() {
@@ -89,6 +90,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
             .keepCurrentImageWhileLoading,
             .onlyLoadFirstFrame,
             .cacheOriginalImage,
+            .diskStoreWriteOptions([.atomic]),
             .alternativeSources([alternativeSource]),
             .retryStrategy(DelayRetryStrategy(maxRetryCount: 10))
         ])
@@ -126,6 +128,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertTrue(options.keepCurrentImageWhileLoading)
         XCTAssertTrue(options.onlyLoadFirstFrame)
         XCTAssertTrue(options.cacheOriginalImage)
+        XCTAssertEqual(options.diskStoreWriteOptions, [Data.WritingOptions.atomic])
         XCTAssertEqual(options.alternativeSources?.count, 1)
         XCTAssertEqual(options.alternativeSources?.first?.url, alternativeSource.url)
 


### PR DESCRIPTION
A follow up for https://github.com/onevcat/Kingfisher/pull/1793

After adding `diskStoreWriteOptions` to `KFOptionsSetter` we now able to add writing options to `KFImage` (SwiftUI) component with a following code:

``` swift
KFImage(ImageLoader.sampleImageURLs.first)
    .diskStoreWriteOptions([.completeFileProtection])
```

As well as updated tests that I missed during my previous PR. Please let me know if there are any changes you would like me to make @onevcat 👍 