### PR TITLE
Move animation setting before image setting

### DIFF
--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -79,10 +79,8 @@ extension KFImage {
                         switch result {
                         case .success(let value):
                             CallbackQueue.mainCurrentOrAsync.execute {
-                                if let animation = (context
-                                    .fadeTransitionDuration(cacheType: value.cacheType)
-                                    .map { duration in Animation.linear(duration: duration) })
-                                {
+                                if let fadeDuration = context.fadeTransitionDuration(cacheType: value.cacheType) {
+                                    let animation = Animation.linear(duration: fadeDuration)
                                     withAnimation(animation) { self.loaded = true }
                                 } else {
                                     self.loaded = true

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -79,10 +79,15 @@ extension KFImage {
                         switch result {
                         case .success(let value):
                             CallbackQueue.mainCurrentOrAsync.execute {
+                                if let animation = (context
+                                    .fadeTransitionDuration(cacheType: value.cacheType)
+                                    .map { duration in Animation.linear(duration: duration) })
+                                {
+                                    withAnimation(animation) { self.loaded = true }
+                                } else {
+                                    self.loaded = true
+                                }
                                 self.loadedImage = value.image
-                                let animation = context.fadeTransitionDuration(cacheType: value.cacheType)
-                                    .map { duration in Animation.linear(duration: duration) }
-                                withAnimation(animation) { self.loaded = true }
                             }
 
                             CallbackQueue.mainAsync.execute {


### PR DESCRIPTION
This should fix an issue mentioned here: https://github.com/onevcat/Kingfisher/issues/1849#issuecomment-975062148

When `animation` is nil, it seems that using of `withAnimation(animation)` cannot guarantee the value is available and "published" correctly by the `@Published` wrapper. So the `ImageRenderer` does not catch it and renders an 0.0 opacity incorrectly.

This patch fixes this case by checking the animation, as well as calling it ahead.