### PR TITLE
Code clean up by fixing swift lint warnings

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/AppDelegate.swift
+++ b/Demo/Demo/Kingfisher-Demo/AppDelegate.swift
@@ -24,16 +24,14 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         return true
     }
-    
 }

--- a/Demo/Demo/Kingfisher-Demo/Extensions/UIViewController+KingfisherOperation.swift
+++ b/Demo/Demo/Kingfisher-Demo/Extensions/UIViewController+KingfisherOperation.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 protocol MainDataViewReloadable {
     func reload()
@@ -66,9 +66,9 @@ func createAlert(_ sender: Any, actions: [UIAlertAction]) -> UIAlertController {
     let alert = UIAlertController(title: "Action", message: nil, preferredStyle: .actionSheet)
     alert.popoverPresentationController?.barButtonItem = sender as? UIBarButtonItem
     alert.popoverPresentationController?.permittedArrowDirections = .any
-    
+
     actions.forEach { alert.addAction($0) }
-    
+
     return alert
 }
 
@@ -82,12 +82,12 @@ extension UIViewController: KingfisherActionAlertPopup {
     }
 }
 
-extension UIViewController  {
+extension UIViewController {
     func setupOperationNavigationBar() {
         navigationItem.rightBarButtonItem =
             UIBarButtonItem(title: "Action", style: .plain, target: self, action: #selector(performKingfisherAction))
     }
-    
+
     @objc func performKingfisherAction(_ sender: Any) {
         present(alertPopup(sender), animated: true)
     }

--- a/Demo/Demo/Kingfisher-Demo/Resources/ImageLoader.swift
+++ b/Demo/Demo/Kingfisher-Demo/Resources/ImageLoader.swift
@@ -31,7 +31,7 @@ struct ImageLoader {
         let prefix = "https://raw.githubusercontent.com/onevcat/Kingfisher-TestImages/master/DemoAppImage/Loading"
         return (1...10).map { URL(string: "\(prefix)/kingfisher-\($0).jpg")! }
     }()
-    
+
     static let orientationImageURLs: [URL] = {
         let prefix = "https://raw.githubusercontent.com/onevcat/Kingfisher-TestImages/master/DemoAppImage/Orientation"
         return (1...16).map { URL(string: "\(prefix)/\($0).jpg")! }
@@ -41,7 +41,7 @@ struct ImageLoader {
         let prefix = "https://raw.githubusercontent.com/onevcat/Kingfisher-TestImages/master/DemoAppImage/HighResolution"
         return (1...20).map { URL(string: "\(prefix)/\($0).jpg")! }
     }()
-    
+
     static let gifImageURLs: [URL] = {
         let prefix = "https://raw.githubusercontent.com/onevcat/Kingfisher-TestImages/master/DemoAppImage/GIF"
         return (1...3).map { URL(string: "\(prefix)/\($0).gif")! }
@@ -51,7 +51,7 @@ struct ImageLoader {
         let prefix = "https://raw.githubusercontent.com/onevcat/Kingfisher-TestImages/master/DemoAppImage/Progressive"
         return URL(string: "\(prefix)/progressive.jpg")!
     }()
-    
+
     static func roseImage(index: Int) -> URL {
         return URL(string: "https://github.com/onevcat/Flower-Data-Set/raw/master/rose/rose-\(index).jpg")!
     }

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/AnimatedImageDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/AnimatedImageDemo.swift
@@ -24,18 +24,17 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import SwiftUI
 import Kingfisher
+import SwiftUI
 
 @available(iOS 14.0, *)
 struct AnimatedImageDemo: View {
-    
     @State private var index = 1
-        
+
     var url: URL {
         ImageLoader.gifImageURLs[index - 1]
     }
-    
+
     var body: some View {
         VStack {
             KFAnimatedImage(url)
@@ -65,15 +64,11 @@ struct AnimatedImageDemo: View {
             }) { Text("Next Image") }
         }.navigationBarTitle(Text("Basic Image"), displayMode: .inline)
     }
-    
 }
 
 @available(iOS 14.0, *)
 struct AnimatedImageDemo_Previews: PreviewProvider {
-    
     static var previews: some View {
         AnimatedImageDemo()
     }
-    
 }
-

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/GeometryReaderDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/GeometryReaderDemo.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import SwiftUI
 import Kingfisher
+import SwiftUI
 
 @available(iOS 14.0, *)
 struct GeometryReaderDemo: View {

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/GridDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/GridDemo.swift
@@ -28,7 +28,6 @@ import SwiftUI
 
 @available(iOS 14.0, *)
 struct GridDemo: View {
-
     @State var columns = [
         GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())
     ]
@@ -43,7 +42,6 @@ struct GridDemo: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: {
-
                     withAnimation(Animation.easeInOut(duration: 0.25)) {
                         self.columns = Array(repeating: .init(.flexible()), count: self.columns.count % 4 + 1)
                     }

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/LazyVStackDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/LazyVStackDemo.swift
@@ -24,13 +24,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import SwiftUI
 import Kingfisher
+import SwiftUI
 
 @available(iOS 14.0, *)
 struct LazyVStackDemo: View {
     @State private var singleImage = false
-    
+
     var body: some View {
         ScrollView {
             // Checking for #1839

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/ListDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/ListDemo.swift
@@ -28,8 +28,7 @@ import Kingfisher
 import SwiftUI
 
 @available(iOS 14.0, *)
-struct ListDemo : View {
-
+struct ListDemo: View {
     var body: some View {
         List(1 ..< 700) { i in
             ImageCell(index: i)
@@ -40,7 +39,6 @@ struct ListDemo : View {
 
 @available(iOS 14.0, *)
 struct ImageCell: View {
-
     var alreadyCached: Bool {
         ImageCache.default.isCached(forKey: url.absoluteString)
     }
@@ -82,11 +80,10 @@ struct ImageCell: View {
             Spacer()
         }.padding(.vertical, 12)
     }
-
 }
 
 @available(iOS 14.0, *)
-struct SwiftUIList_Previews : PreviewProvider {
+struct SwiftUIList_Previews: PreviewProvider {
     static var previews: some View {
         ListDemo()
     }

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/MainView.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/MainView.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import SwiftUI
 import Kingfisher
+import SwiftUI
 
 @available(iOS 14.0, *)
 struct MainView: View {

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SingleViewDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SingleViewDemo.swift
@@ -28,8 +28,7 @@ import Kingfisher
 import SwiftUI
 
 @available(iOS 14.0, *)
-struct SingleViewDemo : View {
-
+struct SingleViewDemo: View {
     @State private var index = 1
     @State private var blackWhite = false
     @State private var forceTransition = true
@@ -68,13 +67,12 @@ struct SingleViewDemo : View {
             }) { Text("Black & White") }
             Toggle("Force Transition?", isOn: $forceTransition)
                 .frame(width: 300)
-
         }.navigationBarTitle(Text("Basic Image"), displayMode: .inline)
     }
 }
 
 @available(iOS 14.0, *)
-struct SingleViewDemo_Previews : PreviewProvider {
+struct SingleViewDemo_Previews: PreviewProvider {
     static var previews: some View {
         SingleViewDemo()
     }

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SizingAnimationDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SizingAnimationDemo.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import SwiftUI
 import Kingfisher
+import SwiftUI
 
 @available(iOS 14.0, *)
 struct SizingAnimationDemo: View {
@@ -47,7 +47,6 @@ struct SizingAnimationDemo: View {
                     .font(.system(size: 60))
             }
         }
-
     }
     func playButtonAction() {
         withAnimation(Animation.spring(response: 0.45, dampingFraction: 0.475, blendDuration: 0)) {

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/TransitionViewDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/TransitionViewDemo.swift
@@ -24,13 +24,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import SwiftUI
 import Kingfisher
+import SwiftUI
 
 @available(iOS 14.0, *)
 struct TransitionViewDemo: View {
     @State private var showDetails = false
-    
+
     var body: some View {
         VStack {
             Button(showDetails ? "Hide" : "Show") {

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/AVAssetImageGeneratorViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/AVAssetImageGeneratorViewController.swift
@@ -24,9 +24,9 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import AVKit
 import Kingfisher
+import UIKit
 
 class AVAssetImageGeneratorViewController: UIViewController {
     @IBOutlet weak var imageView: UIImageView!

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/AutoSizingTableViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/AutoSizingTableViewController.swift
@@ -24,19 +24,18 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 // Cell with an image view (loading by Kingfisher) with fix width and dynamic height which keeps the image with aspect ratio.
 class AutoSizingTableViewCell: UITableViewCell {
-    
     static let p = ResizingImageProcessor(referenceSize: .init(width: 200, height: CGFloat.infinity), mode: .aspectFit)
-    
+
     @IBOutlet weak var leadingImageView: UIImageView!
     @IBOutlet weak var sizeLabel: UILabel!
-    
+
     var updateLayout: (() -> Void)?
-    
+
     func set(with url: URL) {
         leadingImageView.kf.setImage(with: url, options: [.processor(AutoSizingTableViewCell.p), .transition(.fade(1))]) { r in
             if case .success(let value) = r {
@@ -52,17 +51,17 @@ class AutoSizingTableViewCell: UITableViewCell {
 class AutoSizingTableViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
     var data: [Int] = Array(1..<700)
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.estimatedRowHeight = 150
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         UIView.setAnimationsEnabled(false)
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         UIView.setAnimationsEnabled(true)
@@ -74,11 +73,11 @@ extension AutoSizingTableViewController: UITableViewDataSource {
         tableView.beginUpdates()
         tableView.endUpdates()
     }
-    
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return data.count
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "AutoSizingTableViewCell", for: indexPath) as! AutoSizingTableViewCell
         cell.set(with: ImageLoader.roseImage(index: data[indexPath.row]))
@@ -87,6 +86,4 @@ extension AutoSizingTableViewController: UITableViewDataSource {
         }
         return cell
     }
-    
-    
 }

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/DetailImageViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/DetailImageViewController.swift
@@ -31,7 +31,7 @@ class DetailImageViewController: UIViewController {
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var infoLabel: UILabel!
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         scrollView.delegate = self

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/DetailImageViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/DetailImageViewController.swift
@@ -27,7 +27,6 @@
 import UIKit
 
 class DetailImageViewController: UIViewController {
-
     var imageURL: URL!
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var scrollView: UIScrollView!
@@ -36,7 +35,7 @@ class DetailImageViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         scrollView.delegate = self
-        
+
         imageView.kf.setImage(with: imageURL, options: [.memoryCacheExpiration(.expired)]) { result in
             guard let image = try? result.get().image else {
                 return
@@ -49,7 +48,7 @@ class DetailImageViewController: UIViewController {
             DispatchQueue.main.async {
                 self.scrollView.zoomScale = minScale
             }
-            
+
             self.infoLabel.text = "\(image.size)"
         }
     }

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/GIFHeavyViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/GIFHeavyViewController.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 class GIFHeavyViewController: UIViewController {
     let stackView = UIStackView()
@@ -38,38 +38,38 @@ class GIFHeavyViewController: UIViewController {
         super.viewDidLoad()
 
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        
+
         view.addSubview(stackView)
-        
+
         if #available(iOS 11.0, *) {
             NSLayoutConstraint.activate([
                 stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
                 stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
                 stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-                stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+                stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
             ])
         } else {
             NSLayoutConstraint.activate([
                 stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 stackView.topAnchor.constraint(equalTo: view.topAnchor),
                 stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+                stackView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])
         }
-        
+
         stackView.axis = .vertical
         stackView.distribution = .fillEqually
-        
+
         stackView.addArrangedSubview(imageView_1)
         stackView.addArrangedSubview(imageView_2)
         stackView.addArrangedSubview(imageView_3)
         stackView.addArrangedSubview(imageView_4)
-        
+
         imageView_1.contentMode = .scaleAspectFit
         imageView_2.contentMode = .scaleAspectFit
         imageView_3.contentMode = .scaleAspectFit
         imageView_4.contentMode = .scaleAspectFit
-        
+
         let url = URL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher-TestImages/master/DemoAppImage/GIF/GifHeavy.gif")
 
         imageView_1.kf.setImage(with: url)

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/GIFViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/GIFViewController.swift
@@ -24,18 +24,17 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 class GIFViewController: UIViewController {
+    @IBOutlet var imageView: UIImageView!
+    @IBOutlet var animatedImageView: AnimatedImageView!
 
-    @IBOutlet weak var imageView: UIImageView!
-    @IBOutlet weak var animatedImageView: AnimatedImageView!
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         let url = ImageLoader.gifImageURLs.last!
-        
+
         // Should need to use different cache key to prevent data overwritten by each other.
         KF.url(url, cacheKey: "\(url)-imageview").set(to: imageView)
         KF.url(url, cacheKey: "\(url)-animated_imageview").set(to: animatedImageView)

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/HighResolutionCollectionViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/HighResolutionCollectionViewController.swift
@@ -24,13 +24,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 private let reuseIdentifier = "HighResolution"
 
 class HighResolutionCollectionViewController: UICollectionViewController {
-
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "High Resolution"
@@ -41,21 +40,18 @@ class HighResolutionCollectionViewController: UICollectionViewController {
         return 1
     }
 
-
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return ImageLoader.highResolutionImageURLs.count * 30
     }
 
-    override func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath)
-    {
+    override func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         (cell as! ImageCollectionViewCell).cellImageView.kf.cancelDownloadTask()
     }
-    
+
     override func collectionView(
         _ collectionView: UICollectionView,
         willDisplay cell: UICollectionViewCell,
-        forItemAt indexPath: IndexPath)
-    {
+        forItemAt indexPath: IndexPath) {
         let imageView = (cell as! ImageCollectionViewCell).cellImageView!
         let url = ImageLoader.highResolutionImageURLs[indexPath.row % ImageLoader.highResolutionImageURLs.count]
         // Use different cache key to prevent reuse the same image. It is just for
@@ -71,17 +67,17 @@ class HighResolutionCollectionViewController: UICollectionViewController {
             .cacheOriginalImage()
             .set(to: imageView)
     }
-    
+
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath)
         return cell
     }
-    
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "showImage" {
             let vc = segue.destination as! DetailImageViewController
             let index = collectionView.indexPathsForSelectedItems![0].row
-            vc.imageURL =  ImageLoader.highResolutionImageURLs[index % ImageLoader.highResolutionImageURLs.count]
+            vc.imageURL = ImageLoader.highResolutionImageURLs[index % ImageLoader.highResolutionImageURLs.count]
         }
     }
 }

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/ImageCollectionViewCell.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/ImageCollectionViewCell.swift
@@ -27,9 +27,9 @@
 import UIKit
 
 class ImageCollectionViewCell: UICollectionViewCell {
-    
+
     @IBOutlet weak var cellImageView: UIImageView!
-    
+
     #if os(tvOS)
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/ImageDataProviderCollectionViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/ImageDataProviderCollectionViewController.swift
@@ -24,17 +24,16 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 private let reuseIdentifier = "ImageDataProviderCell"
 
 class ImageDataProviderCollectionViewController: UICollectionViewController {
-
     let model: [(String, UIColor)] = [
         ("A", .red), ("B", .green), ("C", .blue), ("D", .yellow), ("赵", .purple), ("钱", .orange),
         ("孙", .black), ("李", .brown), ("ア", .darkGray), ("イ", .cyan), ("ウ", .magenta)]
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Provider"
@@ -47,7 +46,7 @@ class ImageDataProviderCollectionViewController: UICollectionViewController {
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as! ImageCollectionViewCell
-    
+
         let pair = model[indexPath.row]
         let provider = UserNameLetterIconImageProvider(userNameFirstLetter: pair.0, backgroundColor: pair.1)
         KF.dataProvider(provider)
@@ -62,29 +61,29 @@ struct UserNameLetterIconImageProvider: ImageDataProvider {
     var cacheKey: String { return letter }
     let letter: String
     let color: UIColor
-    
+
     init(userNameFirstLetter: String, backgroundColor: UIColor) {
         letter = userNameFirstLetter
         color = backgroundColor
     }
-    
+
     func data(handler: @escaping (Result<Data, Error>) -> Void) {
         let letter = self.letter as NSString
         let rect = CGRect(x: 0, y: 0, width: 250, height: 250)
-        
+
         let format = UIGraphicsImageRendererFormat.default()
         format.scale = 1
-        
+
         let renderer = UIGraphicsImageRenderer(size: rect.size, format: format)
         let data = renderer.pngData { context in
             color.setFill()
             context.fill(rect)
-            
+
             let attributes = [
                 NSAttributedString.Key.foregroundColor: UIColor.white,
                 .font: UIFont.systemFont(ofSize: 200)
             ]
-            
+
             let textSize = letter.size(withAttributes: attributes)
             let textRect = CGRect(
                 x: (rect.width - textSize.width) / 2,

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/IndicatorCollectionViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/IndicatorCollectionViewController.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 private let reuseIdentifier = "IndicatorCell"
 let gifData: Data = {
@@ -34,11 +34,9 @@ let gifData: Data = {
 }()
 
 class IndicatorCollectionViewController: UICollectionViewController {
-
     class MyIndicator: Indicator {
-        
         var timer: Timer?
-        
+
         func startAnimatingView() {
             view.isHidden = false
             timer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: true) { _ in
@@ -51,22 +49,22 @@ class IndicatorCollectionViewController: UICollectionViewController {
                 })
             }
         }
-        
+
         func stopAnimatingView() {
             view.isHidden = true
             timer?.invalidate()
         }
-        
+
         var view: IndicatorView = {
             let view = UIView()
             view.heightAnchor.constraint(equalToConstant: 30).isActive = true
             view.widthAnchor.constraint(equalToConstant: 30).isActive = true
-            
+
             view.backgroundColor = .red
             return view
         }()
     }
-    
+
     let indicators: [String] = [
         "None",
         "UIActivityIndicatorView",
@@ -87,7 +85,7 @@ class IndicatorCollectionViewController: UICollectionViewController {
         default: fatalError()
         }
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupOperationNavigationBar()
@@ -106,11 +104,11 @@ class IndicatorCollectionViewController: UICollectionViewController {
             .set(to: cell.cellImageView)
         return cell
     }
-    
+
     override func alertPopup(_ sender: Any) -> UIAlertController {
         let alert = super.alertPopup(sender)
         for item in indicators.enumerated() {
-            alert.addAction(UIAlertAction.init(title: item.element, style: .default) { _ in
+            alert.addAction(UIAlertAction(title: item.element, style: .default) { _ in
                 self.selectedIndicatorIndex = item.offset
             })
         }

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/InfinityCollectionViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/InfinityCollectionViewController.swift
@@ -24,13 +24,12 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 private let reuseIdentifier = "InfinityCell"
 
 class InfinityCollectionViewController: UICollectionViewController {
-
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Infinity"
@@ -42,7 +41,7 @@ class InfinityCollectionViewController: UICollectionViewController {
     }
 
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 10000000
+        return 10_000_000
     }
 
     override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/NormalLoadingViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/NormalLoadingViewController.swift
@@ -24,11 +24,10 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 class NormalLoadingViewController: UICollectionViewController {
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Loading"
@@ -40,21 +39,19 @@ extension NormalLoadingViewController {
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return ImageLoader.sampleImageURLs.count
     }
-    
+
     override func collectionView(
         _ collectionView: UICollectionView,
         didEndDisplaying cell: UICollectionViewCell,
-        forItemAt indexPath: IndexPath)
-    {
+        forItemAt indexPath: IndexPath) {
         // This will cancel all unfinished downloading task when the cell disappearing.
         (cell as! ImageCollectionViewCell).cellImageView.kf.cancelDownloadTask()
     }
-    
+
     override func collectionView(
         _ collectionView: UICollectionView,
         willDisplay cell: UICollectionViewCell,
-        forItemAt indexPath: IndexPath)
-    {
+        forItemAt indexPath: IndexPath) {
         let imageView = (cell as! ImageCollectionViewCell).cellImageView!
         let url = ImageLoader.sampleImageURLs[indexPath.row]
         KF.url(url)
@@ -65,11 +62,10 @@ extension NormalLoadingViewController {
             .onFailure { err in print("Error: \(err)") }
             .set(to: imageView)
     }
-    
+
     override func collectionView(
         _ collectionView: UICollectionView,
-        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell
-    {
+        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(
             withReuseIdentifier: "collectionViewCell",
             for: indexPath) as! ImageCollectionViewCell

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/OrientationImagesViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/OrientationImagesViewController.swift
@@ -24,11 +24,10 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 class OrientationImagesViewController: UICollectionViewController {
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "EXIF"
@@ -40,21 +39,19 @@ extension OrientationImagesViewController {
     override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return ImageLoader.orientationImageURLs.count
     }
-    
+
     override func collectionView(
         _ collectionView: UICollectionView,
         didEndDisplaying cell: UICollectionViewCell,
-        forItemAt indexPath: IndexPath)
-    {
+        forItemAt indexPath: IndexPath) {
         // This will cancel all unfinished downloading task when the cell disappearing.
         (cell as! ImageCollectionViewCell).cellImageView.kf.cancelDownloadTask()
     }
-    
+
     override func collectionView(
         _ collectionView: UICollectionView,
         willDisplay cell: UICollectionViewCell,
-        forItemAt indexPath: IndexPath)
-    {
+        forItemAt indexPath: IndexPath) {
         let imageView = (cell as! ImageCollectionViewCell).cellImageView!
         let url = ImageLoader.orientationImageURLs[indexPath.row]
         KF.url(url)
@@ -66,11 +63,10 @@ extension OrientationImagesViewController {
             .onFailure { err in print("Error: \(err)") }
             .set(to: imageView)
     }
-    
+
     override func collectionView(
         _ collectionView: UICollectionView,
-        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell
-    {
+        cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(
             withReuseIdentifier: "collectionViewCell",
             for: indexPath) as! ImageCollectionViewCell

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/ProcessorCollectionViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/ProcessorCollectionViewController.swift
@@ -24,19 +24,18 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 private let reuseIdentifier = "ProcessorCell"
 
 class ProcessorCollectionViewController: UICollectionViewController {
-
     var currentProcessor: ImageProcessor = DefaultImageProcessor.default {
         didSet {
             collectionView.reloadData()
         }
     }
-    
+
     var processors: [(ImageProcessor, String)] = [
         (DefaultImageProcessor.default, "Default"),
         (ResizingImageProcessor(referenceSize: CGSize(width: 50, height: 50)), "Resizing"),
@@ -54,7 +53,7 @@ class ProcessorCollectionViewController: UICollectionViewController {
         (DownsamplingImageProcessor(size: CGSize(width: 25, height: 25)), "Downsampling"),
         (BlurImageProcessor(blurRadius: 5) |> RoundCornerImageProcessor(cornerRadius: 20), "Blur + Round Corner")
     ]
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Processor"
@@ -82,7 +81,7 @@ class ProcessorCollectionViewController: UICollectionViewController {
 
         return cell
     }
-    
+
     override func alertPopup(_ sender: Any) -> UIAlertController {
         let alert = super.alertPopup(sender)
         alert.addAction(UIAlertAction(title: "Processor", style: .default, handler: { _ in

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/ProgressiveJPEGViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/ProgressiveJPEGViewController.swift
@@ -24,29 +24,28 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 class ProgressiveJPEGViewController: UIViewController {
+    @IBOutlet var imageView: UIImageView!
+    @IBOutlet var progressLabel: UILabel!
 
-    @IBOutlet weak var imageView: UIImageView!
-    @IBOutlet weak var progressLabel: UILabel!
-    
     private var isBlur = true
     private var isFastestScan = true
-    
+
     private let processor = RoundCornerImageProcessor(cornerRadius: 30)
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Progressive JPEG"
         setupOperationNavigationBar()
         loadImage()
     }
-    
+
     private func loadImage() {
         progressLabel.text = "- / -"
-        
+
         let progressive = ImageProgressive(
             isBlur: isBlur,
             isFastestScan: isFastestScan,
@@ -71,10 +70,10 @@ class ProgressiveJPEGViewController: UIViewController {
             }
             .set(to: imageView)
     }
-    
+
     override func alertPopup(_ sender: Any) -> UIAlertController {
         let alert = super.alertPopup(sender)
-        
+
         func reloadImage() {
             // Cancel
             imageView.kf.cancelDownloadTask()
@@ -88,7 +87,7 @@ class ProgressiveJPEGViewController: UIViewController {
                 }
             )
         }
-        
+
         do {
             let title = isBlur ? "Disable Blur" : "Enable Blur"
             alert.addAction(UIAlertAction(title: title, style: .default) { _ in
@@ -96,7 +95,7 @@ class ProgressiveJPEGViewController: UIViewController {
                 reloadImage()
             })
         }
-        
+
         do {
             let title = isFastestScan ? "Disable Fastest Scan" : "Enable Fastest Scan"
             alert.addAction(UIAlertAction(title: title, style: .default) { _ in

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/TextAttachmentViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/TextAttachmentViewController.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 class TextAttachmentViewController: UIViewController {
     @IBOutlet weak var label: UILabel!
@@ -51,7 +51,7 @@ class TextAttachmentViewController: UIViewController {
             .roundCorner(radius: .point(15))
             .set(to: textAttachment, attributedView: self.getLabel())
     }
-    
+
     func getLabel() -> UILabel {
         return label
     }

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/TransitionViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/TransitionViewController.swift
@@ -32,10 +32,10 @@ class TransitionViewController: UIViewController {
         case transitionType
         case duration
     }
-    
+
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var transitionPickerView: UIPickerView!
-    
+
     let durations: [TimeInterval] = [0.5, 1, 2, 4, 10]
     let transitions: [String] = ["none", "fade", "flip - left", "flip - right", "flip - top", "flip - bottom"]
 

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/TransitionViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/TransitionViewController.swift
@@ -24,11 +24,10 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 class TransitionViewController: UIViewController {
-    
     enum PickerComponent: Int, CaseIterable {
         case transitionType
         case duration
@@ -39,14 +38,14 @@ class TransitionViewController: UIViewController {
     
     let durations: [TimeInterval] = [0.5, 1, 2, 4, 10]
     let transitions: [String] = ["none", "fade", "flip - left", "flip - right", "flip - top", "flip - bottom"]
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Transition"
         setupOperationNavigationBar()
         imageView.kf.indicatorType = .activity
     }
-    
+
     func makeTransition(type: String, duration: TimeInterval) -> ImageTransition {
         switch type {
         case "none": return .none
@@ -58,15 +57,14 @@ class TransitionViewController: UIViewController {
         default: return .none
         }
     }
-    
+
     func reloadImageView() {
-    
         let typeIndex = transitionPickerView.selectedRow(inComponent: PickerComponent.transitionType.rawValue)
         let transitionType = transitions[typeIndex]
-        
+
         let durationIndex = transitionPickerView.selectedRow(inComponent: PickerComponent.duration.rawValue)
         let duration = durations[durationIndex]
-        
+
         let t = makeTransition(type: transitionType, duration: duration)
         let url = ImageLoader.sampleImageURLs[0]
         KF.url(url)
@@ -78,12 +76,12 @@ class TransitionViewController: UIViewController {
 
 extension TransitionViewController: UIPickerViewDelegate {
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        switch PickerComponent(rawValue: component)!  {
+        switch PickerComponent(rawValue: component)! {
         case .transitionType: return transitions[row]
         case .duration: return String(durations[row])
         }
     }
-    
+
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         reloadImageView()
     }
@@ -93,9 +91,9 @@ extension TransitionViewController: UIPickerViewDataSource {
     func numberOfComponents(in pickerView: UIPickerView) -> Int {
         return PickerComponent.allCases.count
     }
-    
+
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        switch PickerComponent(rawValue: component)!  {
+        switch PickerComponent(rawValue: component)! {
         case .transitionType: return transitions.count
         case .duration: return durations.count
         }

--- a/Demo/Demo/Kingfisher-macOS-Demo/AppDelegate.swift
+++ b/Demo/Demo/Kingfisher-macOS-Demo/AppDelegate.swift
@@ -29,7 +29,6 @@ import Kingfisher
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
-
     func applicationDidFinishLaunching(aNotification: NSNotification) {
         // Insert code here to initialize your application
     }
@@ -37,6 +36,4 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationWillTerminate(aNotification: NSNotification) {
         // Insert code here to tear down your application
     }
-
-
 }

--- a/Demo/Demo/Kingfisher-macOS-Demo/ViewController.swift
+++ b/Demo/Demo/Kingfisher-macOS-Demo/ViewController.swift
@@ -28,9 +28,9 @@ import AppKit
 import Kingfisher
 
 class ViewController: NSViewController {
-    
+
     @IBOutlet weak var collectionView: NSCollectionView!
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.

--- a/Demo/Demo/Kingfisher-macOS-Demo/ViewController.swift
+++ b/Demo/Demo/Kingfisher-macOS-Demo/ViewController.swift
@@ -41,7 +41,7 @@ class ViewController: NSViewController {
         KingfisherManager.shared.cache.clearMemoryCache()
         KingfisherManager.shared.cache.clearDiskCache()
     }
-    
+
     @IBAction func reloadPressed(sender: AnyObject) {
         collectionView.reloadData()
     }
@@ -51,19 +51,19 @@ extension ViewController: NSCollectionViewDataSource {
     func collectionView(_ collectionView: NSCollectionView, numberOfItemsInSection section: Int) -> Int {
         return 10
     }
-    
+
     func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
         let item = collectionView.makeItem(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: "Cell"), for: indexPath)
-        
+
         let url = URL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher/master/images/kingfisher-\(indexPath.item + 1).jpg")!
-        
+
         item.imageView?.kf.indicatorType = .activity
         KF.url(url)
             .roundCorner(radius: .point(20))
             .onProgress { receivedSize, totalSize in print("\(indexPath.item + 1): \(receivedSize)/\(totalSize)") }
             .onSuccess { print($0) }
             .set(to: item.imageView!)
-        
+
         // Set imageView's `animates` to true if you are loading a GIF.
         // item.imageView?.animates = true
         return item

--- a/Demo/Demo/Kingfisher-tvOS-Demo/AppDelegate.swift
+++ b/Demo/Demo/Kingfisher-tvOS-Demo/AppDelegate.swift
@@ -24,16 +24,14 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import UIKit
 import Kingfisher
+import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
     var window: UIWindow?
 
-
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         // Override point for customization after application launch.
         return true
     }
@@ -59,6 +57,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
-
 }

--- a/Demo/Demo/Kingfisher-watchOS-Demo Extension/ExtensionDelegate.swift
+++ b/Demo/Demo/Kingfisher-watchOS-Demo Extension/ExtensionDelegate.swift
@@ -27,7 +27,6 @@
 import WatchKit
 
 class ExtensionDelegate: NSObject, WKExtensionDelegate {
-
     func applicationDidFinishLaunching() {
         // Perform any final initialization of your application.
     }
@@ -40,5 +39,4 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, etc.
     }
-
 }

--- a/Demo/Demo/Kingfisher-watchOS-Demo Extension/InterfaceController.swift
+++ b/Demo/Demo/Kingfisher-watchOS-Demo Extension/InterfaceController.swift
@@ -24,27 +24,24 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-
-import WatchKit
 import Foundation
 import Kingfisher
+import WatchKit
 
 var count = 0
 
 class InterfaceController: WKInterfaceController {
-    
     @IBOutlet var interfaceImage: WKInterfaceImage!
-    
+
     var currentIndex: Int?
-    
-    
+
     override func awake(withContext context: Any?) {
         super.awake(withContext: context)
-        
+
         currentIndex = count
         count += 1
     }
-    
+
     func refreshImage() {
         let url = URL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher/master/images/kingfisher-\(currentIndex! + 1).jpg")!
         print("Start loading... \(url)")
@@ -63,5 +60,4 @@ class InterfaceController: WKInterfaceController {
         // This method is called when watch view controller is no longer visible
         super.didDeactivate()
     }
-
 }

--- a/Sources/Cache/CacheSerializer.swift
+++ b/Sources/Cache/CacheSerializer.swift
@@ -24,14 +24,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import Foundation
 import CoreGraphics
+import Foundation
 
 /// An `CacheSerializer` is used to convert some data to an image object after
 /// retrieving it from disk storage, and vice versa, to convert an image to data object
 /// for storing to the disk storage.
 public protocol CacheSerializer {
-    
     /// Gets the serialized data from a provided image
     /// and optional original data for caching to disk.
     ///
@@ -58,7 +57,6 @@ public protocol CacheSerializer {
 /// It could serialize and deserialize images in PNG, JPEG and GIF format. For
 /// image other than these formats, a normalized `pngRepresentation` will be used.
 public struct DefaultCacheSerializer: CacheSerializer {
-    
     /// The default general cache serializer used across Kingfisher's cache.
     public static let `default` = DefaultCacheSerializer()
 
@@ -68,7 +66,7 @@ public struct DefaultCacheSerializer: CacheSerializer {
     /// Whether the original data should be preferred when serializing the image.
     /// If `true`, the input original data will be checked first and used unless the data is `nil`.
     /// In that case, the serialization will fall back to creating data from image.
-    public var preferCacheOriginalData: Bool = false
+    public var preferCacheOriginalData = false
 
     /// Creates a cache serializer that serialize and deserialize images in PNG, JPEG and GIF format.
     ///
@@ -103,7 +101,7 @@ public struct DefaultCacheSerializer: CacheSerializer {
             )
         }
     }
-    
+
     /// Gets an image deserialized from provided data.
     ///
     /// - Parameters:

--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -26,12 +26,10 @@
 
 import Foundation
 
-
 /// Represents a set of conception related to storage which stores a certain type of value in disk.
 /// This is a namespace for the disk storage types. A `Backend` with a certain `Config` will be used to describe the
 /// storage. See these composed types for more information.
 public enum DiskStorage {
-
     /// Represents a storage back-end for the `DiskStorage`. The value is serialized to data
     /// and stored as file in the file system under a specified location.
     ///
@@ -47,12 +45,12 @@ public enum DiskStorage {
 
         let metaChangingQueue: DispatchQueue
 
-        var maybeCached : Set<String>?
+        var maybeCached: Set<String>?
         let maybeCachedCheckingQueue = DispatchQueue(label: "com.onevcat.Kingfisher.maybeCachedCheckingQueue")
 
         // `false` if the storage initialized with an error. This prevents unexpected forcibly crash when creating
         // storage in the default cache.
-        private var storageReady: Bool = true
+        private var storageReady = true
 
         /// Creates a disk storage with the given `DiskStorage.Config`.
         ///
@@ -128,8 +126,7 @@ public enum DiskStorage {
             value: T,
             forKey key: String,
             expiration: StorageExpiration? = nil,
-            writeOptions: Data.WritingOptions = []) throws
-        {
+            writeOptions: Data.WritingOptions = []) throws {
             guard storageReady else {
                 throw KingfisherError.cacheError(reason: .diskStorageIsNotReady(cacheURL: directoryURL))
             }
@@ -137,7 +134,7 @@ public enum DiskStorage {
             let expiration = expiration ?? config.expiration
             // The expiration indicates that already expired, no need to store.
             guard !expiration.isExpired else { return }
-            
+
             let data: Data
             do {
                 data = try value.toData()
@@ -155,7 +152,7 @@ public enum DiskStorage {
             }
 
             let now = Date()
-            let attributes: [FileAttributeKey : Any] = [
+            let attributes: [FileAttributeKey: Any] = [
                 // The last access date.
                 .creationDate: now.fileAttributeDate,
                 // The estimated expiration date.
@@ -193,8 +190,7 @@ public enum DiskStorage {
             forKey key: String,
             referenceDate: Date,
             actuallyLoad: Bool,
-            extendingExpiration: ExpirationExtending) throws -> T?
-        {
+            extendingExpiration: ExpirationExtending) throws -> T? {
             guard storageReady else {
                 throw KingfisherError.cacheError(reason: .diskStorageIsNotReady(cacheURL: directoryURL))
             }
@@ -335,8 +331,7 @@ public enum DiskStorage {
             let fileManager = config.fileManager
 
             guard let directoryEnumerator = fileManager.enumerator(
-                at: directoryURL, includingPropertiesForKeys: propertyKeys, options: .skipsHiddenFiles) else
-            {
+                at: directoryURL, includingPropertiesForKeys: propertyKeys, options: .skipsHiddenFiles) else {
                 throw KingfisherError.cacheError(reason: .fileEnumeratorCreationFailed(url: directoryURL))
             }
 
@@ -384,7 +379,6 @@ public enum DiskStorage {
         ///
         /// - Note: This method checks `config.sizeLimit` and remove cached files in an LRU (Least Recently Used) way.
         func removeSizeExceededValues() throws -> [URL] {
-
             if config.sizeLimit == 0 { return [] } // Back compatible. 0 means no limit.
 
             var size = try totalSize()
@@ -438,7 +432,6 @@ public enum DiskStorage {
 extension DiskStorage {
     /// Represents the config used in a `DiskStorage`.
     public struct Config {
-
         /// The file size limit on disk of the storage in bytes. 0 means no limit.
         public var sizeLimit: UInt
 
@@ -448,7 +441,7 @@ extension DiskStorage {
 
         /// The preferred extension of cache item. It will be appended to the file name as its extension.
         /// Default is `nil`, means that the cache file does not contain a file extension.
-        public var pathExtension: String? = nil
+        public var pathExtension: String?
 
         /// Default is `true`, means that the cache file name will be hashed before storing.
         public var usesHashedFileName = true
@@ -482,8 +475,7 @@ extension DiskStorage {
             name: String,
             sizeLimit: UInt,
             fileManager: FileManager = .default,
-            directory: URL? = nil)
-        {
+            directory: URL? = nil) {
             self.name = name
             self.fileManager = fileManager
             self.directory = directory
@@ -494,18 +486,17 @@ extension DiskStorage {
 
 extension DiskStorage {
     struct FileMeta {
-    
         let url: URL
-        
+
         let lastAccessDate: Date?
         let estimatedExpirationDate: Date?
         let isDirectory: Bool
         let fileSize: Int
-        
+
         static func lastAccessDate(lhs: FileMeta, rhs: FileMeta) -> Bool {
             return lhs.lastAccessDate ?? .distantPast > rhs.lastAccessDate ?? .distantPast
         }
-        
+
         init(fileURL: URL, resourceKeys: Set<URLResourceKey>) throws {
             let meta = try fileURL.resourceValues(forKeys: resourceKeys)
             self.init(
@@ -515,14 +506,13 @@ extension DiskStorage {
                 isDirectory: meta.isDirectory ?? false,
                 fileSize: meta.fileSize ?? 0)
         }
-        
+
         init(
             fileURL: URL,
             lastAccessDate: Date?,
             estimatedExpirationDate: Date?,
             isDirectory: Bool,
-            fileSize: Int)
-        {
+            fileSize: Int) {
             self.url = fileURL
             self.lastAccessDate = lastAccessDate
             self.estimatedExpirationDate = estimatedExpirationDate
@@ -533,15 +523,14 @@ extension DiskStorage {
         func expired(referenceDate: Date) -> Bool {
             return estimatedExpirationDate?.isPast(referenceDate: referenceDate) ?? true
         }
-        
+
         func extendExpiration(with fileManager: FileManager, extendingExpiration: ExpirationExtending) {
             guard let lastAccessDate = lastAccessDate,
-                  let lastEstimatedExpiration = estimatedExpirationDate else
-            {
+                  let lastEstimatedExpiration = estimatedExpirationDate else {
                 return
             }
 
-            let attributes: [FileAttributeKey : Any]
+            let attributes: [FileAttributeKey: Any]
 
             switch extendingExpiration {
             case .none:

--- a/Sources/Cache/FormatIndicatedCacheSerializer.swift
+++ b/Sources/Cache/FormatIndicatedCacheSerializer.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import Foundation
 import CoreGraphics
+import Foundation
 
 /// `FormatIndicatedCacheSerializer` lets you indicate an image format for serialized caches.
 ///
@@ -53,11 +53,10 @@ import CoreGraphics
 /// imageView.kf.setImage(with: url, options: optionsInfo)
 /// ````
 public struct FormatIndicatedCacheSerializer: CacheSerializer {
-    
     /// A `FormatIndicatedCacheSerializer` which converts image from and to PNG format. If the image cannot be
     /// represented by PNG format, it will fallback to its real format which is determined by `original` data.
     public static let png = FormatIndicatedCacheSerializer(imageFormat: .PNG, jpegCompressionQuality: nil)
-    
+
     /// A `FormatIndicatedCacheSerializer` which converts image from and to JPEG format. If the image cannot be
     /// represented by JPEG format, it will fallback to its real format which is determined by `original` data.
     /// The compression quality is 1.0 when using this serializer. If you need to set a customized compression quality,
@@ -71,20 +70,19 @@ public struct FormatIndicatedCacheSerializer: CacheSerializer {
     public static func jpeg(compressionQuality: CGFloat) -> FormatIndicatedCacheSerializer {
         return FormatIndicatedCacheSerializer(imageFormat: .JPEG, jpegCompressionQuality: compressionQuality)
     }
-    
+
     /// A `FormatIndicatedCacheSerializer` which converts image from and to GIF format. If the image cannot be
     /// represented by GIF format, it will fallback to its real format which is determined by `original` data.
     public static let gif = FormatIndicatedCacheSerializer(imageFormat: .GIF, jpegCompressionQuality: nil)
-    
+
     /// The indicated image format.
     private let imageFormat: ImageFormat
 
     /// The compression quality used for loss image format (like JPEG).
     private let jpegCompressionQuality: CGFloat?
-    
+
     /// Creates data which represents the given `image` under a format.
     public func data(with image: KFCrossPlatformImage, original: Data?) -> Data? {
-        
         func imageData(withFormat imageFormat: ImageFormat) -> Data? {
             return autoreleasepool { () -> Data? in
                 switch imageFormat {
@@ -95,22 +93,22 @@ public struct FormatIndicatedCacheSerializer: CacheSerializer {
                 }
             }
         }
-        
+
         // generate data with indicated image format
         if let data = imageData(withFormat: imageFormat) {
             return data
         }
-        
+
         let originalFormat = original?.kf.imageFormat ?? .unknown
-        
+
         // generate data with original image's format
         if originalFormat != imageFormat, let data = imageData(withFormat: originalFormat) {
             return data
         }
-        
+
         return original ?? image.kf.normalized.kf.pngRepresentation()
     }
-    
+
     /// Same implementation as `DefaultCacheSerializer`.
     public func image(with data: Data, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
         return KingfisherWrapper.image(data: data, options: options.imageCreatingOptions)

--- a/Sources/Cache/MemoryStorage.swift
+++ b/Sources/Cache/MemoryStorage.swift
@@ -30,7 +30,6 @@ import Foundation
 /// This is a namespace for the memory storage types. A `Backend` with a certain `Config` will be used to describe the
 /// storage. See these composed types for more information.
 public enum MemoryStorage {
-
     /// Represents a storage which stores a certain type of value in memory. It provides fast access,
     /// but limited storing size. The stored value type needs to conform to `CacheCostCalculable`,
     /// and its `cacheCost` will be used to determine the cost of size for the cache item.
@@ -52,7 +51,7 @@ public enum MemoryStorage {
         // See https://github.com/onevcat/Kingfisher/issues/1233
         var keys = Set<String>()
 
-        private var cleanTimer: Timer? = nil
+        private var cleanTimer: Timer?
         private let lock = NSLock()
 
         /// The config used in this storage. It is a value you can set and
@@ -108,8 +107,7 @@ public enum MemoryStorage {
         public func store(
             value: T,
             forKey key: String,
-            expiration: StorageExpiration? = nil)
-        {
+            expiration: StorageExpiration? = nil) {
             storeNoThrow(value: value, forKey: key, expiration: expiration)
         }
 
@@ -118,19 +116,18 @@ public enum MemoryStorage {
         func storeNoThrow(
             value: T,
             forKey key: String,
-            expiration: StorageExpiration? = nil)
-        {
+            expiration: StorageExpiration? = nil) {
             lock.lock()
             defer { lock.unlock() }
             let expiration = expiration ?? config.expiration
             // The expiration indicates that already expired, no need to store.
             guard !expiration.isExpired else { return }
-            
+
             let object = StorageObject(value, key: key, expiration: expiration)
             storage.setObject(object, forKey: key as NSString, cost: value.cacheCost)
             keys.insert(key)
         }
-        
+
         /// Gets a value from the storage.
         ///
         /// - Parameters:
@@ -180,7 +177,6 @@ public enum MemoryStorage {
 extension MemoryStorage {
     /// Represents the config used in a `MemoryStorage`.
     public struct Config {
-
         /// Total cost limit of the storage in bytes.
         public var totalCostLimit: Int
 
@@ -215,14 +211,14 @@ extension MemoryStorage {
         let value: T
         let expiration: StorageExpiration
         let key: String
-        
+
         private(set) var estimatedExpiration: Date
-        
+
         init(_ value: T, key: String, expiration: StorageExpiration) {
             self.value = value
             self.key = key
             self.expiration = expiration
-            
+
             self.estimatedExpiration = expiration.estimatedExpirationSinceNow
         }
 
@@ -236,7 +232,7 @@ extension MemoryStorage {
                 self.estimatedExpiration = expirationTime.estimatedExpirationSinceNow
             }
         }
-        
+
         var expired: Bool {
             return estimatedExpiration.isPast
         }

--- a/Sources/Cache/Storage.swift
+++ b/Sources/Cache/Storage.swift
@@ -58,7 +58,7 @@ public enum StorageExpiration {
         case .seconds(let seconds):
             return date.addingTimeInterval(seconds)
         case .days(let days):
-            let duration: TimeInterval = TimeInterval(TimeConstants.secondsInOneDay) * TimeInterval(days)
+            let duration = TimeInterval(TimeConstants.secondsInOneDay) * TimeInterval(days)
             return date.addingTimeInterval(duration)
         case .date(let ref):
             return ref
@@ -66,11 +66,11 @@ public enum StorageExpiration {
             return .distantPast
         }
     }
-    
+
     var estimatedExpirationSinceNow: Date {
         return estimatedExpirationSince(Date())
     }
-    
+
     var isExpired: Bool {
         return timeInterval <= 0
     }

--- a/Sources/Extensions/CPListItem+Kingfisher.swift
+++ b/Sources/Extensions/CPListItem+Kingfisher.swift
@@ -1,4 +1,3 @@
-
 //
 //  CPListItem+Kingfisher.swift
 //  Kingfisher
@@ -30,9 +29,8 @@ import CarPlay
 
 @available(iOS 14.0, *)
 extension KingfisherWrapper where Base: CPListItem {
-    
     // MARK: Setting Image
-    
+
     /// Sets an image to the image view with a source.
     ///
     /// - Parameters:
@@ -56,8 +54,7 @@ extension KingfisherWrapper where Base: CPListItem {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         let options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions + (options ?? []))
         return setImage(
             with: source,
@@ -67,7 +64,7 @@ extension KingfisherWrapper where Base: CPListItem {
             completionHandler: completionHandler
         )
     }
-    
+
     /// Sets an image to the image view with a requested resource.
     ///
     /// - Parameters:
@@ -91,8 +88,7 @@ extension KingfisherWrapper where Base: CPListItem {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setImage(
             with: resource?.convertToSource(),
             placeholder: placeholder,
@@ -106,8 +102,7 @@ extension KingfisherWrapper where Base: CPListItem {
         placeholder: KFCrossPlatformImage? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         var mutatingSelf = self
         guard let source = source else {
             /**
@@ -129,7 +124,7 @@ extension KingfisherWrapper where Base: CPListItem {
             completionHandler?(.failure(KingfisherError.imageSettingError(reason: .emptySource)))
             return nil
         }
-        
+
         var options = parsedOptions
         if !options.keepCurrentImageWhileLoading {
             /**
@@ -147,24 +142,24 @@ extension KingfisherWrapper where Base: CPListItem {
             }
             #endif
         }
-        
+
         let issuedIdentifier = Source.Identifier.next()
         mutatingSelf.taskIdentifier = issuedIdentifier
-        
+
         if let block = progressBlock {
             options.onDataReceived = (options.onDataReceived ?? []) + [ImageLoadingProgressSideEffect(block)]
         }
-        
+
         if let provider = ImageProgressiveProvider(options, refresh: { image in
             self.base.setImage(image)
         }) {
             options.onDataReceived = (options.onDataReceived ?? []) + [provider]
         }
-        
+
         options.onDataReceived?.forEach {
             $0.onShouldApply = { issuedIdentifier == self.taskIdentifier }
         }
-        
+
         let task = KingfisherManager.shared.retrieveImage(
             with: source,
             options: options,
@@ -183,15 +178,15 @@ extension KingfisherWrapper where Base: CPListItem {
                         completionHandler?(.failure(error))
                         return
                     }
-                    
+
                     mutatingSelf.imageTask = nil
                     mutatingSelf.taskIdentifier = nil
-                    
+
                     switch result {
                         case .success(let value):
                             self.base.setImage(value.image)
                             completionHandler?(result)
-                            
+
                         case .failure:
                             if let image = options.onFailureImage {
                                 /**
@@ -208,7 +203,6 @@ extension KingfisherWrapper where Base: CPListItem {
                                     self.base.setImage(unwrapped)
                                 }
                                 #endif
-                                
                             } else {
                                 #if compiler(>=5.4)
                                 self.base.setImage(nil)
@@ -219,13 +213,13 @@ extension KingfisherWrapper where Base: CPListItem {
                 }
             }
         )
-        
+
         mutatingSelf.imageTask = task
         return task
     }
-    
+
     // MARK: Cancelling Image
-    
+
     /// Cancel the image download task bounded to the image view if it is running.
     /// Nothing will happen if the downloading has already finished.
     public func cancelDownloadTask() {
@@ -238,7 +232,6 @@ private var imageTaskKey: Void?
 
 // MARK: Properties
 extension KingfisherWrapper where Base: CPListItem {
-
     public private(set) var taskIdentifier: Source.Identifier.Value? {
         get {
             let box: Box<Source.Identifier.Value>? = getAssociatedObject(base, &taskIdentifierKey)
@@ -252,7 +245,7 @@ extension KingfisherWrapper where Base: CPListItem {
 
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
-        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue) }
     }
 }
 #endif

--- a/Sources/Extensions/ImageView+Kingfisher.swift
+++ b/Sources/Extensions/ImageView+Kingfisher.swift
@@ -33,7 +33,6 @@ import UIKit
 #endif
 
 extension KingfisherWrapper where Base: KFCrossPlatformImageView {
-
     // MARK: Setting Image
 
     /// Sets an image to the image view with a `Source`.
@@ -79,8 +78,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         placeholder: Placeholder? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         let options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions + (options ?? .empty))
         return setImage(with: source, placeholder: placeholder, parsedOptions: options, progressBlock: progressBlock, completionHandler: completionHandler)
     }
@@ -125,8 +123,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         with source: Source?,
         placeholder: Placeholder? = nil,
         options: KingfisherOptionsInfo? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setImage(
             with: source,
             placeholder: placeholder,
@@ -166,8 +163,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         placeholder: Placeholder? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setImage(
             with: resource?.convertToSource(),
             placeholder: placeholder,
@@ -203,8 +199,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         with resource: Resource?,
         placeholder: Placeholder? = nil,
         options: KingfisherOptionsInfo? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setImage(
             with: resource,
             placeholder: placeholder,
@@ -235,8 +230,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         placeholder: Placeholder? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setImage(
             with: provider.map { .provider($0) },
             placeholder: placeholder,
@@ -263,8 +257,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         with provider: ImageDataProvider?,
         placeholder: Placeholder? = nil,
         options: KingfisherOptionsInfo? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setImage(
             with: provider,
             placeholder: placeholder,
@@ -274,14 +267,12 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         )
     }
 
-
     func setImage(
         with source: Source?,
         placeholder: Placeholder? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         var mutatingSelf = self
         guard let source = source else {
             mutatingSelf.placeholder = placeholder
@@ -432,7 +423,6 @@ private var placeholderKey: Void?
 private var imageTaskKey: Void?
 
 extension KingfisherWrapper where Base: KFCrossPlatformImageView {
-
     // MARK: Properties
     public private(set) var taskIdentifier: Source.Identifier.Value? {
         get {
@@ -451,7 +441,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         get {
             return getAssociatedObject(base, &indicatorTypeKey) ?? .none
         }
-        
+
         set {
             switch newValue {
             case .none: indicator = nil
@@ -463,7 +453,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
             setRetainedAssociatedObject(base, &indicatorTypeKey, newValue)
         }
     }
-    
+
     /// Holds any type that conforms to the protocol `Indicator`.
     /// The protocol `Indicator` has a `view` property that will be shown when loading an image.
     /// It will be `nil` if `indicatorType` is `.none`.
@@ -472,18 +462,18 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
             let box: Box<Indicator>? = getAssociatedObject(base, &indicatorKey)
             return box?.value
         }
-        
+
         set {
             // Remove previous
             if let previousIndicator = indicator {
                 previousIndicator.view.removeFromSuperview()
             }
-            
+
             // Add new
             if let newIndicator = newValue {
                 // Set default indicator layout
                 let view = newIndicator.view
-                
+
                 base.addSubview(view)
                 view.translatesAutoresizingMaskIntoConstraints = false
                 view.centerXAnchor.constraint(
@@ -501,7 +491,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
                     view.heightAnchor.constraint(equalToConstant: size.height).isActive = true
                     view.widthAnchor.constraint(equalToConstant: size.width).isActive = true
                 }
-                
+
                 newIndicator.view.isHidden = true
             }
 
@@ -511,10 +501,10 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
             setRetainedAssociatedObject(base, &indicatorKey, newValue.map(Box.init))
         }
     }
-    
+
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
-        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue) }
     }
 
     /// Represents the `Placeholder` used for this image view. A `Placeholder` will be shown in the view while
@@ -525,7 +515,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
             if let previousPlaceholder = placeholder {
                 previousPlaceholder.remove(from: base)
             }
-            
+
             if let newPlaceholder = newValue {
                 newPlaceholder.add(to: base)
             } else {
@@ -535,7 +525,6 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         }
     }
 }
-
 
 extension KFCrossPlatformImageView {
     @objc func shouldPreloadAllAnimation() -> Bool { return true }

--- a/Sources/Extensions/NSButton+Kingfisher.swift
+++ b/Sources/Extensions/NSButton+Kingfisher.swift
@@ -29,7 +29,6 @@
 import AppKit
 
 extension KingfisherWrapper where Base: NSButton {
-
     // MARK: Setting Image
 
     /// Sets an image to the button with a source.
@@ -54,8 +53,7 @@ extension KingfisherWrapper where Base: NSButton {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         let options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions + (options ?? .empty))
         return setImage(
             with: source,
@@ -88,8 +86,7 @@ extension KingfisherWrapper where Base: NSButton {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setImage(
             with: resource?.convertToSource(),
             placeholder: placeholder,
@@ -103,8 +100,7 @@ extension KingfisherWrapper where Base: NSButton {
         placeholder: KFCrossPlatformImage? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         var mutatingSelf = self
         guard let source = source else {
             base.image = placeholder
@@ -192,8 +188,7 @@ extension KingfisherWrapper where Base: NSButton {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         let options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions + (options ?? .empty))
         return setAlternateImage(
             with: source,
@@ -226,8 +221,7 @@ extension KingfisherWrapper where Base: NSButton {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setAlternateImage(
             with: resource?.convertToSource(),
             placeholder: placeholder,
@@ -241,8 +235,7 @@ extension KingfisherWrapper where Base: NSButton {
         placeholder: KFCrossPlatformImage? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         var mutatingSelf = self
         guard let source = source else {
             base.alternateImage = placeholder
@@ -323,7 +316,6 @@ extension KingfisherWrapper where Base: NSButton {
     }
 }
 
-
 // MARK: - Associated Object
 private var taskIdentifierKey: Void?
 private var imageTaskKey: Void?
@@ -332,9 +324,8 @@ private var alternateTaskIdentifierKey: Void?
 private var alternateImageTaskKey: Void?
 
 extension KingfisherWrapper where Base: NSButton {
-
     // MARK: Properties
-    
+
     public private(set) var taskIdentifier: Source.Identifier.Value? {
         get {
             let box: Box<Source.Identifier.Value>? = getAssociatedObject(base, &taskIdentifierKey)
@@ -345,10 +336,10 @@ extension KingfisherWrapper where Base: NSButton {
             setRetainedAssociatedObject(base, &taskIdentifierKey, box)
         }
     }
-    
+
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
-        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue) }
     }
 
     public private(set) var alternateTaskIdentifier: Source.Identifier.Value? {
@@ -364,7 +355,7 @@ extension KingfisherWrapper where Base: NSButton {
 
     private var alternateImageTask: DownloadTask? {
         get { return getAssociatedObject(base, &alternateImageTaskKey) }
-        set { setRetainedAssociatedObject(base, &alternateImageTaskKey, newValue)}
+        set { setRetainedAssociatedObject(base, &alternateImageTaskKey, newValue) }
     }
 }
 #endif

--- a/Sources/Extensions/NSTextAttachment+Kingfisher.swift
+++ b/Sources/Extensions/NSTextAttachment+Kingfisher.swift
@@ -33,7 +33,6 @@ import UIKit
 #endif
 
 extension KingfisherWrapper where Base: NSTextAttachment {
-
     // MARK: Setting Image
 
     /// Sets an image to the text attachment with a source.
@@ -86,8 +85,7 @@ extension KingfisherWrapper where Base: NSTextAttachment {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         let options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions + (options ?? .empty))
         return setImage(
             with: source,
@@ -149,8 +147,7 @@ extension KingfisherWrapper where Base: NSTextAttachment {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         let options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions + (options ?? .empty))
         return setImage(
             with: resource.map { .network($0) },
@@ -168,8 +165,7 @@ extension KingfisherWrapper where Base: NSTextAttachment {
         placeholder: KFCrossPlatformImage? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         var mutatingSelf = self
         guard let source = source else {
             base.image = placeholder
@@ -237,7 +233,7 @@ extension KingfisherWrapper where Base: NSTextAttachment {
                     }
                     completionHandler?(result)
                 }
-        }
+            }
         )
 
         mutatingSelf.imageTask = task
@@ -258,7 +254,6 @@ private var imageTaskKey: Void?
 
 // MARK: Properties
 extension KingfisherWrapper where Base: NSTextAttachment {
-
     public private(set) var taskIdentifier: Source.Identifier.Value? {
         get {
             let box: Box<Source.Identifier.Value>? = getAssociatedObject(base, &taskIdentifierKey)
@@ -272,7 +267,7 @@ extension KingfisherWrapper where Base: NSTextAttachment {
 
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
-        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue) }
     }
 }
 

--- a/Sources/Extensions/TVMonogramView+Kingfisher.swift
+++ b/Sources/Extensions/TVMonogramView+Kingfisher.swift
@@ -32,7 +32,6 @@ import TVUIKit
 
 @available(tvOS 12.0, *)
 extension KingfisherWrapper where Base: TVMonogramView {
-
     // MARK: Setting Image
 
     /// Sets an image to the image view with a source.
@@ -58,8 +57,7 @@ extension KingfisherWrapper where Base: TVMonogramView {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         let options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions + (options ?? .empty))
         return setImage(
             with: source,
@@ -75,8 +73,7 @@ extension KingfisherWrapper where Base: TVMonogramView {
         placeholder: KFCrossPlatformImage? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         var mutatingSelf = self
         guard let source = source else {
             base.image = placeholder
@@ -147,7 +144,7 @@ extension KingfisherWrapper where Base: TVMonogramView {
         mutatingSelf.imageTask = task
         return task
     }
-    
+
     /// Sets an image to the image view with a requested resource.
     ///
     /// - Parameters:
@@ -171,8 +168,7 @@ extension KingfisherWrapper where Base: TVMonogramView {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setImage(
             with: resource?.convertToSource(),
             placeholder: placeholder,
@@ -196,7 +192,6 @@ private var imageTaskKey: Void?
 // MARK: Properties
 @available(tvOS 12.0, *)
 extension KingfisherWrapper where Base: TVMonogramView {
-    
     public private(set) var taskIdentifier: Source.Identifier.Value? {
         get {
             let box: Box<Source.Identifier.Value>? = getAssociatedObject(base, &taskIdentifierKey)
@@ -210,7 +205,7 @@ extension KingfisherWrapper where Base: TVMonogramView {
 
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
-        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue) }
     }
 }
 

--- a/Sources/Extensions/UIButton+Kingfisher.swift
+++ b/Sources/Extensions/UIButton+Kingfisher.swift
@@ -30,7 +30,6 @@
 import UIKit
 
 extension KingfisherWrapper where Base: UIButton {
-
     // MARK: Setting Image
     /// Sets an image to the button for a specified state with a source.
     ///
@@ -56,8 +55,7 @@ extension KingfisherWrapper where Base: UIButton {
         placeholder: UIImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         let options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions + (options ?? .empty))
         return setImage(
             with: source,
@@ -68,7 +66,7 @@ extension KingfisherWrapper where Base: UIButton {
             completionHandler: completionHandler
         )
     }
-    
+
     /// Sets an image to the button for a specified state with a requested resource.
     ///
     /// - Parameters:
@@ -93,8 +91,7 @@ extension KingfisherWrapper where Base: UIButton {
         placeholder: UIImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setImage(
             with: resource?.convertToSource(),
             for: state,
@@ -111,8 +108,7 @@ extension KingfisherWrapper where Base: UIButton {
         placeholder: UIImage? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         guard let source = source else {
             base.setImage(placeholder, for: state)
             setTaskIdentifier(nil, for: state)
@@ -185,7 +181,7 @@ extension KingfisherWrapper where Base: UIButton {
     }
 
     // MARK: Cancelling Downloading Task
-    
+
     /// Cancels the image download task of the button if it is running.
     /// Nothing will happen if the downloading has already finished.
     public func cancelImageDownloadTask() {
@@ -218,8 +214,7 @@ extension KingfisherWrapper where Base: UIButton {
         placeholder: UIImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         let options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions + (options ?? .empty))
         return setBackgroundImage(
             with: source,
@@ -255,8 +250,7 @@ extension KingfisherWrapper where Base: UIButton {
         placeholder: UIImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setBackgroundImage(
             with: resource?.convertToSource(),
             for: state,
@@ -272,8 +266,7 @@ extension KingfisherWrapper where Base: UIButton {
         placeholder: UIImage? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         guard let source = source else {
             base.setBackgroundImage(placeholder, for: state)
             setBackgroundTaskIdentifier(nil, for: state)
@@ -346,7 +339,7 @@ extension KingfisherWrapper where Base: UIButton {
     }
 
     // MARK: Cancelling Background Downloading Task
-    
+
     /// Cancels the background image download task of the button if it is running.
     /// Nothing will happen if the downloading has already finished.
     public func cancelBackgroundImageDownloadTask() {
@@ -360,9 +353,8 @@ private var imageTaskKey: Void?
 
 // MARK: Properties
 extension KingfisherWrapper where Base: UIButton {
-
     private typealias TaskIdentifier = Box<[UInt: Source.Identifier.Value]>
-    
+
     public func taskIdentifier(for state: UIControl.State) -> Source.Identifier.Value? {
         return taskIdentifierInfo.value[state.rawValue]
     }
@@ -370,42 +362,40 @@ extension KingfisherWrapper where Base: UIButton {
     private func setTaskIdentifier(_ identifier: Source.Identifier.Value?, for state: UIControl.State) {
         taskIdentifierInfo.value[state.rawValue] = identifier
     }
-    
+
     private var taskIdentifierInfo: TaskIdentifier {
         return  getAssociatedObject(base, &taskIdentifierKey) ?? {
             setRetainedAssociatedObject(base, &taskIdentifierKey, $0)
             return $0
-        } (TaskIdentifier([:]))
+        }(TaskIdentifier([:]))
     }
-    
+
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
-        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue) }
     }
 }
-
 
 private var backgroundTaskIdentifierKey: Void?
 private var backgroundImageTaskKey: Void?
 
 // MARK: Background Properties
 extension KingfisherWrapper where Base: UIButton {
-    
     public func backgroundTaskIdentifier(for state: UIControl.State) -> Source.Identifier.Value? {
         return backgroundTaskIdentifierInfo.value[state.rawValue]
     }
-    
+
     private func setBackgroundTaskIdentifier(_ identifier: Source.Identifier.Value?, for state: UIControl.State) {
         backgroundTaskIdentifierInfo.value[state.rawValue] = identifier
     }
-    
+
     private var backgroundTaskIdentifierInfo: TaskIdentifier {
         return  getAssociatedObject(base, &backgroundTaskIdentifierKey) ?? {
             setRetainedAssociatedObject(base, &backgroundTaskIdentifierKey, $0)
             return $0
-        } (TaskIdentifier([:]))
+        }(TaskIdentifier([:]))
     }
-    
+
     private var backgroundImageTask: DownloadTask? {
         get { return getAssociatedObject(base, &backgroundImageTaskKey) }
         mutating set { setRetainedAssociatedObject(base, &backgroundImageTaskKey, newValue) }

--- a/Sources/Extensions/WKInterfaceImage+Kingfisher.swift
+++ b/Sources/Extensions/WKInterfaceImage+Kingfisher.swift
@@ -29,7 +29,6 @@
 import WatchKit
 
 extension KingfisherWrapper where Base: WKInterfaceImage {
-
     // MARK: Setting Image
 
     /// Sets an image to the image view with a source.
@@ -55,8 +54,7 @@ extension KingfisherWrapper where Base: WKInterfaceImage {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         let options = KingfisherParsedOptionsInfo(KingfisherManager.shared.defaultOptions + (options ?? .empty))
         return setImage(
             with: source,
@@ -66,7 +64,7 @@ extension KingfisherWrapper where Base: WKInterfaceImage {
             completionHandler: completionHandler
         )
     }
-    
+
     /// Sets an image to the image view with a requested resource.
     ///
     /// - Parameters:
@@ -90,8 +88,7 @@ extension KingfisherWrapper where Base: WKInterfaceImage {
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         return setImage(
             with: resource?.convertToSource(),
             placeholder: placeholder,
@@ -105,8 +102,7 @@ extension KingfisherWrapper where Base: WKInterfaceImage {
         placeholder: KFCrossPlatformImage? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         var mutatingSelf = self
         guard let source = source else {
             base.setImage(placeholder)
@@ -192,7 +188,6 @@ private var imageTaskKey: Void?
 
 // MARK: Properties
 extension KingfisherWrapper where Base: WKInterfaceImage {
-    
     public private(set) var taskIdentifier: Source.Identifier.Value? {
         get {
             let box: Box<Source.Identifier.Value>? = getAssociatedObject(base, &taskIdentifierKey)
@@ -206,7 +201,7 @@ extension KingfisherWrapper where Base: WKInterfaceImage {
 
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
-        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue) }
     }
 }
 #endif

--- a/Sources/General/ImageSource/AVAssetImageDataProvider.swift
+++ b/Sources/General/ImageSource/AVAssetImageDataProvider.swift
@@ -26,8 +26,8 @@
 
 #if !os(watchOS)
 
-import Foundation
 import AVKit
+import Foundation
 
 #if canImport(MobileCoreServices)
 import MobileCoreServices
@@ -37,7 +37,6 @@ import CoreServices
 
 /// A data provider to provide thumbnail data from a given AVKit asset.
 public struct AVAssetImageDataProvider: ImageDataProvider {
-
     /// The possible error might be caused by the `AVAssetImageDataProvider`.
     /// - userCancelled: The data provider process is cancelled.
     /// - invalidImage: The retrieved image is invalid.

--- a/Sources/General/ImageSource/ImageDataProvider.swift
+++ b/Sources/General/ImageSource/ImageDataProvider.swift
@@ -31,10 +31,9 @@ import Foundation
 /// to load some image data in your own way, as long as you can provide the data
 /// representation for the image.
 public protocol ImageDataProvider {
-    
     /// The key used in cache.
     var cacheKey: String { get }
-    
+
     /// Provides the data which represents image. Kingfisher uses the data you pass in the
     /// handler to process images and caches it for later use.
     ///
@@ -65,7 +64,6 @@ public extension ImageDataProvider {
 /// directly, you can get benefit of using Kingfisher's extension methods, as well
 /// as applying `ImageProcessor`s and storing the image to `ImageCache` of Kingfisher.
 public struct LocalFileImageDataProvider: ImageDataProvider {
-
     // MARK: Public Properties
 
     /// The file URL from which the image be loaded.
@@ -111,7 +109,7 @@ public struct LocalFileImageDataProvider: ImageDataProvider {
 
 extension URL {
     static let localFileCacheKeyPrefix = "kingfisher.local.cacheKey"
-    
+
     // The special version of cache key for a local file on disk. Every time the app is reinstalled on the disk,
     // the system assigns a new container folder to hold the .app (and the extensions, .appex) folder. So the URL for
     // the same image in bundle might be different.
@@ -139,7 +137,6 @@ extension URL {
 
 /// Represents an image data provider for loading image from a given Base64 encoded string.
 public struct Base64ImageDataProvider: ImageDataProvider {
-
     // MARK: Public Properties
     /// The encoded Base64 string for the image.
     public let base64String: String
@@ -169,7 +166,6 @@ public struct Base64ImageDataProvider: ImageDataProvider {
 
 /// Represents an image data provider for a raw data object.
 public struct RawImageDataProvider: ImageDataProvider {
-
     // MARK: Public Properties
 
     /// The raw data object to provide to Kingfisher image loader.
@@ -188,7 +184,7 @@ public struct RawImageDataProvider: ImageDataProvider {
     }
 
     // MARK: Protocol Conforming
-    
+
     /// The key used in cache.
     public var cacheKey: String
 

--- a/Sources/General/ImageSource/Resource.swift
+++ b/Sources/General/ImageSource/Resource.swift
@@ -30,16 +30,14 @@ import Foundation
 /// Kingfisher will use a `Resource` to download a resource from network and cache it with the cache key when
 /// using `Source.network` as its image setting source.
 public protocol Resource {
-    
     /// The key used in cache.
     var cacheKey: String { get }
-    
+
     /// The target image URL.
     var downloadURL: URL { get }
 }
 
 extension Resource {
-
     /// Converts `self` to a valid `Source` based on its `downloadURL` scheme. A `.provider` with
     /// `LocalFileImageDataProvider` associated will be returned if the URL points to a local file. Otherwise,
     /// `.network` is returned.
@@ -54,7 +52,6 @@ extension Resource {
 /// When passed to image view set methods, Kingfisher will try to download the target
 /// image from the `downloadURL`, and then store it with the `cacheKey` as the key in cache.
 public struct ImageResource: Resource {
-
     // MARK: - Initializers
 
     /// Creates an image resource.
@@ -69,7 +66,7 @@ public struct ImageResource: Resource {
     }
 
     // MARK: Protocol Conforming
-    
+
     /// The key used in cache.
     public let cacheKey: String
 

--- a/Sources/General/ImageSource/Source.swift
+++ b/Sources/General/ImageSource/Source.swift
@@ -35,10 +35,8 @@ import Foundation
 /// - provider: The target image should be provided in a data format. Normally, it can be an image
 ///             from local storage or in any other encoding format (like Base64).
 public enum Source {
-
     /// Represents the source task identifier when setting an image to a view with extension methods.
     public enum Identifier {
-
         /// The underlying value type of source identifier.
         public typealias Value = UInt
         static var current: Value = 0
@@ -53,7 +51,7 @@ public enum Source {
     /// The target image should be got from network remotely. The associated `Resource`
     /// value defines detail information like image URL and cache key.
     case network(Resource)
-    
+
     /// The target image should be provided in a data format. Normally, it can be an image
     /// from local storage or in any other encoding format (like Base64).
     case provider(ImageDataProvider)
@@ -87,9 +85,9 @@ extension Source: Hashable {
             return r1.cacheKey == r2.cacheKey && r1.downloadURL == r2.downloadURL
         case (.provider(let p1), .provider(let p2)):
             return p1.cacheKey == p2.cacheKey && p1.contentURL == p2.contentURL
-        case (.provider(_), .network(_)):
+        case (.provider, .network):
             return false
-        case (.network(_), .provider(_)):
+        case (.network, .provider):
             return false
         }
     }

--- a/Sources/General/KF.swift
+++ b/Sources/General/KF.swift
@@ -47,7 +47,6 @@ import TVUIKit
 /// A helper type to create image setting tasks in a builder pattern.
 /// Use methods in this type to create a `KF.Builder` instance and configure image tasks there.
 public enum KF {
-
     /// Creates a builder for a given `Source`.
     /// - Parameter source: The `Source` object defines data information from network or a data provider.
     /// - Returns: A `KF.Builder` for future configuration. After configuring the builder, call `set(to:)`
@@ -98,9 +97,7 @@ public enum KF {
     }
 }
 
-
 extension KF {
-
     /// A builder class to configure an image retrieving task and set it to a holder view or component.
     public class Builder {
         private let source: Source?
@@ -164,7 +161,7 @@ extension KF.Builder {
     ///            This value is `nil` if the image is being loaded from cache.
     @discardableResult
     public func set(to attachment: NSTextAttachment, attributedView: @autoclosure @escaping () -> KFCrossPlatformView) -> DownloadTask? {
-        let placeholderImage = placeholder as? KFCrossPlatformImage ?? nil
+        let placeholderImage = placeholder as? KFCrossPlatformImage
         return attachment.kf.setImage(
             with: source,
             attributedView: attributedView,
@@ -185,7 +182,7 @@ extension KF.Builder {
     ///            This value is `nil` if the image is being loaded from cache.
     @discardableResult
     public func set(to button: UIButton, for state: UIControl.State) -> DownloadTask? {
-        let placeholderImage = placeholder as? KFCrossPlatformImage ?? nil
+        let placeholderImage = placeholder as? KFCrossPlatformImage
         return button.kf.setImage(
             with: source,
             for: state,
@@ -204,7 +201,7 @@ extension KF.Builder {
     ///            This value is `nil` if the image is being loaded from cache.
     @discardableResult
     public func setBackground(to button: UIButton, for state: UIControl.State) -> DownloadTask? {
-        let placeholderImage = placeholder as? KFCrossPlatformImage ?? nil
+        let placeholderImage = placeholder as? KFCrossPlatformImage
         return button.kf.setBackgroundImage(
             with: source,
             for: state,
@@ -215,9 +212,9 @@ extension KF.Builder {
         )
     }
     #endif // end of canImport(UIKit)
-    
+
     #if canImport(CarPlay)
-    
+
     /// Builds the image task request and sets it to the image for a list item.
     /// - Parameters:
     ///   - listItem: The list item which loads the task and should be set with the image.
@@ -226,7 +223,7 @@ extension KF.Builder {
     @available(iOS 14.0, *)
     @discardableResult
     public func set(to listItem: CPListItem) -> DownloadTask? {
-        let placeholderImage = placeholder as? KFCrossPlatformImage ?? nil
+        let placeholderImage = placeholder as? KFCrossPlatformImage
         return listItem.kf.setImage(
             with: source,
             placeholder: placeholderImage,
@@ -234,9 +231,8 @@ extension KF.Builder {
             progressBlock: progressBlock,
             completionHandler: resultHandler
         )
-        
     }
-    
+
     #endif
 
     #if canImport(AppKit) && !targetEnvironment(macCatalyst)
@@ -246,7 +242,7 @@ extension KF.Builder {
     ///            This value is `nil` if the image is being loaded from cache.
     @discardableResult
     public func set(to button: NSButton) -> DownloadTask? {
-        let placeholderImage = placeholder as? KFCrossPlatformImage ?? nil
+        let placeholderImage = placeholder as? KFCrossPlatformImage
         return button.kf.setImage(
             with: source,
             placeholder: placeholderImage,
@@ -262,7 +258,7 @@ extension KF.Builder {
     ///            This value is `nil` if the image is being loaded from cache.
     @discardableResult
     public func setAlternative(to button: NSButton) -> DownloadTask? {
-        let placeholderImage = placeholder as? KFCrossPlatformImage ?? nil
+        let placeholderImage = placeholder as? KFCrossPlatformImage
         return button.kf.setAlternateImage(
             with: source,
             placeholder: placeholderImage,
@@ -299,7 +295,7 @@ extension KF.Builder {
     @available(tvOS 12.0, *)
     @discardableResult
     public func set(to monogramView: TVMonogramView) -> DownloadTask? {
-        let placeholderImage = placeholder as? KFCrossPlatformImage ?? nil
+        let placeholderImage = placeholder as? KFCrossPlatformImage
         return monogramView.kf.setImage(
             with: source,
             placeholder: placeholderImage,
@@ -335,7 +331,6 @@ extension KF.Builder {
 #endif
 
 extension KF.Builder {
-
     #if os(iOS) || os(tvOS)
     /// Sets the transition for the image task.
     /// - Parameter transition: The desired transition effect when setting the image to image view.
@@ -421,11 +416,9 @@ extension KF.Builder {
 
 // MARK: - Redirect Handler
 extension KF {
-
     /// Represents the detail information when a task redirect happens. It is wrapping necessary information for a
     /// `ImageDownloadRedirectHandler`. See that protocol for more information.
     public struct RedirectPayload {
-
         /// The related session data task when the redirect happens. It is
         /// the current `SessionDataTask` which triggers this redirect.
         public let task: SessionDataTask

--- a/Sources/General/KFOptionsSetter.swift
+++ b/Sources/General/KFOptionsSetter.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import Foundation
 import CoreGraphics
+import Foundation
 
 public protocol KFOptionSetter {
     var options: KingfisherParsedOptionsInfo { get nonmutating set }
@@ -424,7 +424,6 @@ extension KFOptionSetter {
 
 // MARK: - Processor
 extension KFOptionSetter {
-
     /// Sets an image processor for the image task. It replaces the current image processor settings.
     ///
     /// - Parameter processor: The processor you want to use to process the image after it is downloaded.
@@ -480,8 +479,7 @@ extension KFOptionSetter {
         targetSize: CGSize? = nil,
         roundingCorners corners: RectCorner = .all,
         backgroundColor: KFCrossPlatformColor? = nil
-    ) -> Self
-    {
+    ) -> Self {
         let processor = RoundCornerImageProcessor(
             radius: radius,
             targetSize: targetSize,
@@ -562,7 +560,6 @@ extension KFOptionSetter {
         }
     }
 
-
     /// Appends a `ResizingImageProcessor` to current processors.
     ///
     /// If you need to resize a data represented image to a smaller size, use `DownsamplingImageProcessor`
@@ -581,7 +578,6 @@ extension KFOptionSetter {
 
 // MARK: - Cache Serializer
 extension KFOptionSetter {
-
     /// Uses a given `CacheSerializer` to convert some data to an image object for retrieving from disk cache or vice
     /// versa for storing to disk cache.
     /// - Parameter cacheSerializer: The `CacheSerializer` which will be used.
@@ -616,7 +612,6 @@ extension KFOptionSetter {
 
 // MARK: - Image Modifier
 extension KFOptionSetter {
-
     /// Sets an `ImageModifier` to the image task. Use this to modify the fetched image object properties if needed.
     ///
     /// If the image was fetched directly from the downloader, the modifier will run directly after the
@@ -646,10 +641,8 @@ extension KFOptionSetter {
     }
 }
 
-
 // MARK: - Cache Expiration
 extension KFOptionSetter {
-
     /// Sets the expiration setting for memory cache of this image task.
     ///
     /// By default, the underlying `MemoryStorage.Backend` uses the

--- a/Sources/General/KingfisherError.swift
+++ b/Sources/General/KingfisherError.swift
@@ -33,7 +33,6 @@ extension Never {}
 /// as its error type. To handle errors from Kingfisher, you switch over the error to get a reason catalog,
 /// then switch over the reason to know error detail.
 public enum KingfisherError: Error {
-
     // MARK: Error Reason Types
 
     /// Represents the error reason during networking request phase.
@@ -42,20 +41,19 @@ public enum KingfisherError: Error {
     /// - invalidURL: The URL of request is invalid. Code 1002.
     /// - taskCancelled: The downloading task is cancelled by user. Code 1003.
     public enum RequestErrorReason {
-        
         /// The request is empty. Code 1001.
         case emptyRequest
-        
+
         /// The URL of request is invalid. Code 1002.
         /// - request: The request is tend to be sent but its URL is invalid.
         case invalidURL(request: URLRequest)
-        
+
         /// The downloading task is cancelled by user. Code 1003.
         /// - task: The session data task which is cancelled.
         /// - token: The cancel token which is used for cancelling the task.
         case taskCancelled(task: SessionDataTask, token: SessionDataTask.CancelToken)
     }
-    
+
     /// Represents the error reason during networking response phase.
     ///
     /// - invalidURLResponse: The response is not a valid URL response. Code 2001.
@@ -64,32 +62,31 @@ public enum KingfisherError: Error {
     /// - dataModifyingFailed: Data modifying fails on returning a valid data. Code 2004.
     /// - noURLResponse: The task is done but no URL response found. Code 2005.
     public enum ResponseErrorReason {
-        
         /// The response is not a valid URL response. Code 2001.
         /// - response: The received invalid URL response.
         ///             The response is expected to be an HTTP response, but it is not.
         case invalidURLResponse(response: URLResponse)
-        
+
         /// The response contains an invalid HTTP status code. Code 2002.
         /// - Note:
         ///   By default, status code 200..<400 is recognized as valid. You can override
         ///   this behavior by conforming to the `ImageDownloaderDelegate`.
         /// - response: The received response.
         case invalidHTTPStatusCode(response: HTTPURLResponse)
-        
+
         /// An error happens in the system URL session. Code 2003.
         /// - error: The underlying URLSession error object.
         case URLSessionError(error: Error)
-        
+
         /// Data modifying fails on returning a valid data. Code 2004.
         /// - task: The failed task.
         case dataModifyingFailed(task: SessionDataTask)
-        
+
         /// The task is done but no URL response found. Code 2005.
         /// - task: The failed task.
         case noURLResponse(task: SessionDataTask)
     }
-    
+
     /// Represents the error reason during Kingfisher caching system.
     ///
     /// - fileEnumeratorCreationFailed: Cannot create a file enumerator for a certain disk URL. Code 3001.
@@ -103,39 +100,38 @@ public enum KingfisherError: Error {
     /// - cannotCreateCacheFile: Cannot create the cache file at a certain fileURL under a key. Code 3009.
     /// - cannotSetCacheFileAttribute: Cannot set file attributes to a cached file. Code 3010.
     public enum CacheErrorReason {
-        
         /// Cannot create a file enumerator for a certain disk URL. Code 3001.
         /// - url: The target disk URL from which the file enumerator should be created.
         case fileEnumeratorCreationFailed(url: URL)
-        
+
         /// Cannot get correct file contents from a file enumerator. Code 3002.
         /// - url: The target disk URL from which the content of a file enumerator should be got.
         case invalidFileEnumeratorContent(url: URL)
-        
+
         /// The file at target URL exists, but its URL resource is unavailable. Code 3003.
         /// - error: The underlying error thrown by file manager.
         /// - key: The key used to getting the resource from cache.
         /// - url: The disk URL where the target cached file exists.
         case invalidURLResource(error: Error, key: String, url: URL)
-        
+
         /// The file at target URL exists, but the data cannot be loaded from it. Code 3004.
         /// - url: The disk URL where the target cached file exists.
         /// - error: The underlying error which describes why this error happens.
         case cannotLoadDataFromDisk(url: URL, error: Error)
-        
+
         /// Cannot create a folder at a given path. Code 3005.
         /// - path: The disk path where the directory creating operation fails.
         /// - error: The underlying error which describes why this error happens.
         case cannotCreateDirectory(path: String, error: Error)
-        
+
         /// The requested image does not exist in cache. Code 3006.
         /// - key: Key of the requested image in cache.
         case imageNotExisting(key: String)
-        
+
         /// Cannot convert an object to data for storing. Code 3007.
         /// - object: The object which needs be convert to data.
         case cannotConvertToData(object: Any, error: Error)
-        
+
         /// Cannot serialize an image to data for storing. Code 3008.
         /// - image: The input image needs to be serialized to cache.
         /// - original: The original image data, if exists.
@@ -156,7 +152,7 @@ public enum KingfisherError: Error {
         /// - attributes: The file attribute to be set to the target file.
         /// - error: The underlying error originally thrown by Foundation when setting the `attributes` to the disk
         ///          file at `filePath`.
-        case cannotSetCacheFileAttribute(filePath: String, attributes: [FileAttributeKey : Any], error: Error)
+        case cannotSetCacheFileAttribute(filePath: String, attributes: [FileAttributeKey: Any], error: Error)
 
         /// The disk storage of cache is not ready. Code 3011.
         ///
@@ -166,8 +162,7 @@ public enum KingfisherError: Error {
         /// - cacheURL: The intended URL which should be the storage folder.
         case diskStorageIsNotReady(cacheURL: URL)
     }
-    
-    
+
     /// Represents the error reason during image processing phase.
     ///
     /// - processingFailed: Image processing fails. There is no valid output image from the processor. Code 4001.
@@ -184,10 +179,9 @@ public enum KingfisherError: Error {
     /// - notCurrentSourceTask: The source task is finished, but it is not the one expected now. Code 5002.
     /// - dataProviderError: An error happens during getting data from an `ImageDataProvider`. Code 5003.
     public enum ImageSettingErrorReason {
-        
         /// The input resource is empty or `nil`. Code 5001.
         case emptySource
-        
+
         /// The resource task is finished, but it is not the one expected now. This usually happens when you set another
         /// resource on the view without cancelling the current on-going one. The previous setting task will fail with
         /// this `.notCurrentSourceTask` error when a result got, regardless of it being successful or not for that task.
@@ -212,7 +206,7 @@ public enum KingfisherError: Error {
     }
 
     // MARK: Member Cases
-    
+
     /// Represents the error reason during networking request phase.
     case requestError(reason: RequestErrorReason)
     /// Represents the error reason during networking response phase.
@@ -269,18 +263,15 @@ public enum KingfisherError: Error {
         if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *),
            case .responseError(reason: .URLSessionError(let sessionError)) = self,
            let urlError = sessionError as? URLError,
-           urlError.networkUnavailableReason == .constrained
-        {
+           urlError.networkUnavailableReason == .constrained {
             return true
         }
         return false
     }
-
 }
 
 // MARK: - LocalizedError Conforming
 extension KingfisherError: LocalizedError {
-    
     /// A localized message describing what error occurred.
     public var errorDescription: String? {
         switch self {
@@ -293,10 +284,8 @@ extension KingfisherError: LocalizedError {
     }
 }
 
-
 // MARK: - CustomNSError Conforming
 extension KingfisherError: CustomNSError {
-
     /// The error domain of `KingfisherError`. All errors from Kingfisher is under this domain.
     public static let domain = "com.onevcat.Kingfisher.Error"
 
@@ -323,7 +312,7 @@ extension KingfisherError.RequestErrorReason {
             return "The session task was cancelled. Task: \(task), cancel token: \(token)."
         }
     }
-    
+
     var errorCode: Int {
         switch self {
         case .emptyRequest: return 1001
@@ -348,7 +337,7 @@ extension KingfisherError.ResponseErrorReason {
             return "No URL response received. Task: \(task),"
         }
     }
-    
+
     var errorCode: Int {
         switch self {
         case .invalidURLResponse: return 2001
@@ -382,7 +371,7 @@ extension KingfisherError.CacheErrorReason {
                    "Object: \(object). Underlying error: \(error)"
         case .cannotSerializeImage(let image, let originalData, let serializer):
             return "Cannot serialize an image due to the cache serializer returning `nil`. " +
-                   "Image: \(String(describing:image)), original data: \(String(describing: originalData)), " +
+                   "Image: \(String(describing: image)), original data: \(String(describing: originalData)), " +
                    "serializer: \(serializer)."
         case .cannotCreateCacheFile(let fileURL, let key, let data, let error):
             return "Cannot create cache file at url: \(fileURL), key: \(key), data length: \(data.count). " +
@@ -395,7 +384,7 @@ extension KingfisherError.CacheErrorReason {
                 "This is usually caused by extremely lack of disk space. Ask users to free up some space and restart the app."
         }
     }
-    
+
     var errorCode: Int {
         switch self {
         case .fileEnumeratorCreationFailed: return 3001
@@ -420,7 +409,7 @@ extension KingfisherError.ProcessorErrorReason {
             return "Processing image failed. Processor: \(processor). Processing item: \(item)."
         }
     }
-    
+
     var errorCode: Int {
         switch self {
         case .processingFailed: return 4001
@@ -449,7 +438,7 @@ extension KingfisherError.ImageSettingErrorReason {
             return "Image setting from alternaive sources failed: \(errors)"
         }
     }
-    
+
     var errorCode: Int {
         switch self {
         case .emptySource: return 5001

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -24,7 +24,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-
 import Foundation
 
 /// The downloading progress block type.
@@ -35,7 +34,6 @@ public typealias DownloadProgressBlock = ((_ receivedSize: Int64, _ totalSize: I
 
 /// Represents the result of a Kingfisher retrieving image task.
 public struct RetrieveImageResult {
-
     /// Gets the image object of this result.
     public let image: KFCrossPlatformImage
 
@@ -55,14 +53,12 @@ public struct RetrieveImageResult {
 /// A struct that stores some related information of an `KingfisherError`. It provides some context information for
 /// a pure error so you can identify the error easier.
 public struct PropagationError {
-
     /// The `Source` to which current `error` is bound.
     public let source: Source
 
     /// The actual error happens in framework.
     public let error: KingfisherError
 }
-
 
 /// The downloading task updated block type. The parameter `newTask` is the updated new task of image setting process.
 /// It is a `nil` if the image loading does not require an image downloading process. If an image downloading is issued,
@@ -73,36 +69,35 @@ public typealias DownloadTaskUpdatedBlock = ((_ newTask: DownloadTask?) -> Void)
 /// to provide a set of convenience methods to use Kingfisher for tasks.
 /// You can use this class to retrieve an image via a specified URL from web or cache.
 public class KingfisherManager {
-
     /// Represents a shared manager used across Kingfisher.
     /// Use this instance for getting or storing images with Kingfisher.
     public static let shared = KingfisherManager()
 
-    // Mark: Public Properties
+    // MARK: Public Properties
     /// The `ImageCache` used by this manager. It is `ImageCache.default` by default.
     /// If a cache is specified in `KingfisherManager.defaultOptions`, the value in `defaultOptions` will be
     /// used instead.
     public var cache: ImageCache
-    
+
     /// The `ImageDownloader` used by this manager. It is `ImageDownloader.default` by default.
     /// If a downloader is specified in `KingfisherManager.defaultOptions`, the value in `defaultOptions` will be
     /// used instead.
     public var downloader: ImageDownloader
-    
+
     /// Default options used by the manager. This option will be used in
     /// Kingfisher manager related methods, as well as all view extension methods.
     /// You can also passing other options for each image task by sending an `options` parameter
     /// to Kingfisher's APIs. The per image options will overwrite the default ones,
     /// if the option exists in both.
     public var defaultOptions = KingfisherOptionsInfo.empty
-    
+
     // Use `defaultOptions` to overwrite the `downloader` and `cache`.
     private var currentDefaultOptions: KingfisherOptionsInfo {
         return [.downloader(downloader), .targetCache(cache)] + defaultOptions
     }
 
     private let processingQueue: CallbackQueue
-    
+
     private convenience init() {
         self.init(downloader: .default, cache: .default)
     }
@@ -148,8 +143,7 @@ public class KingfisherManager {
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
         downloadTaskUpdated: DownloadTaskUpdatedBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask? {
         return retrieveImage(
             with: resource.convertToSource(),
             options: options,
@@ -186,8 +180,7 @@ public class KingfisherManager {
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
         downloadTaskUpdated: DownloadTaskUpdatedBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask? {
         let options = currentDefaultOptions + (options ?? .empty)
         let info = KingfisherParsedOptionsInfo(options)
         return retrieveImage(
@@ -203,8 +196,7 @@ public class KingfisherManager {
         options: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
         downloadTaskUpdated: DownloadTaskUpdatedBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask? {
         var info = options
         if let block = progressBlock {
             info.onDataReceived = (info.onDataReceived ?? []) + [ImageLoadingProgressSideEffect(block)]
@@ -220,8 +212,7 @@ public class KingfisherManager {
         with source: Source,
         options: KingfisherParsedOptionsInfo,
         downloadTaskUpdated: DownloadTaskUpdatedBlock? = nil,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask? {
         let retrievingContext = RetrievingContext(options: options, originalSource: source)
         var retryContext: RetryContext?
 
@@ -295,42 +286,38 @@ public class KingfisherManager {
 
         return retrieveImage(
             with: source,
-            context: retrievingContext)
-        {
+            context: retrievingContext) {
             result in
             handler(currentSource: source, result: result)
         }
-
     }
-    
+
     private func retrieveImage(
         with source: Source,
         context: RetrievingContext,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask? {
         let options = context.options
         if options.forceRefresh {
             return loadAndCacheImage(
                 source: source,
                 context: context,
                 completionHandler: completionHandler)?.value
-            
         } else {
             let loadedFromCache = retrieveImageFromCache(
                 source: source,
                 context: context,
                 completionHandler: completionHandler)
-            
+
             if loadedFromCache {
                 return nil
             }
-            
+
             if options.onlyFromCache {
                 let error = KingfisherError.cacheError(reason: .imageNotExisting(key: source.cacheKey))
                 completionHandler?(.failure(error))
                 return nil
             }
-            
+
             return loadAndCacheImage(
                 source: source,
                 context: context,
@@ -341,8 +328,7 @@ public class KingfisherManager {
     func provideImage(
         provider: ImageDataProvider,
         options: KingfisherParsedOptionsInfo,
-        completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)?)
-    {
+        completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)?) {
         guard let  completionHandler = completionHandler else { return }
         provider.data { result in
             switch result {
@@ -370,7 +356,6 @@ public class KingfisherManager {
                         reason: .dataProviderError(provider: provider, error: error))
                     completionHandler(.failure(error))
                 }
-
             }
         }
     }
@@ -381,8 +366,7 @@ public class KingfisherManager {
         context: RetrievingContext,
         result: Result<ImageLoadingResult, KingfisherError>,
         completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?
-    )
-    {
+    ) {
         switch result {
         case .success(let value):
             let needToCacheOriginalImage = options.cacheOriginalImage &&
@@ -402,8 +386,7 @@ public class KingfisherManager {
                 original: value.originalData,
                 forKey: source.cacheKey,
                 options: options,
-                toDisk: !options.cacheMemoryOnly)
-            {
+                toDisk: !options.cacheMemoryOnly) {
                 _ in
                 coordinator.apply(.cachingImage) {
                     completionHandler?(.success(result))
@@ -418,8 +401,7 @@ public class KingfisherManager {
                     value.originalData,
                     forKey: source.cacheKey,
                     processorIdentifier: DefaultImageProcessor.default.identifier,
-                    expiration: options.diskCacheExpiration)
-                {
+                    expiration: options.diskCacheExpiration) {
                     _ in
                     coordinator.apply(.cachingOriginalImage) {
                         completionHandler?(.success(result))
@@ -440,8 +422,7 @@ public class KingfisherManager {
     func loadAndCacheImage(
         source: Source,
         context: RetrievingContext,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask.WrappedTask?
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask.WrappedTask? {
         let options = context.options
         func _cacheImage(_ result: Result<ImageLoadingResult, KingfisherError>) {
             cacheImage(
@@ -459,7 +440,6 @@ public class KingfisherManager {
             let task = downloader.downloadImage(
                 with: resource.downloadURL, options: options, completionHandler: _cacheImage
             )
-
 
             // The code below is neat, but it fails the Swift 5.2 compiler with a runtime crash when 
             // `BUILD_LIBRARY_FOR_DISTRIBUTION` is turned on. I believe it is a bug in the compiler. 
@@ -480,7 +460,7 @@ public class KingfisherManager {
             return .dataProviding
         }
     }
-    
+
     /// Retrieves image from memory or disk cache.
     ///
     /// - Parameters:
@@ -503,15 +483,14 @@ public class KingfisherManager {
     func retrieveImageFromCache(
         source: Source,
         context: RetrievingContext,
-        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> Bool
-    {
+        completionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> Bool {
         let options = context.options
         // 1. Check whether the image was already in target cache. If so, just get it.
         let targetCache = options.targetCache ?? cache
         let key = source.cacheKey
         let targetImageCached = targetCache.imageCachedType(
             forKey: key, processorIdentifier: options.processor.identifier)
-        
+
         let validCache = targetImageCached.cached &&
             (options.fromMemoryCacheOrRefresh == false || targetImageCached == .memory)
         if validCache {
@@ -555,18 +534,17 @@ public class KingfisherManager {
         let originalImageCacheType = originalCache.imageCachedType(
             forKey: key, processorIdentifier: DefaultImageProcessor.default.identifier)
         let canAcceptDiskCache = !options.fromMemoryCacheOrRefresh
-        
+
         let canUseOriginalImageCache =
             (canAcceptDiskCache && originalImageCacheType.cached) ||
             (!canAcceptDiskCache && originalImageCacheType == .memory)
-        
+
         if canUseOriginalImageCache {
             // Now we are ready to get found the original image from cache. We need the unprocessed image, so remove
             // any processor from options first.
             var optionsWithoutProcessor = options
             optionsWithoutProcessor.processor = DefaultImageProcessor.default
             originalCache.retrieveImage(forKey: key, options: optionsWithoutProcessor) { result in
-
                 result.match(
                     onSuccess: { cacheResult in
                         guard let image = cacheResult.image else {
@@ -601,8 +579,7 @@ public class KingfisherManager {
                                 processedImage,
                                 forKey: key,
                                 options: cacheOptions,
-                                toDisk: !options.cacheMemoryOnly)
-                            {
+                                toDisk: !options.cacheMemoryOnly) {
                                 _ in
                                 coordinator.apply(.cachingImage) {
                                     options.callbackQueue.execute { completionHandler?(.success(result)) }
@@ -633,7 +610,6 @@ public class KingfisherManager {
 }
 
 class RetrievingContext {
-
     var options: KingfisherParsedOptionsInfo
 
     let originalSource: Source
@@ -662,7 +638,6 @@ class RetrievingContext {
 }
 
 class CacheCallbackCoordinator {
-
     enum State {
         case idle
         case imageCached

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -29,7 +29,6 @@ import AppKit
 #else
 import UIKit
 #endif
-    
 
 /// KingfisherOptionsInfo is a typealias for [KingfisherOptionsInfoItem].
 /// You can use the enum of option item with value to control some behaviors of Kingfisher.
@@ -41,11 +40,10 @@ extension Array where Element == KingfisherOptionsInfoItem {
 
 /// Represents the available option items could be used in `KingfisherOptionsInfo`.
 public enum KingfisherOptionsInfoItem {
-    
     /// Kingfisher will use the associated `ImageCache` object when handling related operations,
     /// including trying to retrieve the cached images and store the downloaded image to it.
     case targetCache(ImageCache)
-    
+
     /// The `ImageCache` for storing and retrieving original images. If `originalCache` is
     /// contained in the options, it will be preferred for storing and retrieving original images.
     /// If there is no `.originalCache` in the options, `.targetCache` will be used to store original images.
@@ -57,7 +55,7 @@ public enum KingfisherOptionsInfoItem {
     /// it will be used and applied with the given processor. It is an optimization for not downloading
     /// the same image for multiple times.
     case originalCache(ImageCache)
-    
+
     /// Kingfisher will use the associated `ImageDownloader` object to download the requested images.
     case downloader(ImageDownloader)
 
@@ -66,11 +64,11 @@ public enum KingfisherOptionsInfoItem {
     /// image is retrieved from either memory or disk cache by default. If you need to do the transition even when
     /// the image being retrieved from cache, set `.forceRefresh` as well.
     case transition(ImageTransition)
-    
+
     /// Associated `Float` value will be set as the priority of image download task. The value for it should be
     /// between 0.0~1.0. If this option not set, the default value (`URLSessionTask.defaultPriority`) will be used.
     case downloadPriority(Float)
-    
+
     /// If set, Kingfisher will ignore the cache and try to start a download task for the image source.
     case forceRefresh
 
@@ -79,22 +77,22 @@ public enum KingfisherOptionsInfoItem {
     /// you want to display a changeable image behind the same url at the same app session, while avoiding download
     /// it for multiple times.
     case fromMemoryCacheOrRefresh
-    
+
     /// If set, setting the image to an image view will happen with transition even when retrieved from cache.
     /// See `.transition` option for more.
     case forceTransition
-    
+
     /// If set, Kingfisher will only cache the value in memory but not in disk.
     case cacheMemoryOnly
-    
+
     /// If set, Kingfisher will wait for caching operation to be completed before calling the completion block.
     case waitForCache
-    
+
     /// If set, Kingfisher will only try to retrieve the image from cache, but not from network. If the image is not in
     /// cache, the image retrieving will fail with the `KingfisherError.cacheError` with `.imageNotExisting` as its
     /// reason.
     case onlyFromCache
-    
+
     /// Decode the image in background thread before using. It will decode the downloaded image data and do a off-screen
     /// rendering to extract pixel information in background. This can speed up display, but will cost more time to
     /// prepare the image for using.
@@ -107,7 +105,7 @@ public enum KingfisherOptionsInfoItem {
     /// This option does not affect the callbacks for UI related extension methods. You will always get the
     /// callbacks called from main queue.
     case callbackQueue(CallbackQueue)
-    
+
     /// The associated value will be used as the scale factor when converting retrieved data to an image.
     /// Specify the image scale, instead of your screen scale. You may need to set the correct scale when you dealing
     /// with 2x or 3x retina images. Otherwise, Kingfisher will convert the data to image object at `scale` 1.0.
@@ -122,26 +120,26 @@ public enum KingfisherOptionsInfoItem {
     /// uses more CPU when display. While a normal image view (`UIImageView` or `NSImageView`) loads all data at once,
     /// which uses more memory but only decode image frames once.
     case preloadAllAnimationData
-    
+
     /// The `ImageDownloadRequestModifier` contained will be used to change the request before it being sent.
     /// This is the last chance you can modify the image download request. You can modify the request for some
     /// customizing purpose, such as adding auth token to the header, do basic HTTP auth or something like url mapping.
     /// The original request will be sent without any modification by default.
     case requestModifier(AsyncImageDownloadRequestModifier)
-    
+
     /// The `ImageDownloadRedirectHandler` contained will be used to change the request before redirection.
     /// This is the possibility you can modify the image download request during redirect. You can modify the request for
     /// some customizing purpose, such as adding auth token to the header, do basic HTTP auth or something like url
     /// mapping.
     /// The original redirection request will be sent without any modification by default.
     case redirectHandler(ImageDownloadRedirectHandler)
-    
+
     /// Processor for processing when the downloading finishes, a processor will convert the downloaded data to an image
     /// and/or apply some filter on it. If a cache is connected to the downloader (it happens when you are using
     /// KingfisherManager or any of the view extension methods), the converted image will also be sent to cache as well.
     /// If not set, the `DefaultImageProcessor.default` will be used.
     case processor(ImageProcessor)
-    
+
     /// Provides a `CacheSerializer` to convert some data to an image object for
     /// retrieving from disk cache or vice versa for storing to disk cache.
     /// If not set, the `DefaultCacheSerializer.default` will be used.
@@ -154,19 +152,19 @@ public enum KingfisherOptionsInfoItem {
     /// Use `ImageModifier` when you need to set properties that do not persist when caching the image on a concrete
     /// type of `Image`, such as the `renderingMode` or the `alignmentInsets` of `UIImage`.
     case imageModifier(ImageModifier)
-    
+
     /// Keep the existing image of image view while setting another image to it.
     /// By setting this option, the placeholder image parameter of image view extension method
     /// will be ignored and the current image will be kept while loading or downloading the new image.
     case keepCurrentImageWhileLoading
-    
+
     /// If set, Kingfisher will only load the first frame from an animated image file as a single image.
     /// Loading an animated images may take too much memory. It will be useful when you want to display a
     /// static preview of the first frame from an animated image.
     ///
     /// This option will be ignored if the target image is not animated image data.
     case onlyLoadFirstFrame
-    
+
     /// If set and an `ImageProcessor` is used, Kingfisher will try to cache both the final result and original
     /// image. Kingfisher will have a chance to use the original image when another processor is applied to the same
     /// resource, instead of downloading it again. You can use `.originalCache` to specify a cache or the original
@@ -174,17 +172,17 @@ public enum KingfisherOptionsInfoItem {
     ///
     /// The original image will be only cached to disk storage.
     case cacheOriginalImage
-    
+
     /// If set and an image retrieving error occurred Kingfisher will set provided image (or empty)
     /// in place of requested one. It's useful when you don't want to show placeholder
     /// during loading time but wants to use some default image when requests will be failed.
     case onFailureImage(KFCrossPlatformImage?)
-    
+
     /// If set and used in `ImagePrefetcher`, the prefetching operation will load the images into memory storage
     /// aggressively. By default this is not contained in the options, that means if the requested image is already
     /// in disk cache, Kingfisher will not try to load it to memory.
     case alsoPrefetchToMemory
-    
+
     /// If set, the disk storage loading will happen in the same calling queue. By default, disk storage file loading
     /// happens in its own queue with an asynchronous dispatch behavior. Although it provides better non-blocking disk
     /// loading performance, it also causes a flickering when you reload an image from disk, if the image view already
@@ -202,7 +200,7 @@ public enum KingfisherOptionsInfoItem {
     /// expiration in its config for all items. If set, the `MemoryStorage.Backend` will use this associated
     /// value to overwrite the config setting for this caching item.
     case memoryCacheExpiration(StorageExpiration)
-    
+
     /// The expiration extending setting for memory cache. The item expiration time will be incremented by this
     /// value after access.
     /// By default, the underlying `MemoryStorage.Backend` uses the initial cache expiration as extending
@@ -210,7 +208,7 @@ public enum KingfisherOptionsInfoItem {
     ///
     /// To disable extending option at all add memoryCacheAccessExtendingExpiration(.none) to options.
     case memoryCacheAccessExtendingExpiration(ExpirationExtending)
-    
+
     /// The expiration setting for disk cache. By default, the underlying `DiskStorage.Backend` uses the
     /// expiration in its config for all items. If set, the `DiskStorage.Backend` will use this associated
     /// value to overwrite the config setting for this caching item.
@@ -220,13 +218,13 @@ public enum KingfisherOptionsInfoItem {
     /// By default, the underlying `DiskStorage.Backend` uses the initial cache expiration as extending value: .cacheTime.
     /// To disable extending option at all add diskCacheAccessExtendingExpiration(.none) to options.
     case diskCacheAccessExtendingExpiration(ExpirationExtending)
-    
+
     /// Decides on which queue the image processing should happen. By default, Kingfisher uses a pre-defined serial
     /// queue to process images. Use this option to change this behavior. For example, specify a `.mainCurrentOrAsync`
     /// to let the image be processed in main queue to prevent a possible flickering (but with a possibility of
     /// blocking the UI, especially if the processor needs a lot of time to run).
     case processingQueue(CallbackQueue)
-    
+
     /// Enable progressive image loading, Kingfisher will use the associated `ImageProgressive` value to process the
     /// progressive JPEG data and display it in a progressive way.
     case progressiveJPEG(ImageProgressive)
@@ -270,10 +268,9 @@ public enum KingfisherOptionsInfoItem {
 /// in `KingfisherOptionsInfoItem`. When a `KingfisherOptionsInfo` sent to Kingfisher related methods, it will be
 /// parsed and converted to a `KingfisherParsedOptionsInfo` first, and pass through the internal methods.
 public struct KingfisherParsedOptionsInfo {
-
-    public var targetCache: ImageCache? = nil
-    public var originalCache: ImageCache? = nil
-    public var downloader: ImageDownloader? = nil
+    public var targetCache: ImageCache?
+    public var originalCache: ImageCache?
+    public var downloader: ImageDownloader?
     public var transition: ImageTransition = .none
     public var downloadPriority: Float = URLSessionTask.defaultPriority
     public var forceRefresh = false
@@ -286,10 +283,10 @@ public struct KingfisherParsedOptionsInfo {
     public var preloadAllAnimationData = false
     public var callbackQueue: CallbackQueue = .mainCurrentOrAsync
     public var scaleFactor: CGFloat = 1.0
-    public var requestModifier: AsyncImageDownloadRequestModifier? = nil
-    public var redirectHandler: ImageDownloadRedirectHandler? = nil
+    public var requestModifier: AsyncImageDownloadRequestModifier?
+    public var redirectHandler: ImageDownloadRedirectHandler?
     public var processor: ImageProcessor = DefaultImageProcessor.default
-    public var imageModifier: ImageModifier? = nil
+    public var imageModifier: ImageModifier?
     public var cacheSerializer: CacheSerializer = DefaultCacheSerializer.default
     public var keepCurrentImageWhileLoading = false
     public var onlyLoadFirstFrame = false
@@ -298,18 +295,18 @@ public struct KingfisherParsedOptionsInfo {
     public var alsoPrefetchToMemory = false
     public var loadDiskFileSynchronously = false
     public var diskStoreWriteOptions: Data.WritingOptions = []
-    public var memoryCacheExpiration: StorageExpiration? = nil
+    public var memoryCacheExpiration: StorageExpiration?
     public var memoryCacheAccessExtendingExpiration: ExpirationExtending = .cacheTime
-    public var diskCacheExpiration: StorageExpiration? = nil
+    public var diskCacheExpiration: StorageExpiration?
     public var diskCacheAccessExtendingExpiration: ExpirationExtending = .cacheTime
-    public var processingQueue: CallbackQueue? = nil
-    public var progressiveJPEG: ImageProgressive? = nil
-    public var alternativeSources: [Source]? = nil
-    public var retryStrategy: RetryStrategy? = nil
-    public var lowDataModeSource: Source? = nil
+    public var processingQueue: CallbackQueue?
+    public var progressiveJPEG: ImageProgressive?
+    public var alternativeSources: [Source]?
+    public var retryStrategy: RetryStrategy?
+    public var lowDataModeSource: Source?
 
-    var onDataReceived: [DataReceivingSideEffect]? = nil
-    
+    var onDataReceived: [DataReceivingSideEffect]?
+
     public init(_ info: KingfisherOptionsInfo?) {
         guard let info = info else { return }
         for option in info {
@@ -375,9 +372,8 @@ protocol DataReceivingSideEffect: AnyObject {
 }
 
 class ImageLoadingProgressSideEffect: DataReceivingSideEffect {
-
     var onShouldApply: () -> Bool = { return true }
-    
+
     let block: DownloadProgressBlock
 
     init(_ block: @escaping DownloadProgressBlock) {
@@ -387,8 +383,7 @@ class ImageLoadingProgressSideEffect: DataReceivingSideEffect {
     func onDataReceived(_ session: URLSession, task: SessionDataTask, data: Data) {
         guard self.onShouldApply() else { return }
         guard let expectedContentLength = task.task.response?.expectedContentLength,
-                  expectedContentLength != -1 else
-        {
+                  expectedContentLength != -1 else {
             return
         }
 

--- a/Sources/Image/Filter.swift
+++ b/Sources/Image/Filter.swift
@@ -41,7 +41,6 @@ public protocol CIImageProcessor: ImageProcessor {
 }
 
 extension CIImageProcessor {
-    
     /// Processes the input `ImageProcessItem` with this processor.
     ///
     /// - Parameters:
@@ -63,36 +62,35 @@ extension CIImageProcessor {
 /// A wrapper struct for a `Transformer` of CIImage filters. A `Filter`
 /// value could be used to create a `CIImage` processor.
 public struct Filter {
-    
     let transform: Transformer
 
     public init(transform: @escaping Transformer) {
         self.transform = transform
     }
-    
+
     /// Tint filter which will apply a tint color to images.
     public static var tint: (KFCrossPlatformColor) -> Filter = {
         color in
         Filter {
             input in
-            
+
             let colorFilter = CIFilter(name: "CIConstantColorGenerator")!
             colorFilter.setValue(CIColor(color: color), forKey: kCIInputColorKey)
-            
+
             let filter = CIFilter(name: "CISourceOverCompositing")!
-            
+
             let colorImage = colorFilter.outputImage
             filter.setValue(colorImage, forKey: kCIInputImageKey)
             filter.setValue(input, forKey: kCIInputBackgroundImageKey)
-            
+
             return filter.outputImage?.cropped(to: input.extent)
         }
     }
-    
+
     /// Represents color control elements. It is a tuple of
     /// `(brightness, contrast, saturation, inputEV)`
     public typealias ColorElement = (CGFloat, CGFloat, CGFloat, CGFloat)
-    
+
     /// Color control filter which will apply color control change to images.
     public static var colorControl: (ColorElement) -> Filter = { arg -> Filter in
         let (brightness, contrast, saturation, inputEV) = arg
@@ -108,7 +106,6 @@ public struct Filter {
 }
 
 extension KingfisherWrapper where Base: KFCrossPlatformImage {
-
     /// Applies a `Filter` containing `CIImage` transformer to `self`.
     ///
     /// - Parameter filter: The filter used to transform `self`.
@@ -118,12 +115,11 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     ///    Only CG-based images are supported. If any error happens
     ///    during transforming, `self` will be returned.
     public func apply(_ filter: Filter) -> KFCrossPlatformImage {
-        
         guard let cgImage = cgImage else {
             assertionFailure("[Kingfisher] Tint image only works for CG-based image.")
             return base
         }
-        
+
         let inputImage = CIImage(cgImage: cgImage)
         guard let outputImage = filter.transform(inputImage) else {
             return base
@@ -133,14 +129,13 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             assertionFailure("[Kingfisher] Can not make an tint image within context.")
             return base
         }
-        
+
         #if os(macOS)
             return fixedForRetinaPixel(cgImage: result, to: size)
         #else
             return KFCrossPlatformImage(cgImage: result, scale: base.scale, orientation: base.imageOrientation)
         #endif
     }
-
 }
 
 #endif

--- a/Sources/Image/GIFAnimatedImage.swift
+++ b/Sources/Image/GIFAnimatedImage.swift
@@ -29,7 +29,6 @@ import ImageIO
 
 /// Represents a set of image creating options used in Kingfisher.
 public struct ImageCreatingOptions {
-
     /// The target scale of image needs to be created.
     public let scale: CGFloat
 
@@ -42,7 +41,7 @@ public struct ImageCreatingOptions {
     /// For an animated image, whether or not only the first image should be
     /// loaded as a static image. It is useful for preview purpose of an animated image.
     public let onlyFirstFrame: Bool
-    
+
     /// Creates an `ImageCreatingOptions` object.
     ///
     /// - Parameters:
@@ -59,8 +58,7 @@ public struct ImageCreatingOptions {
         scale: CGFloat = 1.0,
         duration: TimeInterval = 0.0,
         preloadAll: Bool = false,
-        onlyFirstFrame: Bool = false)
-    {
+        onlyFirstFrame: Bool = false) {
         self.scale = scale
         self.duration = duration
         self.preloadAll = preloadAll
@@ -73,17 +71,17 @@ public struct ImageCreatingOptions {
 public class GIFAnimatedImage {
     let images: [KFCrossPlatformImage]
     let duration: TimeInterval
-    
+
     init?(from imageSource: CGImageSource, for info: [String: Any], options: ImageCreatingOptions) {
         let frameCount = CGImageSourceGetCount(imageSource)
         var images = [KFCrossPlatformImage]()
         var gifDuration = 0.0
-        
+
         for i in 0 ..< frameCount {
             guard let imageRef = CGImageSourceCreateImageAtIndex(imageSource, i, info as CFDictionary) else {
                 return nil
             }
-            
+
             if frameCount == 1 {
                 gifDuration = .infinity
             } else {
@@ -96,16 +94,16 @@ public class GIFAnimatedImage {
         self.images = images
         self.duration = gifDuration
     }
-    
+
     /// Calculates frame duration for a gif frame out of the kCGImagePropertyGIFDictionary dictionary.
     public static func getFrameDuration(from gifInfo: [String: Any]?) -> TimeInterval {
         let defaultFrameDuration = 0.1
         guard let gifInfo = gifInfo else { return defaultFrameDuration }
-        
+
         let unclampedDelayTime = gifInfo[kCGImagePropertyGIFUnclampedDelayTime as String] as? NSNumber
         let delayTime = gifInfo[kCGImagePropertyGIFDelayTime as String] as? NSNumber
         let duration = unclampedDelayTime ?? delayTime
-        
+
         guard let frameDuration = duration else { return defaultFrameDuration }
         return frameDuration.doubleValue > 0.011 ? frameDuration.doubleValue : defaultFrameDuration
     }

--- a/Sources/Image/GraphicsContext.swift
+++ b/Sources/Image/GraphicsContext.swift
@@ -39,7 +39,7 @@ enum GraphicsContext {
         UIGraphicsBeginImageContextWithOptions(size, false, scale)
         #endif
     }
-    
+
     static func current(size: CGSize, scale: CGFloat, inverting: Bool, cgImage: CGImage?) -> CGContext? {
         #if os(macOS)
         guard let rep = NSBitmapImageRep(
@@ -52,8 +52,7 @@ enum GraphicsContext {
             isPlanar: false,
             colorSpaceName: .calibratedRGB,
             bytesPerRow: 0,
-            bitsPerPixel: 0) else
-        {
+            bitsPerPixel: 0) else {
             assertionFailure("[Kingfisher] Image representation cannot be created.")
             return nil
         }
@@ -62,7 +61,7 @@ enum GraphicsContext {
             assertionFailure("[Kingfisher] Image context cannot be created.")
             return nil
         }
-        
+
         NSGraphicsContext.current = context
         return context.cgContext
         #else
@@ -76,7 +75,7 @@ enum GraphicsContext {
         return context
         #endif
     }
-    
+
     static func end() {
         #if os(macOS)
         NSGraphicsContext.restoreGraphicsState()
@@ -85,4 +84,3 @@ enum GraphicsContext {
         #endif
     }
 }
-

--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -24,14 +24,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-
 #if os(macOS)
 import AppKit
 private var imagesKey: Void?
 private var durationKey: Void?
 #else
-import UIKit
 import MobileCoreServices
+import UIKit
 private var imageSourceKey: Void?
 #endif
 
@@ -51,31 +50,31 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         get { return getAssociatedObject(base, &animatedImageDataKey) }
         set { setRetainedAssociatedObject(base, &animatedImageDataKey, newValue) }
     }
-    
+
     public var imageFrameCount: Int? {
         get { return getAssociatedObject(base, &imageFrameCountKey) }
         set { setRetainedAssociatedObject(base, &imageFrameCountKey, newValue) }
     }
-    
+
     #if os(macOS)
     var cgImage: CGImage? {
         return base.cgImage(forProposedRect: nil, context: nil, hints: nil)
     }
-    
+
     var scale: CGFloat {
         return 1.0
     }
-    
+
     private(set) var images: [KFCrossPlatformImage]? {
         get { return getAssociatedObject(base, &imagesKey) }
         set { setRetainedAssociatedObject(base, &imagesKey, newValue) }
     }
-    
+
     private(set) var duration: TimeInterval {
         get { return getAssociatedObject(base, &durationKey) ?? 0.0 }
         set { setRetainedAssociatedObject(base, &durationKey, newValue) }
     }
-    
+
     var size: CGSize {
         return base.representations.reduce(.zero) { size, rep in
             let width = max(size.width, CGFloat(rep.pixelsWide))
@@ -89,7 +88,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     var images: [KFCrossPlatformImage]? { return base.images }
     var duration: TimeInterval { return base.duration }
     var size: CGSize { return base.size }
-    
+
     /// The image source reference of current image.
     public private(set) var imageSource: CGImageSource? {
         get { return getAssociatedObject(base, &imageSourceKey) }
@@ -113,7 +112,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     static func image(cgImage: CGImage, scale: CGFloat, refImage: KFCrossPlatformImage?) -> KFCrossPlatformImage {
         return KFCrossPlatformImage(cgImage: cgImage, size: .zero)
     }
-    
+
     /// Normalize the image. This getter does nothing on macOS but return the image itself.
     public var normalized: KFCrossPlatformImage { return base }
 
@@ -123,7 +122,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     static func image(cgImage: CGImage, scale: CGFloat, refImage: KFCrossPlatformImage?) -> KFCrossPlatformImage {
         return KFCrossPlatformImage(cgImage: cgImage, scale: scale, orientation: refImage?.imageOrientation ?? .up)
     }
-    
+
     /// Returns normalized image for current `base` image.
     /// This method will try to redraw an image with orientation and scale considered.
     public var normalized: KFCrossPlatformImage {
@@ -139,7 +138,6 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     }
 
     func fixOrientation(in context: CGContext) {
-
         var transform = CGAffineTransform.identity
 
         let orientation = base.imageOrientation
@@ -162,7 +160,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         #endif
         }
 
-        //Flip image one more time if needed to, this is to prevent flipped image
+        // Flip image one more time if needed to, this is to prevent flipped image
         switch orientation {
         case .upMirrored, .downMirrored:
             transform = transform.translatedBy(x: size.width, y: 0)
@@ -216,7 +214,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
                 return nil
             }
             let rep = NSBitmapImageRep(cgImage: cgImage)
-            return rep.representation(using:.jpeg, properties: [.compressionFactor: compressionQuality])
+            return rep.representation(using: .jpeg, properties: [.compressionFactor: compressionQuality])
         #else
             return base.jpegData(compressionQuality: compressionQuality)
         #endif
@@ -245,7 +243,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             case .GIF: data = gifRepresentation()
             case .unknown: data = normalized.kf.pngRepresentation()
             }
-            
+
             return data
         }
     }
@@ -253,7 +251,6 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
 
 // MARK: - Creating Images
 extension KingfisherWrapper where Base: KFCrossPlatformImage {
-
     /// Creates an animated image from a given data and options. Currently only GIF data is supported.
     ///
     /// - Parameters:
@@ -266,11 +263,11 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             kCGImageSourceShouldCache as String: true,
             kCGImageSourceTypeIdentifierHint as String: kUTTypeGIF
         ]
-        
+
         guard let imageSource = CGImageSourceCreateWithData(data as CFData, info as CFDictionary) else {
             return nil
         }
-        
+
         #if os(macOS)
         guard let animatedImage = GIFAnimatedImage(from: imageSource, for: info, options: options) else {
             return nil
@@ -288,7 +285,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         image?.kf.imageFrameCount = Int(CGImageSourceGetCount(imageSource))
         return image
         #else
-        
+
         var image: KFCrossPlatformImage?
         if options.preloadAll || options.onlyFirstFrame {
             // Use `images` image if you want to preload all animated data
@@ -308,7 +305,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             kf?.imageSource = imageSource
             kf?.animatedImageData = data
         }
-        
+
         image?.kf.imageFrameCount = Int(CGImageSourceGetCount(imageSource))
         return image
         #endif
@@ -337,7 +334,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         }
         return image
     }
-    
+
     /// Creates a downsampled image from given data to a certain size and scale.
     ///
     /// - Parameters:
@@ -358,7 +355,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         guard let imageSource = CGImageSourceCreateWithData(data as CFData, imageSourceOptions) else {
             return nil
         }
-        
+
         let maxDimensionInPixels = max(pointSize.width, pointSize.height) * scale
         let downsampleOptions = [
             kCGImageSourceCreateThumbnailFromImageAlways: true,

--- a/Sources/Image/ImageDrawing.swift
+++ b/Sources/Image/ImageDrawing.swift
@@ -48,26 +48,25 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     #if !os(macOS)
     public func image(withBlendMode blendMode: CGBlendMode,
                       alpha: CGFloat = 1.0,
-                      backgroundColor: KFCrossPlatformColor? = nil) -> KFCrossPlatformImage
-    {
+                      backgroundColor: KFCrossPlatformColor? = nil) -> KFCrossPlatformImage {
         guard let _ = cgImage else {
             assertionFailure("[Kingfisher] Blend mode image only works for CG-based image.")
             return base
         }
-        
+
         let rect = CGRect(origin: .zero, size: size)
         return draw(to: rect.size, inverting: false) { _ in
             if let backgroundColor = backgroundColor {
                 backgroundColor.setFill()
                 UIRectFill(rect)
             }
-            
+
             base.draw(in: rect, blendMode: blendMode, alpha: alpha)
             return false
         }
     }
     #endif
-    
+
     #if os(macOS)
     // MARK: Compositing
     /// Creates image from `base` image and apply compositing operation.
@@ -87,7 +86,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             assertionFailure("[Kingfisher] Compositing Operation image only works for CG-based image.")
             return base
         }
-        
+
         let rect = CGRect(origin: .zero, size: size)
         return draw(to: rect.size, inverting: false) { _ in
             if let backgroundColor = backgroundColor {
@@ -99,9 +98,9 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         }
     }
     #endif
-    
+
     // MARK: Round Corner
-    
+
     /// Creates a round corner image from on `base` image.
     ///
     /// - Parameters:
@@ -120,12 +119,11 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         backgroundColor: KFCrossPlatformColor? = nil
     ) -> KFCrossPlatformImage
     {
-
         guard let _ = cgImage else {
             assertionFailure("[Kingfisher] Round corner image only works for CG-based image.")
             return base
         }
-        
+
         let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: size)
         return draw(to: size, inverting: false) { _ in
             #if os(macOS)
@@ -134,7 +132,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
                 backgroundColor.setFill()
                 rectPath.fill()
             }
-            
+
             let path = pathForRoundCorner(rect: rect, radius: radius, corners: corners)
             path.addClip()
             base.draw(in: rect)
@@ -143,13 +141,13 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
                 assertionFailure("[Kingfisher] Failed to create CG context for image.")
                 return false
             }
-            
+
             if let backgroundColor = backgroundColor {
                 let rectPath = UIBezierPath(rect: rect)
                 backgroundColor.setFill()
                 rectPath.fill()
             }
-            
+
             let path = pathForRoundCorner(rect: rect, radius: radius, corners: corners)
             context.addPath(path.cgPath)
             context.clip()
@@ -158,7 +156,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             return false
         }
     }
-    
+
     /// Creates a round corner image from on `base` image.
     ///
     /// - Parameters:
@@ -179,7 +177,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     {
         image(withRadius: .point(radius), fit: size, roundingCorners: corners, backgroundColor: backgroundColor)
     }
-    
+
     #if os(macOS)
     func pathForRoundCorner(rect: CGRect, radius: Radius, corners: RectCorner, offsetBase: CGFloat = 0) -> NSBezierPath {
         let cornerRadius = radius.compute(with: rect.size)
@@ -200,7 +198,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         )
     }
     #endif
-    
+
     #if os(iOS) || os(tvOS)
     func resize(to size: CGSize, for contentMode: UIView.ContentMode) -> KFCrossPlatformImage {
         switch contentMode {
@@ -213,7 +211,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         }
     }
     #endif
-    
+
     // MARK: Resizing
     /// Resizes `base` image to an image with new size.
     ///
@@ -226,7 +224,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             assertionFailure("[Kingfisher] Resize only works for CG-based image.")
             return base
         }
-        
+
         let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: size)
         return draw(to: size, inverting: false) { _ in
             #if os(macOS)
@@ -237,7 +235,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             return false
         }
     }
-    
+
     /// Resizes `base` image to an image of new size, respecting the given content mode.
     ///
     /// - Parameters:
@@ -267,16 +265,16 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             assertionFailure("[Kingfisher] Crop only works for CG-based image.")
             return base
         }
-        
+
         let rect = self.size.kf.constrainedRect(for: size, anchor: anchor)
         guard let image = cgImage.cropping(to: rect.scaled(scale)) else {
             assertionFailure("[Kingfisher] Cropping image failed.")
             return base
         }
-        
+
         return KingfisherWrapper.image(cgImage: image, scale: scale, refImage: base)
     }
-    
+
     // MARK: Blur
     /// Creates an image with blur effect based on `base` image.
     ///
@@ -286,24 +284,23 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     /// - Note: This method only works for CG-based image. The current image scale is kept.
     ///         For any non-CG-based image, `base` itself is returned.
     public func blurred(withRadius radius: CGFloat) -> KFCrossPlatformImage {
-        
         guard let cgImage = cgImage else {
             assertionFailure("[Kingfisher] Blur only works for CG-based image.")
             return base
         }
-        
+
         // http://www.w3.org/TR/SVG/filters.html#feGaussianBlurElement
         // let d = floor(s * 3*sqrt(2*pi)/4 + 0.5)
         // if d is odd, use three box-blurs of size 'd', centered on the output pixel.
         let s = max(radius, 2.0)
         // We will do blur on a resized image (*0.5), so the blur radius could be half as well.
-        
+
         // Fix the slow compiling time for Swift 3.
         // See https://github.com/onevcat/Kingfisher/issues/611
         let pi2 = 2 * CGFloat.pi
         let sqrtPi2 = sqrt(pi2)
         var targetRadius = floor(s * 3.0 * sqrtPi2 / 4.0 + 0.5)
-        
+
         if targetRadius.isEven { targetRadius += 1 }
 
         // Determine necessary iteration count by blur radius.
@@ -315,16 +312,16 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         } else {
             iterations = 3
         }
-        
+
         let w = Int(size.width)
         let h = Int(size.height)
-        
+
         func createEffectBuffer(_ context: CGContext) -> vImage_Buffer {
             let data = context.data
             let width = vImagePixelCount(context.width)
             let height = vImagePixelCount(context.height)
             let rowBytes = context.bytesPerRow
-            
+
             return vImage_Buffer(data: data, height: height, width: width, rowBytes: rowBytes)
         }
         GraphicsContext.begin(size: size, scale: scale)
@@ -334,9 +331,9 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         }
         context.draw(cgImage, in: CGRect(x: 0, y: 0, width: w, height: h))
         GraphicsContext.end()
-        
+
         var inBuffer = createEffectBuffer(context)
-        
+
         GraphicsContext.begin(size: size, scale: scale)
         guard let outContext = GraphicsContext.current(size: size, scale: scale, inverting: true, cgImage: cgImage) else {
             assertionFailure("[Kingfisher] Failed to create CG context for blurring image.")
@@ -344,7 +341,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         }
         defer { GraphicsContext.end() }
         var outBuffer = createEffectBuffer(outContext)
-        
+
         for _ in 0 ..< iterations {
             let flag = vImage_Flags(kvImageEdgeExtend)
             vImageBoxConvolve_ARGB8888(
@@ -352,7 +349,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             // Next inBuffer should be the outButter of current iteration
             (inBuffer, outBuffer) = (outBuffer, inBuffer)
         }
-        
+
         #if os(macOS)
         let result = outContext.makeImage().flatMap {
             fixedForRetinaPixel(cgImage: $0, to: size)
@@ -366,31 +363,28 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             assertionFailure("[Kingfisher] Can not make an blurred image within this context.")
             return base
         }
-        
+
         return blurredImage
     }
-    
-    public func addingBorder(_ border: Border) -> KFCrossPlatformImage
-    {
+
+    public func addingBorder(_ border: Border) -> KFCrossPlatformImage {
         guard let _ = cgImage else {
             assertionFailure("[Kingfisher] Blend mode image only works for CG-based image.")
             return base
         }
-        
+
         let rect = CGRect(origin: .zero, size: size)
         return draw(to: rect.size, inverting: false) { context in
-            
             #if os(macOS)
             base.draw(in: rect)
             #else
             base.draw(in: rect, blendMode: .normal, alpha: 1.0)
             #endif
-            
-            
-            let strokeRect =  rect.insetBy(dx: border.lineWidth / 2, dy: border.lineWidth / 2)
+
+            let strokeRect = rect.insetBy(dx: border.lineWidth / 2, dy: border.lineWidth / 2)
             context.setStrokeColor(border.color.cgColor)
             context.setAlpha(border.color.rgba.a)
-            
+
             let line = pathForRoundCorner(
                 rect: strokeRect,
                 radius: border.radius,
@@ -400,11 +394,11 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             line.lineCapStyle = .square
             line.lineWidth = border.lineWidth
             line.stroke()
-            
+
             return false
         }
     }
-    
+
     // MARK: Overlay
     /// Creates an image from `base` image with a color overlay layer.
     ///
@@ -417,12 +411,11 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     /// - Note: This method only works for CG-based image. The current image scale is kept.
     ///         For any non-CG-based image, `base` itself is returned.
     public func overlaying(with color: KFCrossPlatformColor, fraction: CGFloat) -> KFCrossPlatformImage {
-        
         guard let _ = cgImage else {
             assertionFailure("[Kingfisher] Overlaying only works for CG-based image.")
             return base
         }
-        
+
         let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
         return draw(to: rect.size, inverting: false) { context in
             #if os(macOS)
@@ -435,7 +428,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             color.set()
             UIRectFill(rect)
             base.draw(in: rect, blendMode: .destinationIn, alpha: 1.0)
-            
+
             if fraction > 0 {
                 base.draw(in: rect, blendMode: .sourceAtop, alpha: fraction)
             }
@@ -443,7 +436,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             return false
         }
     }
-    
+
     // MARK: Tint
     /// Creates an image from `base` image with a color tint.
     ///
@@ -456,9 +449,9 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         return apply(.tint(color))
         #endif
     }
-    
+
     // MARK: Color Control
-    
+
     /// Create an image from `self` with color control.
     ///
     /// - Parameters:
@@ -474,7 +467,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         return apply(.colorControl((brightness, contrast, saturation, inputEV)))
         #endif
     }
-    
+
     /// Return an image with given scale.
     ///
     /// - Parameter scale: Target scale factor the new image should have.
@@ -493,7 +486,6 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
 
 // MARK: - Decoding Image
 extension KingfisherWrapper where Base: KFCrossPlatformImage {
-    
     /// Returns the decoded image of the `base` image. It will draw the image in a plain context and return the data
     /// from it. This could improve the drawing performance when an image is just created from data but not yet
     /// displayed for the first time.
@@ -501,7 +493,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     /// - Note: This method only works for CG-based image. The current image scale is kept.
     ///         For any non-CG-based image or animated image, `base` itself is returned.
     public var decoded: KFCrossPlatformImage { return decoded(scale: scale) }
-    
+
     /// Returns decoded image of the `base` image at a given scale. It will draw the image in a plain context and
     /// return the data from it. This could improve the drawing performance when an image is just created from
     /// data but not yet displayed for the first time.
@@ -572,8 +564,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         scale: CGFloat? = nil,
         refImage: KFCrossPlatformImage? = nil,
         draw: (CGContext) -> Bool // Whether use the refImage (`true`) or ignore image orientation (`false`)
-    ) -> KFCrossPlatformImage
-    {
+    ) -> KFCrossPlatformImage {
         #if os(macOS) || os(watchOS)
         let targetScale = scale ?? self.scale
         GraphicsContext.begin(size: size, scale: targetScale)
@@ -589,20 +580,19 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         let ref = useRefImage ? (refImage ?? base) : nil
         return KingfisherWrapper.image(cgImage: cgImage, scale: targetScale, refImage: ref)
         #else
-        
+
         let format = UIGraphicsImageRendererFormat.preferred()
         format.scale = scale ?? self.scale
         let renderer = UIGraphicsImageRenderer(size: size, format: format)
-        
-        var useRefImage: Bool = false
+
+        var useRefImage = false
         let image = renderer.image { rendererContext in
-            
             let context = rendererContext.cgContext
             if inverting { // If drawing a CGImage, we need to make context flipped.
                 context.scaleBy(x: 1.0, y: -1.0)
                 context.translateBy(x: 0, y: -size.height)
             }
-            
+
             useRefImage = draw(context)
         }
         if useRefImage {
@@ -616,10 +606,9 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         }
         #endif
     }
-    
+
     #if os(macOS)
     func fixedForRetinaPixel(cgImage: CGImage, to size: CGSize) -> KFCrossPlatformImage {
-        
         let image = KFCrossPlatformImage(cgImage: cgImage, size: base.size)
         let rect = CGRect(origin: CGPoint(x: 0, y: 0), size: size)
         

--- a/Sources/Image/ImageFormat.swift
+++ b/Sources/Image/ImageFormat.swift
@@ -41,27 +41,27 @@ public enum ImageFormat {
     case JPEG
     /// GIF image format.
     case GIF
-    
+
     struct HeaderData {
         static var PNG: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
         static var JPEG_SOI: [UInt8] = [0xFF, 0xD8]
         static var JPEG_IF: [UInt8] = [0xFF]
         static var GIF: [UInt8] = [0x47, 0x49, 0x46]
     }
-    
+
     /// https://en.wikipedia.org/wiki/JPEG
     public enum JPEGMarker {
-        case SOF0           //baseline
-        case SOF2           //progressive
-        case DHT            //Huffman Table
-        case DQT            //Quantization Table
-        case DRI            //Restart Interval
-        case SOS            //Start Of Scan
-        case RSTn(UInt8)    //Restart
-        case APPn           //Application-specific
-        case COM            //Comment
-        case EOI            //End Of Image
-        
+        case SOF0           // baseline
+        case SOF2           // progressive
+        case DHT            // Huffman Table
+        case DQT            // Quantization Table
+        case DRI            // Restart Interval
+        case SOS            // Start Of Scan
+        case RSTn(UInt8)    // Restart
+        case APPn           // Application-specific
+        case COM            // Comment
+        case EOI            // End Of Image
+
         var bytes: [UInt8] {
             switch self {
             case .SOF0:         return [0xFF, 0xC0]
@@ -79,7 +79,6 @@ public enum ImageFormat {
     }
 }
 
-
 extension Data: KingfisherCompatibleValue {}
 
 // MARK: - Misc Helpers
@@ -87,34 +86,30 @@ extension KingfisherWrapper where Base == Data {
     /// Gets the image format corresponding to the data.
     public var imageFormat: ImageFormat {
         guard base.count > 8 else { return .unknown }
-        
+
         var buffer = [UInt8](repeating: 0, count: 8)
         base.copyBytes(to: &buffer, count: 8)
-        
+
         if buffer == ImageFormat.HeaderData.PNG {
             return .PNG
-            
         } else if buffer[0] == ImageFormat.HeaderData.JPEG_SOI[0],
             buffer[1] == ImageFormat.HeaderData.JPEG_SOI[1],
-            buffer[2] == ImageFormat.HeaderData.JPEG_IF[0]
-        {
+            buffer[2] == ImageFormat.HeaderData.JPEG_IF[0] {
             return .JPEG
-            
         } else if buffer[0] == ImageFormat.HeaderData.GIF[0],
             buffer[1] == ImageFormat.HeaderData.GIF[1],
-            buffer[2] == ImageFormat.HeaderData.GIF[2]
-        {
+            buffer[2] == ImageFormat.HeaderData.GIF[2] {
             return .GIF
         }
-        
+
         return .unknown
     }
-    
+
     public func contains(jpeg marker: ImageFormat.JPEGMarker) -> Bool {
         guard imageFormat == .JPEG else {
             return false
         }
-        
+
         let bytes = [UInt8](base)
         let markerBytes = marker.bytes
         for (index, item) in bytes.enumerated() where bytes.count > index + 1 {

--- a/Sources/Image/ImageProcessor.swift
+++ b/Sources/Image/ImageProcessor.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import Foundation
 import CoreGraphics
+import Foundation
 
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
@@ -38,11 +38,10 @@ import AppKit
 /// - data:  Input data. The processor should provide a way to apply
 ///          processing on this `data` and return the result image.
 public enum ImageProcessItem {
-    
     /// Input image. The processor should provide a way to apply
     /// processing on this `image` and return the result image.
     case image(KFCrossPlatformImage)
-    
+
     /// Input data. The processor should provide a way to apply
     /// processing on this `data` and return the result image.
     case data(Data)
@@ -78,7 +77,6 @@ public protocol ImageProcessor {
 }
 
 extension ImageProcessor {
-    
     /// Appends an `ImageProcessor` to another. The identifier of the new `ImageProcessor`
     /// will be "\(self.identifier)|>\(another.identifier)".
     ///
@@ -120,18 +118,17 @@ struct GeneralProcessor: ImageProcessor {
 /// If an image item is given as `.image` case, `DefaultImageProcessor` will
 /// do nothing on it and return the associated image.
 public struct DefaultImageProcessor: ImageProcessor {
-    
     /// A default `DefaultImageProcessor` could be used across.
     public static let `default` = DefaultImageProcessor()
-    
+
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier = ""
-    
+
     /// Creates a `DefaultImageProcessor`. Use `DefaultImageProcessor.default` to get an instance,
     /// if you do not have a good reason to create your own `DefaultImageProcessor`.
     public init() {}
-    
+
     /// Processes the input `ImageProcessItem` with this processor.
     ///
     /// - Parameters:
@@ -152,32 +149,31 @@ public struct DefaultImageProcessor: ImageProcessor {
 
 /// Represents the rect corner setting when processing a round corner image.
 public struct RectCorner: OptionSet {
-    
     /// Raw value of the rect corner.
     public let rawValue: Int
-    
+
     /// Represents the top left corner.
     public static let topLeft = RectCorner(rawValue: 1 << 0)
-    
+
     /// Represents the top right corner.
     public static let topRight = RectCorner(rawValue: 1 << 1)
-    
+
     /// Represents the bottom left corner.
     public static let bottomLeft = RectCorner(rawValue: 1 << 2)
-    
+
     /// Represents the bottom right corner.
     public static let bottomRight = RectCorner(rawValue: 1 << 3)
-    
+
     /// Represents all corners.
     public static let all: RectCorner = [.topLeft, .topRight, .bottomLeft, .bottomRight]
-    
+
     /// Creates a `RectCorner` option set with a given value.
     ///
     /// - Parameter rawValue: The value represents a certain corner option.
     public init(rawValue: Int) {
         self.rawValue = rawValue
     }
-    
+
     var cornerIdentifier: String {
         if self == .all {
             return ""
@@ -189,7 +185,6 @@ public struct RectCorner: OptionSet {
 #if !os(macOS)
 /// Processor for adding an blend mode to images. Only CG-based images are supported.
 public struct BlendImageProcessor: ImageProcessor {
-
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier: String
@@ -244,7 +239,6 @@ public struct BlendImageProcessor: ImageProcessor {
 #if os(macOS)
 /// Processor for adding an compositing operation to images. Only CG-based images are supported in macOS.
 public struct CompositingImageProcessor: ImageProcessor {
-
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier: String
@@ -268,8 +262,7 @@ public struct CompositingImageProcessor: ImageProcessor {
     ///   - backgroundColor: Background color to apply for the output image. Default is `nil`.
     public init(compositingOperation: NSCompositingOperation,
                 alpha: CGFloat = 1.0,
-                backgroundColor: KFCrossPlatformColor? = nil)
-    {
+                backgroundColor: KFCrossPlatformColor? = nil) {
         self.compositingOperation = compositingOperation
         self.alpha = alpha
         self.backgroundColor = backgroundColor
@@ -324,7 +317,7 @@ public enum Radius {
             return p.description
         }
     }
-    
+
     public func compute(with size: CGSize) -> CGFloat {
         let cornerRadius: CGFloat
         switch self {
@@ -352,7 +345,6 @@ public enum Radius {
 /// case.
 ///
 public struct RoundCornerImageProcessor: ImageProcessor {
-
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier: String
@@ -361,10 +353,10 @@ public struct RoundCornerImageProcessor: ImageProcessor {
     /// target image with `.widthFraction`. or `.heightFraction`. For example, given a square image with width and
     /// height equals,  `.widthFraction(0.5)` means use half of the length of size and makes the final image a round one.
     public let radius: Radius
-    
+
     /// The target corners which will be applied rounding.
     public let roundingCorners: RectCorner
-    
+
     /// Target size of output image should be. If `nil`, the image will keep its original size after processing.
     public let targetSize: CGSize?
 
@@ -392,8 +384,7 @@ public struct RoundCornerImageProcessor: ImageProcessor {
         targetSize: CGSize? = nil,
         roundingCorners corners: RectCorner = .all,
         backgroundColor: KFCrossPlatformColor? = nil
-    )
-    {
+    ) {
         let radius = Radius.point(cornerRadius)
         self.init(radius: radius, targetSize: targetSize, roundingCorners: corners, backgroundColor: backgroundColor)
     }
@@ -412,8 +403,7 @@ public struct RoundCornerImageProcessor: ImageProcessor {
         targetSize: CGSize? = nil,
         roundingCorners corners: RectCorner = .all,
         backgroundColor: KFCrossPlatformColor? = nil
-    )
-    {
+    ) {
         self.radius = radius
         self.targetSize = targetSize
         self.roundingCorners = corners
@@ -436,7 +426,7 @@ public struct RoundCornerImageProcessor: ImageProcessor {
             return identifier
         }()
     }
-    
+
     /// Processes the input `ImageProcessItem` with this processor.
     ///
     /// - Parameters:
@@ -464,15 +454,15 @@ public struct RoundCornerImageProcessor: ImageProcessor {
 public struct Border {
     public var color: KFCrossPlatformColor
     public var lineWidth: CGFloat
-    
+
     /// The radius will be applied in processing. Specify a certain point value with `.point`, or a fraction of the
     /// target image with `.widthFraction`. or `.heightFraction`. For example, given a square image with width and
     /// height equals,  `.widthFraction(0.5)` means use half of the length of size and makes the final image a round one.
     public var radius: Radius
-    
+
     /// The target corners which will be applied rounding.
     public var roundingCorners: RectCorner
-    
+
     public init(
         color: KFCrossPlatformColor = .black,
         lineWidth: CGFloat = 4,
@@ -484,7 +474,7 @@ public struct Border {
         self.radius = radius
         self.roundingCorners = roundingCorners
     }
-    
+
     var identifier: String {
         "\(color.rgbaDescription)_\(lineWidth)_\(radius.radiusIdentifier)_\(roundingCorners.cornerIdentifier)"
     }
@@ -493,11 +483,11 @@ public struct Border {
 public struct BorderImageProcessor: ImageProcessor {
     public var identifier: String { "com.onevcat.Kingfisher.RoundCornerImageProcessor(\(border)" }
     public let border: Border
-    
+
     public init(border: Border) {
         self.border = border
     }
-    
+
     public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
         switch item {
         case .image(let image):
@@ -526,18 +516,17 @@ public enum ContentMode {
 /// If you need to resize a data represented image to a smaller size, use `DownsamplingImageProcessor`
 /// instead, which is more efficient and uses less memory.
 public struct ResizingImageProcessor: ImageProcessor {
-    
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier: String
-    
+
     /// The reference size for resizing operation in point.
     public let referenceSize: CGSize
-    
+
     /// Target content mode of output image should be.
     /// Default is `.none`.
     public let targetContentMode: ContentMode
-    
+
     /// Creates a `ResizingImageProcessor`.
     ///
     /// - Parameters:
@@ -560,14 +549,14 @@ public struct ResizingImageProcessor: ImageProcessor {
     public init(referenceSize: CGSize, mode: ContentMode = .none) {
         self.referenceSize = referenceSize
         self.targetContentMode = mode
-        
+
         if mode == .none {
             self.identifier = "com.onevcat.Kingfisher.ResizingImageProcessor(\(referenceSize))"
         } else {
             self.identifier = "com.onevcat.Kingfisher.ResizingImageProcessor(\(referenceSize), \(mode))"
         }
     }
-    
+
     /// Processes the input `ImageProcessItem` with this processor.
     ///
     /// - Parameters:
@@ -590,11 +579,10 @@ public struct ResizingImageProcessor: ImageProcessor {
 /// Processor for adding blur effect to images. `Accelerate.framework` is used underhood for 
 /// a better performance. A simulated Gaussian blur with specified blur radius will be applied.
 public struct BlurImageProcessor: ImageProcessor {
-    
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier: String
-    
+
     /// Blur radius for the simulated Gaussian blur.
     public let blurRadius: CGFloat
 
@@ -605,7 +593,7 @@ public struct BlurImageProcessor: ImageProcessor {
         self.blurRadius = blurRadius
         self.identifier = "com.onevcat.Kingfisher.BlurImageProcessor(\(blurRadius))"
     }
-    
+
     /// Processes the input `ImageProcessItem` with this processor.
     ///
     /// - Parameters:
@@ -628,17 +616,16 @@ public struct BlurImageProcessor: ImageProcessor {
 
 /// Processor for adding an overlay to images. Only CG-based images are supported in macOS.
 public struct OverlayImageProcessor: ImageProcessor {
-    
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier: String
-    
+
     /// Overlay color will be used to overlay the input image.
     public let overlay: KFCrossPlatformColor
-    
+
     /// Fraction will be used when overlay the color to image.
     public let fraction: CGFloat
-    
+
     /// Creates an `OverlayImageProcessor`
     ///
     /// - parameter overlay:  Overlay color will be used to overlay the input image.
@@ -649,7 +636,7 @@ public struct OverlayImageProcessor: ImageProcessor {
         self.fraction = fraction
         self.identifier = "com.onevcat.Kingfisher.OverlayImageProcessor(\(overlay.rgbaDescription)_\(fraction))"
     }
-    
+
     /// Processes the input `ImageProcessItem` with this processor.
     ///
     /// - Parameters:
@@ -671,14 +658,13 @@ public struct OverlayImageProcessor: ImageProcessor {
 
 /// Processor for tint images with color. Only CG-based images are supported.
 public struct TintImageProcessor: ImageProcessor {
-    
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier: String
-    
+
     /// Tint color will be used to tint the input image.
     public let tint: KFCrossPlatformColor
-    
+
     /// Creates a `TintImageProcessor`
     ///
     /// - parameter tint: Tint color will be used to tint the input image.
@@ -686,7 +672,7 @@ public struct TintImageProcessor: ImageProcessor {
         self.tint = tint
         self.identifier = "com.onevcat.Kingfisher.TintImageProcessor(\(tint.rgbaDescription))"
     }
-    
+
     /// Processes the input `ImageProcessItem` with this processor.
     ///
     /// - Parameters:
@@ -709,23 +695,22 @@ public struct TintImageProcessor: ImageProcessor {
 /// Processor for applying some color control to images. Only CG-based images are supported.
 /// watchOS is not supported.
 public struct ColorControlsProcessor: ImageProcessor {
-    
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier: String
-    
+
     /// Brightness changing to image.
     public let brightness: CGFloat
-    
+
     /// Contrast changing to image.
     public let contrast: CGFloat
-    
+
     /// Saturation changing to image.
     public let saturation: CGFloat
-    
+
     /// InputEV changing to image.
     public let inputEV: CGFloat
-    
+
     /// Creates a `ColorControlsProcessor`
     ///
     /// - Parameters:
@@ -740,7 +725,7 @@ public struct ColorControlsProcessor: ImageProcessor {
         self.inputEV = inputEV
         self.identifier = "com.onevcat.Kingfisher.ColorControlsProcessor(\(brightness)_\(contrast)_\(saturation)_\(inputEV))"
     }
-    
+
     /// Processes the input `ImageProcessItem` with this processor.
     ///
     /// - Parameters:
@@ -763,14 +748,13 @@ public struct ColorControlsProcessor: ImageProcessor {
 /// Processor for applying black and white effect to images. Only CG-based images are supported.
 /// watchOS is not supported.
 public struct BlackWhiteProcessor: ImageProcessor {
-    
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier = "com.onevcat.Kingfisher.BlackWhiteProcessor"
-    
+
     /// Creates a `BlackWhiteProcessor`
     public init() {}
-    
+
     /// Processes the input `ImageProcessItem` with this processor.
     ///
     /// - Parameters:
@@ -788,20 +772,19 @@ public struct BlackWhiteProcessor: ImageProcessor {
 /// Processor for cropping an image. Only CG-based images are supported.
 /// watchOS is not supported.
 public struct CroppingImageProcessor: ImageProcessor {
-    
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier: String
-    
+
     /// Target size of output image should be.
     public let size: CGSize
-    
+
     /// Anchor point from which the output size should be calculate.
     /// The anchor point is consisted by two values between 0.0 and 1.0.
     /// It indicates a related point in current image. 
     /// See `CroppingImageProcessor.init(size:anchor:)` for more.
     public let anchor: CGPoint
-    
+
     /// Creates a `CroppingImageProcessor`.
     ///
     /// - Parameters:
@@ -826,7 +809,7 @@ public struct CroppingImageProcessor: ImageProcessor {
         self.anchor = anchor
         self.identifier = "com.onevcat.Kingfisher.CroppingImageProcessor(\(size)_\(anchor))"
     }
-    
+
     /// Processes the input `ImageProcessItem` with this processor.
     ///
     /// - Parameters:
@@ -852,16 +835,15 @@ public struct CroppingImageProcessor: ImageProcessor {
 ///
 /// Only CG-based images are supported. Animated images (like GIF) is not supported.
 public struct DownsamplingImageProcessor: ImageProcessor {
-    
     /// Target size of output image should be. It should be smaller than the size of
     /// input image. If it is larger, the result image will be the same size of input
     /// data without downsampling.
     public let size: CGSize
-    
+
     /// Identifier of the processor.
     /// - Note: See documentation of `ImageProcessor` protocol for more.
     public let identifier: String
-    
+
     /// Creates a `DownsamplingImageProcessor`.
     ///
     /// - Parameter size: The target size of the downsample operation.
@@ -869,7 +851,7 @@ public struct DownsamplingImageProcessor: ImageProcessor {
         self.size = size
         self.identifier = "com.onevcat.Kingfisher.DownsamplingImageProcessor(\(size))"
     }
-    
+
     /// Processes the input `ImageProcessItem` with this processor.
     ///
     /// - Parameters:
@@ -897,7 +879,6 @@ public func |>(left: ImageProcessor, right: ImageProcessor) -> ImageProcessor {
 }
 
 extension KFCrossPlatformColor {
-    
     var rgba: (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
         var r: CGFloat = 0
         var g: CGFloat = 0
@@ -909,27 +890,26 @@ extension KFCrossPlatformColor {
         #else
         getRed(&r, green: &g, blue: &b, alpha: &a)
         #endif
-        
+
         return (r, g, b, a)
     }
-    
+
     var rgbaDescription: String {
         let components = self.rgba
         return String(format: "(%.2f,%.2f,%.2f,%.2f)", components.r, components.g, components.b, components.a)
     }
-    
+
     @available(*, deprecated, message: "`hex` is not safe for colors in extended space. Do not use this.")
     var hex: String {
-        
         let (r, g, b, a) = rgba
 
         let rInt = Int(r * 255) << 24
         let gInt = Int(g * 255) << 16
         let bInt = Int(b * 255) << 8
         let aInt = Int(a * 255)
-        
+
         let rgba = rInt | gInt | bInt | aInt
-        
-        return String(format:"#%08x", rgba)
+
+        return String(format: "#%08x", rgba)
     }
 }

--- a/Sources/Image/ImageTransition.swift
+++ b/Sources/Image/ImageTransition.swift
@@ -65,42 +65,42 @@ public enum ImageTransition {
                  options: UIView.AnimationOptions,
               animations: ((UIImageView, UIImage) -> Void)?,
               completion: ((Bool) -> Void)?)
-    
+
     var duration: TimeInterval {
         switch self {
         case .none:                          return 0
         case .fade(let duration):            return duration
-            
+
         case .flipFromLeft(let duration):    return duration
         case .flipFromRight(let duration):   return duration
         case .flipFromTop(let duration):     return duration
         case .flipFromBottom(let duration):  return duration
-            
+
         case .custom(let duration, _, _, _): return duration
         }
     }
-    
+
     var animationOptions: UIView.AnimationOptions {
         switch self {
         case .none:                         return []
         case .fade:                         return .transitionCrossDissolve
-            
+
         case .flipFromLeft:                 return .transitionFlipFromLeft
         case .flipFromRight:                return .transitionFlipFromRight
         case .flipFromTop:                  return .transitionFlipFromTop
         case .flipFromBottom:               return .transitionFlipFromBottom
-            
+
         case .custom(_, let options, _, _): return options
         }
     }
-    
+
     var animations: ((UIImageView, UIImage) -> Void)? {
         switch self {
         case .custom(_, _, let animations, _): return animations
         default: return { $0.image = $1 }
         }
     }
-    
+
     var completion: ((Bool) -> Void)? {
         switch self {
         case .custom(_, _, _, let completion): return completion

--- a/Sources/Image/Placeholder.swift
+++ b/Sources/Image/Placeholder.swift
@@ -37,10 +37,9 @@ import UIKit
 /// Represents a placeholder type which could be set while loading as well as
 /// loading finished without getting an image.
 public protocol Placeholder {
-    
     /// How the placeholder should be added to a given image view.
     func add(to imageView: KFCrossPlatformImageView)
-    
+
     /// How the placeholder should be removed from a given image view.
     func remove(from imageView: KFCrossPlatformImageView)
 }
@@ -61,7 +60,6 @@ extension KFCrossPlatformImage: Placeholder {
 /// To use your customize View type as placeholder, simply let it conforming to 
 /// `Placeholder` by `extension MyView: Placeholder {}`.
 extension Placeholder where Self: KFCrossPlatformView {
-    
     /// How the placeholder should be added to a given image view.
     public func add(to imageView: KFCrossPlatformImageView) {
         imageView.addSubview(self)

--- a/Sources/Networking/AuthenticationChallengeResponsable.swift
+++ b/Sources/Networking/AuthenticationChallengeResponsable.swift
@@ -31,7 +31,6 @@ public typealias AuthenticationChallengeResponsable = AuthenticationChallengeRes
 
 /// Protocol indicates that an authentication challenge could be handled.
 public protocol AuthenticationChallengeResponsible: AnyObject {
-
     /// Called when a session level authentication challenge is received.
     /// This method provide a chance to handle and response to the authentication
     /// challenge before downloading could start.
@@ -65,12 +64,10 @@ public protocol AuthenticationChallengeResponsible: AnyObject {
 }
 
 extension AuthenticationChallengeResponsible {
-
     public func downloader(
         _ downloader: ImageDownloader,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
-    {
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
             if let trustedHosts = downloader.trustedHosts, trustedHosts.contains(challenge.protectionSpace.host) {
                 let credential = URLCredential(trust: challenge.protectionSpace.serverTrust!)
@@ -86,9 +83,7 @@ extension AuthenticationChallengeResponsible {
         _ downloader: ImageDownloader,
         task: URLSessionTask,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
-    {
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         completionHandler(.performDefaultHandling, nil)
     }
-
 }

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -34,7 +34,6 @@ typealias DownloadResult = Result<ImageLoadingResult, KingfisherError>
 
 /// Represents a success result of an image downloading progress.
 public struct ImageLoadingResult {
-
     /// The downloaded image.
     public let image: KFCrossPlatformImage
 
@@ -47,7 +46,6 @@ public struct ImageLoadingResult {
 
 /// Represents a task of an image downloading process.
 public struct DownloadTask {
-
     /// The `SessionDataTask` object bounded to this download task. Multiple `DownloadTask`s could refer
     /// to a same `sessionTask`. This is an optimization in Kingfisher to prevent multiple downloading task
     /// for the same URL resource at the same time.
@@ -99,7 +97,6 @@ extension DownloadTask {
 
 /// Represents a downloading manager for requesting the image with a URL from server.
 open class ImageDownloader {
-
     // MARK: Singleton
     /// The default downloader.
     public static let `default` = ImageDownloader(name: "default")
@@ -107,7 +104,7 @@ open class ImageDownloader {
     // MARK: Public Properties
     /// The duration before the downloading is timeout. Default is 15 seconds.
     open var downloadTimeout: TimeInterval = 15.0
-    
+
     /// A set of trusted hosts when receiving server trust challenges. A challenge with host name contained in this
     /// set will be ignored. You can use this set to specify the self-signed site. It only will be used if you don't
     /// specify the `authenticationChallengeResponder`.
@@ -115,7 +112,7 @@ open class ImageDownloader {
     /// If `authenticationChallengeResponder` is set, this property will be ignored and the implementation of
     /// `authenticationChallengeResponder` will be used instead.
     open var trustedHosts: Set<String>?
-    
+
     /// Use this to set supply a configuration for the downloader. By default,
     /// NSURLSessionConfiguration.ephemeralSessionConfiguration() will be used.
     ///
@@ -134,13 +131,13 @@ open class ImageDownloader {
             setupSessionHandler()
         }
     }
-    
+
     /// Whether the download requests should use pipeline or not. Default is false.
     open var requestsUsePipelining = false
 
     /// Delegate of this `ImageDownloader` object. See `ImageDownloaderDelegate` protocol for more.
     open weak var delegate: ImageDownloaderDelegate?
-    
+
     /// A responder for authentication challenge. 
     /// Downloader will forward the received authentication challenge for the downloading session to this responder.
     open weak var authenticationChallengeResponder: AuthenticationChallengeResponsible?
@@ -213,8 +210,7 @@ open class ImageDownloader {
     private func createTaskCallback(
         _ completionHandler: ((DownloadResult) -> Void)?,
         options: KingfisherParsedOptionsInfo
-    ) -> SessionDataTask.TaskCallback
-    {
+    ) -> SessionDataTask.TaskCallback {
         return SessionDataTask.TaskCallback(
             onCompleted: createCompletionCallBack(completionHandler),
             options: options
@@ -225,10 +221,8 @@ open class ImageDownloader {
         with url: URL,
         options: KingfisherParsedOptionsInfo,
         done: @escaping ((Result<DownloadingContext, KingfisherError>) -> Void)
-    )
-    {
+    ) {
         func checkRequestAndDone(r: URLRequest) {
-
             // There is a possibility that request modifier changed the url to `nil` or empty.
             // In this case, throw an error.
             guard let url = r.url, !url.absoluteString.isEmpty else {
@@ -242,7 +236,7 @@ open class ImageDownloader {
         // Creates default request.
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: downloadTimeout)
         request.httpShouldUsePipelining = requestsUsePipelining
-        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) , options.lowDataModeSource != nil {
+        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *), options.lowDataModeSource != nil {
             request.allowsConstrainedNetworkAccess = false
         }
 
@@ -263,8 +257,7 @@ open class ImageDownloader {
     private func addDownloadTask(
         context: DownloadingContext,
         callback: SessionDataTask.TaskCallback
-    ) -> DownloadTask
-    {
+    ) -> DownloadTask {
         // Ready to start download. Add it to session task manager (`sessionHandler`)
         let downloadTask: DownloadTask
         if let existingTask = sessionDelegate.task(for: context.url) {
@@ -276,7 +269,6 @@ open class ImageDownloader {
         }
         return downloadTask
     }
-
 
     private func reportWillDownloadImage(url: URL, request: URLRequest) {
         delegate?.imageDownloader(self, willDownloadImageForURL: url, with: request)
@@ -300,20 +292,16 @@ open class ImageDownloader {
 
     private func reportDidProcessImage(
         result: Result<KFCrossPlatformImage, KingfisherError>, url: URL, response: URLResponse?
-    )
-    {
+    ) {
         if let image = try? result.get() {
             self.delegate?.imageDownloader(self, didDownload: image, for: url, with: response)
         }
-
     }
 
     private func startDownloadTask(
         context: DownloadingContext,
         callback: SessionDataTask.TaskCallback
-    ) -> DownloadTask
-    {
-
+    ) -> DownloadTask {
         let downloadTask = addDownloadTask(context: context, callback: callback)
 
         let sessionTask = downloadTask.sessionTask
@@ -375,8 +363,7 @@ open class ImageDownloader {
     open func downloadImage(
         with url: URL,
         options: KingfisherParsedOptionsInfo,
-        completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         var downloadTask: DownloadTask?
         createDownloadContext(with: url, options: options) { result in
             switch result {
@@ -417,8 +404,7 @@ open class ImageDownloader {
         with url: URL,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
-        completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         var info = KingfisherParsedOptionsInfo(options)
         if let block = progressBlock {
             info.onDataReceived = (info.onDataReceived ?? []) + [ImageLoadingProgressSideEffect(block)]
@@ -441,8 +427,7 @@ open class ImageDownloader {
     open func downloadImage(
         with url: URL,
         options: KingfisherOptionsInfo? = nil,
-        completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
-    {
+        completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
         downloadImage(
             with: url,
             options: KingfisherParsedOptionsInfo(options),
@@ -453,7 +438,6 @@ open class ImageDownloader {
 
 // MARK: Cancelling Task
 extension ImageDownloader {
-
     /// Cancel all downloading tasks for this `ImageDownloader`. It will trigger the completion handlers
     /// for all not-yet-finished downloading tasks.
     ///

--- a/Sources/Networking/ImageDownloaderDelegate.swift
+++ b/Sources/Networking/ImageDownloaderDelegate.swift
@@ -29,7 +29,6 @@ import Foundation
 /// Protocol of `ImageDownloader`. This protocol provides a set of methods which are related to image downloader
 /// working stages and rules.
 public protocol ImageDownloaderDelegate: AnyObject {
-
     /// Called when the `ImageDownloader` object will start downloading an image from a specified URL.
     ///
     /// - Parameters:
@@ -69,7 +68,7 @@ public protocol ImageDownloaderDelegate: AnyObject {
     ///
     ///  If this method is implemented, `imageDownloader(_:didDownload:for:)` will not be called anymore.
     func imageDownloader(_ downloader: ImageDownloader, didDownload data: Data, with dataTask: SessionDataTask) -> Data?
-  
+
     /// Called when the `ImageDownloader` object successfully downloaded image data from specified URL. This is
     /// your last chance to verify or modify the downloaded data before Kingfisher tries to perform addition
     /// processing on the image data.
@@ -140,14 +139,14 @@ extension ImageDownloaderDelegate {
     public func isValidStatusCode(_ code: Int, for downloader: ImageDownloader) -> Bool {
         return (200..<400).contains(code)
     }
-  
+
     public func imageDownloader(_ downloader: ImageDownloader, didDownload data: Data, with task: SessionDataTask) -> Data? {
         guard let url = task.originalURL else {
             return data
         }
         return imageDownloader(downloader, didDownload: data, for: url)
     }
-  
+
     public func imageDownloader(_ downloader: ImageDownloader, didDownload data: Data, for url: URL) -> Data? {
         return data
     }

--- a/Sources/Networking/ImageModifier.swift
+++ b/Sources/Networking/ImageModifier.swift
@@ -47,7 +47,6 @@ public protocol ImageModifier {
 /// This type conforms to `ImageModifier` and wraps an image modify block.
 /// If the `block` throws an error, the original image will be used.
 public struct AnyImageModifier: ImageModifier {
-
     /// A block which modifies images, or returns the original image
     /// if modification cannot be performed with an error.
     let block: (KFCrossPlatformImage) throws -> KFCrossPlatformImage
@@ -68,7 +67,6 @@ import UIKit
 
 /// Modifier for setting the rendering mode of images.
 public struct RenderingModeImageModifier: ImageModifier {
-
     /// The rendering mode to apply to the image.
     public let renderingMode: UIImage.RenderingMode
 
@@ -87,7 +85,6 @@ public struct RenderingModeImageModifier: ImageModifier {
 
 /// Modifier for setting the `flipsForRightToLeftLayoutDirection` property of images.
 public struct FlipsForRightToLeftLayoutDirectionImageModifier: ImageModifier {
-
     /// Creates a `FlipsForRightToLeftLayoutDirectionImageModifier`.
     public init() {}
 
@@ -99,7 +96,6 @@ public struct FlipsForRightToLeftLayoutDirectionImageModifier: ImageModifier {
 
 /// Modifier for setting the `alignmentRectInsets` property of images.
 public struct AlignmentRectInsetsImageModifier: ImageModifier {
-
     /// The alignment insets to apply to the image
     public let alignmentInsets: UIEdgeInsets
 

--- a/Sources/Networking/ImagePrefetcher.swift
+++ b/Sources/Networking/ImagePrefetcher.swift
@@ -24,7 +24,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-
 #if os(macOS)
 import AppKit
 #else
@@ -70,11 +69,10 @@ public typealias PrefetcherSourceCompletionHandler =
 /// some Cocoa prefetching mechanism like table view or collection view `prefetchDataSource`, to start image downloading
 /// and caching before they display on screen.
 public class ImagePrefetcher: CustomStringConvertible {
-
     public var description: String {
         return "\(Unmanaged.passUnretained(self).toOpaque())"
     }
-    
+
     /// The maximum concurrent downloads to use when prefetching images. Default is 5.
     public var maxConcurrentDownloads = 5
 
@@ -86,16 +84,16 @@ public class ImagePrefetcher: CustomStringConvertible {
 
     private var progressSourceBlock: PrefetcherSourceProgressBlock?
     private var completionSourceHandler: PrefetcherSourceCompletionHandler?
-    
+
     private var tasks = [String: DownloadTask.WrappedTask]()
-    
+
     private var pendingSources: ArraySlice<Source>
     private var skippedSources = [Source]()
     private var completedSources = [Source]()
     private var failedSources = [Source]()
-    
+
     private var stopped = false
-    
+
     // A manager used for prefetching. We will use the helper methods in manager.
     private let manager: KingfisherManager
 
@@ -128,8 +126,7 @@ public class ImagePrefetcher: CustomStringConvertible {
         urls: [URL],
         options: KingfisherOptionsInfo? = nil,
         progressBlock: PrefetcherProgressBlock? = nil,
-        completionHandler: PrefetcherCompletionHandler? = nil)
-    {
+        completionHandler: PrefetcherCompletionHandler? = nil) {
         let resources: [Resource] = urls.map { $0 }
         self.init(
             resources: resources,
@@ -157,8 +154,7 @@ public class ImagePrefetcher: CustomStringConvertible {
     public convenience init(
         urls: [URL],
         options: KingfisherOptionsInfo? = nil,
-        completionHandler: PrefetcherCompletionHandler? = nil)
-    {
+        completionHandler: PrefetcherCompletionHandler? = nil) {
         let resources: [Resource] = urls.map { $0 }
         self.init(
             resources: resources,
@@ -184,8 +180,7 @@ public class ImagePrefetcher: CustomStringConvertible {
         resources: [Resource],
         options: KingfisherOptionsInfo? = nil,
         progressBlock: PrefetcherProgressBlock? = nil,
-        completionHandler: PrefetcherCompletionHandler? = nil)
-    {
+        completionHandler: PrefetcherCompletionHandler? = nil) {
         self.init(sources: resources.map { $0.convertToSource() }, options: options)
         self.progressBlock = progressBlock
         self.completionHandler = completionHandler
@@ -206,8 +201,7 @@ public class ImagePrefetcher: CustomStringConvertible {
     public convenience init(
         resources: [Resource],
         options: KingfisherOptionsInfo? = nil,
-        completionHandler: PrefetcherCompletionHandler? = nil)
-    {
+        completionHandler: PrefetcherCompletionHandler? = nil) {
         self.init(sources: resources.map { $0.convertToSource() }, options: options)
         self.completionHandler = completionHandler
     }
@@ -228,8 +222,7 @@ public class ImagePrefetcher: CustomStringConvertible {
     public convenience init(sources: [Source],
         options: KingfisherOptionsInfo? = nil,
         progressBlock: PrefetcherSourceProgressBlock? = nil,
-        completionHandler: PrefetcherSourceCompletionHandler? = nil)
-    {
+        completionHandler: PrefetcherSourceCompletionHandler? = nil) {
         self.init(sources: sources, options: options)
         self.progressSourceBlock = progressBlock
         self.completionSourceHandler = completionHandler
@@ -249,8 +242,7 @@ public class ImagePrefetcher: CustomStringConvertible {
     /// main thread. The `.callbackQueue` value in `optionsInfo` will be ignored in this method.
     public convenience init(sources: [Source],
         options: KingfisherOptionsInfo? = nil,
-        completionHandler: PrefetcherSourceCompletionHandler? = nil)
-    {
+        completionHandler: PrefetcherSourceCompletionHandler? = nil) {
         self.init(sources: sources, options: options)
         self.completionSourceHandler = completionHandler
     }
@@ -311,18 +303,17 @@ public class ImagePrefetcher: CustomStringConvertible {
             self.tasks.values.forEach { $0.cancel() }
         }
     }
-    
-    private func downloadAndCache(_ source: Source) {
 
+    private func downloadAndCache(_ source: Source) {
         let downloadTaskCompletionHandler: ((Result<RetrieveImageResult, KingfisherError>) -> Void) = { result in
             self.tasks.removeValue(forKey: source.cacheKey)
             do {
-                let _ = try result.get()
+                _ = try result.get()
                 self.completedSources.append(source)
             } catch {
                 self.failedSources.append(source)
             }
-            
+
             self.reportProgress()
             if self.stopped {
                 if self.tasks.isEmpty {
@@ -349,21 +340,20 @@ public class ImagePrefetcher: CustomStringConvertible {
             tasks[source.cacheKey] = downloadTask
         }
     }
-    
+
     private func append(cached source: Source) {
         skippedSources.append(source)
- 
+
         reportProgress()
         reportCompletionOrStartNext()
     }
-    
-    private func startPrefetching(_ source: Source)
-    {
+
+    private func startPrefetching(_ source: Source) {
         if optionsInfo.forceRefresh {
             downloadAndCache(source)
             return
         }
-        
+
         let cacheType = manager.cache.imageCachedType(
             forKey: source.cacheKey,
             processorIdentifier: optionsInfo.processor.identifier)
@@ -375,8 +365,7 @@ public class ImagePrefetcher: CustomStringConvertible {
                 let context = RetrievingContext(options: optionsInfo, originalSource: source)
                 _ = manager.retrieveImageFromCache(
                     source: source,
-                    context: context)
-                {
+                    context: context) {
                     _ in
                     self.append(cached: source)
                 }
@@ -387,9 +376,8 @@ public class ImagePrefetcher: CustomStringConvertible {
             downloadAndCache(source)
         }
     }
-    
-    private func reportProgress() {
 
+    private func reportProgress() {
         if progressBlock == nil && progressSourceBlock == nil {
             return
         }
@@ -406,7 +394,7 @@ public class ImagePrefetcher: CustomStringConvertible {
             )
         }
     }
-    
+
     private func reportCompletionOrStartNext() {
         if let resource = self.pendingSources.popFirst() {
             // Loose call stack for huge ammount of sources.
@@ -420,13 +408,12 @@ public class ImagePrefetcher: CustomStringConvertible {
     var allFinished: Bool {
         return skippedSources.count + failedSources.count + completedSources.count == prefetchSources.count
     }
-    
-    private func handleComplete() {
 
+    private func handleComplete() {
         if completionHandler == nil && completionSourceHandler == nil {
             return
         }
-        
+
         // The completion handler should be called on the main thread
         CallbackQueue.mainCurrentOrAsync.execute {
             self.completionSourceHandler?(self.skippedSources, self.failedSources, self.completedSources)

--- a/Sources/Networking/ImagePrefetcher.swift
+++ b/Sources/Networking/ImagePrefetcher.swift
@@ -289,7 +289,7 @@ public class ImagePrefetcher: CustomStringConvertible {
             }
 
             // Empty case.
-            guard self.prefetchSources.count > 0 else {
+            guard !self.prefetchSources.isEmpty else {
                 self.handleComplete()
                 return
             }

--- a/Sources/Networking/RedirectHandler.swift
+++ b/Sources/Networking/RedirectHandler.swift
@@ -28,7 +28,6 @@ import Foundation
 
 /// Represents and wraps a method for modifying request during an image download request redirection.
 public protocol ImageDownloadRedirectHandler {
-
     /// The `ImageDownloadRedirectHandler` contained will be used to change the request before redirection.
     /// This is the posibility you can modify the image download request during redirection. You can modify the
     /// request for some customizing purpose, such as adding auth token to the header, do basic HTTP auth or
@@ -54,18 +53,16 @@ public protocol ImageDownloadRedirectHandler {
 /// A wrapper for creating an `ImageDownloadRedirectHandler` easier.
 /// This type conforms to `ImageDownloadRedirectHandler` and wraps a redirect request modify block.
 public struct AnyRedirectHandler: ImageDownloadRedirectHandler {
-    
     let block: (SessionDataTask, HTTPURLResponse, URLRequest, @escaping (URLRequest?) -> Void) -> Void
 
     public func handleHTTPRedirection(
         for task: SessionDataTask,
         response: HTTPURLResponse,
         newRequest: URLRequest,
-        completionHandler: @escaping (URLRequest?) -> Void)
-    {
+        completionHandler: @escaping (URLRequest?) -> Void) {
         block(task, response, newRequest, completionHandler)
     }
-    
+
     /// Creates a value of `ImageDownloadRedirectHandler` which runs `modify` block.
     ///
     /// - Parameter modify: The request modifying block runs when a request modifying task comes.

--- a/Sources/Networking/RequestModifier.swift
+++ b/Sources/Networking/RequestModifier.swift
@@ -28,7 +28,6 @@ import Foundation
 
 /// Represents and wraps a method for modifying request before an image download request starts in an asynchronous way.
 public protocol AsyncImageDownloadRequestModifier {
-
     /// This method will be called just before the `request` being sent.
     /// This is the last chance you can modify the image download request. You can modify the request for some
     /// customizing purpose, such as adding auth token to the header, do basic HTTP auth or something like url mapping.
@@ -56,7 +55,6 @@ public protocol AsyncImageDownloadRequestModifier {
 
 /// Represents and wraps a method for modifying request before an image download request starts.
 public protocol ImageDownloadRequestModifier: AsyncImageDownloadRequestModifier {
-
     /// This method will be called just before the `request` being sent.
     /// This is the last chance you can modify the image download request. You can modify the request for some
     /// customizing purpose, such as adding auth token to the header, do basic HTTP auth or something like url mapping.
@@ -88,14 +86,13 @@ extension ImageDownloadRequestModifier {
 /// A wrapper for creating an `ImageDownloadRequestModifier` easier.
 /// This type conforms to `ImageDownloadRequestModifier` and wraps an image modify block.
 public struct AnyModifier: ImageDownloadRequestModifier {
-    
     let block: (URLRequest) -> URLRequest?
 
     /// For `ImageDownloadRequestModifier` conformation.
     public func modified(for request: URLRequest) -> URLRequest? {
         return block(request)
     }
-    
+
     /// Creates a value of `ImageDownloadRequestModifier` which runs `modify` block.
     ///
     /// - Parameter modify: The request modifying block runs when a request modifying task comes.

--- a/Sources/Networking/RetryStrategy.swift
+++ b/Sources/Networking/RetryStrategy.swift
@@ -28,7 +28,6 @@ import Foundation
 
 /// Represents a retry context which could be used to determine the current retry status.
 public class RetryContext {
-
     /// The source from which the target image should be retrieved.
     public let source: Source
 
@@ -41,7 +40,7 @@ public class RetryContext {
     /// A user set value for passing any other information during the retry. If you choose to use `RetryDecision.retry`
     /// as the retry decision for `RetryStrategy.retry(context:retryHandler:)`, the associated value of
     /// `RetryDecision.retry` will be delivered to you in the next retry.
-    public internal(set) var userInfo: Any? = nil
+    public internal(set) var userInfo: Any?
 
     init(source: Source, error: KingfisherError) {
         self.source = source
@@ -66,7 +65,6 @@ public enum RetryDecision {
 
 /// Defines a retry strategy can be applied to a `.retryStrategy` option.
 public protocol RetryStrategy {
-
     /// Kingfisher calls this method if an error happens during the image retrieving process from a `KingfisherManager`.
     /// You implement this method to provide necessary logic based on the `context` parameter. Then you need to call
     /// `retryHandler` to pass the retry decision back to Kingfisher.
@@ -80,7 +78,6 @@ public protocol RetryStrategy {
 /// A retry strategy that guides Kingfisher to retry when a `.responseError` happens, with a specified max retry count
 /// and a certain interval mechanism.
 public struct DelayRetryStrategy: RetryStrategy {
-
     /// Represents the interval mechanism which used in a `DelayRetryStrategy`.
     public enum Interval {
         /// The next retry attempt should happen in fixed seconds. For example, if the associated value is 3, the

--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -29,7 +29,6 @@ import Foundation
 /// Represents a session data task in `ImageDownloader`. It consists of an underlying `URLSessionDataTask` and
 /// an array of `TaskCallback`. Multiple `TaskCallback`s could be added for a single downloading data task.
 public class SessionDataTask {
-
     /// Represents the type of token which used for cancelling a task.
     public typealias CancelToken = Int
 

--- a/Sources/Networking/SessionDelegate.swift
+++ b/Sources/Networking/SessionDelegate.swift
@@ -29,7 +29,6 @@ import Foundation
 // Represents the delegate object of downloader session. It also behave like a task manager for downloading.
 @objc(KFSessionDelegate) // Fix for ObjC header name conflicting. https://github.com/onevcat/Kingfisher/issues/1530
 open class SessionDelegate: NSObject {
-
     typealias SessionChallengeFunc = (
         URLSession,
         URLAuthenticationChallenge,
@@ -56,8 +55,7 @@ open class SessionDelegate: NSObject {
     func add(
         _ dataTask: URLSessionDataTask,
         url: URL,
-        callback: SessionDataTask.TaskCallback) -> DownloadTask
-    {
+        callback: SessionDataTask.TaskCallback) -> DownloadTask {
         lock.lock()
         defer { lock.unlock() }
 
@@ -92,8 +90,7 @@ open class SessionDelegate: NSObject {
     func append(
         _ task: SessionDataTask,
         url: URL,
-        callback: SessionDataTask.TaskCallback) -> DownloadTask
-    {
+        callback: SessionDataTask.TaskCallback) -> DownloadTask {
         let token = task.addCallback(callback)
         return DownloadTask(sessionTask: task, cancelToken: token)
     }
@@ -148,13 +145,11 @@ open class SessionDelegate: NSObject {
 }
 
 extension SessionDelegate: URLSessionDataDelegate {
-
     open func urlSession(
         _ session: URLSession,
         dataTask: URLSessionDataTask,
         didReceive response: URLResponse,
-        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void)
-    {
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
         guard let httpResponse = response as? HTTPURLResponse else {
             let error = KingfisherError.responseError(reason: .invalidURLResponse(response: response))
             onCompleted(task: dataTask, result: .failure(error))
@@ -176,9 +171,9 @@ extension SessionDelegate: URLSessionDataDelegate {
         guard let task = self.task(for: dataTask) else {
             return
         }
-        
+
         task.didReceiveData(data)
-        
+
         task.callbacks.forEach { callback in
             callback.options.onDataReceived?.forEach { sideEffect in
                 sideEffect.onDataReceived(session, task: task, data: data)
@@ -217,8 +212,7 @@ extension SessionDelegate: URLSessionDataDelegate {
     open func urlSession(
         _ session: URLSession,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
-    {
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         onReceiveSessionChallenge.call((session, challenge, completionHandler))
     }
 
@@ -226,25 +220,22 @@ extension SessionDelegate: URLSessionDataDelegate {
         _ session: URLSession,
         task: URLSessionTask,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
-    {
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         onReceiveSessionTaskChallenge.call((session, task, challenge, completionHandler))
     }
-    
+
     open func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
         willPerformHTTPRedirection response: HTTPURLResponse,
         newRequest request: URLRequest,
-        completionHandler: @escaping (URLRequest?) -> Void)
-    {
+        completionHandler: @escaping (URLRequest?) -> Void) {
         guard let sessionDataTask = self.task(for: task),
-              let redirectHandler = Array(sessionDataTask.callbacks).last?.options.redirectHandler else
-        {
+              let redirectHandler = Array(sessionDataTask.callbacks).last?.options.redirectHandler else {
             completionHandler(request)
             return
         }
-        
+
         redirectHandler.handleHTTPRedirection(
             for: sessionDataTask,
             response: response,

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -25,16 +25,14 @@
 //  THE SOFTWARE.
 
 #if canImport(SwiftUI) && canImport(Combine)
-import SwiftUI
 import Combine
+import SwiftUI
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension KFImage {
-
     /// Represents a binder for `KFImage`. It takes responsibility as an `ObjectBinding` and performs
     /// image downloading and progress reporting based on `KingfisherManager`.
     class ImageBinder: ObservableObject {
-        
         init() {}
 
         var downloadTask: DownloadTask?
@@ -46,9 +44,9 @@ extension KFImage {
 
         // Do not use @Published due to https://github.com/onevcat/Kingfisher/issues/1717. Revert to @Published once
         // we can drop iOS 12.
-        var loaded = false                           { willSet { objectWillChange.send() } }
-        var loadedImage: KFCrossPlatformImage? = nil { willSet { objectWillChange.send() } }
-        var progress: Progress = .init()             { willSet { objectWillChange.send() } }
+        var loaded = false { willSet { objectWillChange.send() } }
+        var loadedImage: KFCrossPlatformImage? { willSet { objectWillChange.send() } }
+        var progress: Progress = .init() { willSet { objectWillChange.send() } }
 
         func start<HoldingView: KFImageHoldingView>(context: Context<HoldingView>) {
             guard let source = context.source else {
@@ -59,7 +57,7 @@ extension KFImage {
             }
 
             loading = true
-            
+
             progress = .init()
             downloadTask = KingfisherManager.shared
                 .retrieveImage(
@@ -70,14 +68,13 @@ extension KFImage {
                         context.onProgressDelegate.call((size, total))
                     },
                     completionHandler: { [weak self] result in
-
                         guard let self = self else { return }
 
                         CallbackQueue.mainCurrentOrAsync.execute {
                             self.downloadTask = nil
                             self.loading = false
                         }
-                        
+
                         switch result {
                         case .success(let value):
                             CallbackQueue.mainCurrentOrAsync.execute {
@@ -100,14 +97,14 @@ extension KFImage {
                                 }
                                 self.loaded = true
                             }
-                            
+
                             CallbackQueue.mainAsync.execute {
                                 context.onFailureDelegate.call(error)
                             }
                         }
-                })
+                    })
         }
-        
+
         private func updateProgress(downloaded: Int64, total: Int64) {
             progress.totalUnitCount = total
             progress.completedUnitCount = downloaded

--- a/Sources/SwiftUI/ImageContext.swift
+++ b/Sources/SwiftUI/ImageContext.swift
@@ -25,8 +25,8 @@
 //  THE SOFTWARE.
 
 #if canImport(SwiftUI) && canImport(Combine)
-import SwiftUI
 import Combine
+import SwiftUI
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension KFImage {
@@ -39,8 +39,8 @@ extension KFImage {
         var configurations: [(HoldingView) -> HoldingView] = []
         var renderConfigurations: [(HoldingView.RenderingView) -> Void] = []
         
-        var cancelOnDisappear: Bool = false
-        var placeholder: ((Progress) -> AnyView)? = nil
+        var cancelOnDisappear = false
+        var placeholder: ((Progress) -> AnyView)?
 
         let onFailureDelegate = Delegate<KingfisherError, Void>()
         let onSuccessDelegate = Delegate<RetrieveImageResult, Void>()
@@ -49,7 +49,7 @@ extension KFImage {
         init(source: Source?) {
             self.source = source
         }
-        
+
         func shouldApplyFade(cacheType: CacheType) -> Bool {
             options.forceTransition || cacheType == .none
         }
@@ -73,7 +73,6 @@ extension ImageTransition {
         }
     }
 }
-
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension KFImage.Context: Hashable {

--- a/Sources/SwiftUI/KFAnimatedImage.swift
+++ b/Sources/SwiftUI/KFAnimatedImage.swift
@@ -25,8 +25,8 @@
 //  THE SOFTWARE.
 
 #if canImport(SwiftUI) && canImport(Combine) && canImport(UIKit) && !os(watchOS)
-import SwiftUI
 import Combine
+import SwiftUI
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public struct KFAnimatedImage: KFImageProtocol {
@@ -35,7 +35,7 @@ public struct KFAnimatedImage: KFImageProtocol {
     public init(context: KFImage.Context<HoldingView>) {
         self.context = context
     }
-    
+
     /// Configures current rendering view with a `block`. This block will be applied when the under-hood
     /// `AnimatedImageView` is created in `UIViewRepresentable.makeUIView(context:)`
     ///
@@ -54,32 +54,31 @@ public struct KFAnimatedImageViewRepresenter: UIViewRepresentable, KFImageHoldin
     public static func created(from image: KFCrossPlatformImage?, context: KFImage.Context<Self>) -> KFAnimatedImageViewRepresenter {
         KFAnimatedImageViewRepresenter(image: image, context: context)
     }
-    
+
     var image: KFCrossPlatformImage?
     let context: KFImage.Context<KFAnimatedImageViewRepresenter>
-    
+
     public func makeUIView(context: Context) -> AnimatedImageView {
         let view = AnimatedImageView()
-        
+
         self.context.renderConfigurations.forEach { $0(view) }
-        
+
         view.image = image
-        
+
         // Allow SwiftUI scale (fit/fill) working fine.
         view.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         view.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         return view
     }
-    
+
     public func updateUIView(_ uiView: AnimatedImageView, context: Context) {
         uiView.image = image
     }
-    
 }
 
 #if DEBUG
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
-struct KFAnimatedImage_Previews : PreviewProvider {
+struct KFAnimatedImage_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             KFAnimatedImage(source: .network(URL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher-TestImages/master/DemoAppImage/GIF/1.gif")!))

--- a/Sources/SwiftUI/KFImage.swift
+++ b/Sources/SwiftUI/KFImage.swift
@@ -25,8 +25,8 @@
 //  THE SOFTWARE.
 
 #if canImport(SwiftUI) && canImport(Combine)
-import SwiftUI
 import Combine
+import SwiftUI
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public struct KFImage: KFImageProtocol {
@@ -47,11 +47,9 @@ extension Image: KFImageHoldingView {
 // MARK: - Image compatibility.
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension KFImage {
-
     public func resizable(
         capInsets: EdgeInsets = EdgeInsets(),
-        resizingMode: Image.ResizingMode = .stretch) -> KFImage
-    {
+        resizingMode: Image.ResizingMode = .stretch) -> KFImage {
         configure { $0.resizable(capInsets: capInsets, resizingMode: resizingMode) }
     }
 
@@ -66,7 +64,7 @@ extension KFImage {
     public func antialiased(_ isAntialiased: Bool) -> KFImage {
         configure { $0.antialiased(isAntialiased) }
     }
-    
+
     /// Starts the loading process of `self` immediately.
     ///
     /// By default, a `KFImage` will not load its source until the `onAppear` is called. This is a lazily loading
@@ -86,7 +84,7 @@ extension KFImage {
 
 #if DEBUG
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
-struct KFImage_Previews : PreviewProvider {
+struct KFImage_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             KFImage.url(URL(string: "https://raw.githubusercontent.com/onevcat/Kingfisher/master/images/logo.png")!)

--- a/Sources/SwiftUI/KFImageOptions.swift
+++ b/Sources/SwiftUI/KFImageOptions.swift
@@ -25,22 +25,20 @@
 //  THE SOFTWARE.
 
 #if canImport(SwiftUI) && canImport(Combine)
-import SwiftUI
 import Combine
+import SwiftUI
 
 // MARK: - KFImage creating.
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension KFImageProtocol {
-
     /// Creates a `KFImage` for a given `Source`.
     /// - Parameters:
     ///   - source: The `Source` object defines data information from network or a data provider.
     /// - Returns: A `KFImage` for future configuration or embedding to a `SwiftUI.View`.
     public static func source(
         _ source: Source?
-    ) -> Self
-    {
-        Self.init(source: source)
+    ) -> Self {
+        Self(source: source)
     }
 
     /// Creates a `KFImage` for a given `Resource`.
@@ -49,8 +47,7 @@ extension KFImageProtocol {
     /// - Returns: A `KFImage` for future configuration or embedding to a `SwiftUI.View`.
     public static func resource(
         _ resource: Resource?
-    ) -> Self
-    {
+    ) -> Self {
         source(resource?.convertToSource())
     }
 
@@ -62,8 +59,7 @@ extension KFImageProtocol {
     /// - Returns: A `KFImage` for future configuration or embedding to a `SwiftUI.View`.
     public static func url(
         _ url: URL?, cacheKey: String? = nil
-    ) -> Self
-    {
+    ) -> Self {
         source(url?.convertToSource(overrideCacheKey: cacheKey))
     }
 
@@ -73,8 +69,7 @@ extension KFImageProtocol {
     /// - Returns: A `KFImage` for future configuration or embedding to a `SwiftUI.View`.
     public static func dataProvider(
         _ provider: ImageDataProvider?
-    ) -> Self
-    {
+    ) -> Self {
         source(provider?.convertToSource())
     }
 
@@ -85,8 +80,7 @@ extension KFImageProtocol {
     /// - Returns: A `KFImage` for future configuration or embedding to a `SwiftUI.View`.
     public static func data(
         _ data: Data?, cacheKey: String
-    ) -> Self
-    {
+    ) -> Self {
         if let data = data {
             return dataProvider(RawImageDataProvider(data: data, cacheKey: cacheKey))
         } else {
@@ -106,7 +100,7 @@ extension KFImageProtocol {
         }
         return self
     }
-    
+
     /// Sets a placeholder `View` which shows when loading the image.
     /// - Parameter content: A view that describes the placeholder.
     /// - Returns: A `KFImage` view that contains `content` as its placeholder.

--- a/Sources/SwiftUI/KFImageProtocol.swift
+++ b/Sources/SwiftUI/KFImageProtocol.swift
@@ -25,8 +25,8 @@
 //  THE SOFTWARE.
 
 #if canImport(SwiftUI) && canImport(Combine)
-import SwiftUI
 import Combine
+import SwiftUI
 
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public protocol KFImageProtocol: View, KFOptionSetter {
@@ -44,7 +44,7 @@ extension KFImageProtocol {
             ).id(context)
         }
     }
-    
+
     /// Creates a Kingfisher compatible image view to load image from the given `Source`.
     /// - Parameters:
     ///   - source: The image `Source` defining where to load the target image.
@@ -59,7 +59,7 @@ extension KFImageProtocol {
     public init(_ url: URL?) {
         self.init(source: url?.convertToSource())
     }
-    
+
     /// Configures current image with a `block`. This block will be lazily applied when creating the final `Image`.
     /// - Parameter block: The block applies to loaded image.
     /// - Returns: A `KFImage` view that configures internal `Image` with `block`.
@@ -88,6 +88,5 @@ extension KFImageProtocol {
 
     public var delegateObserver: AnyObject { context }
 }
-
 
 #endif

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -25,17 +25,16 @@
 //  THE SOFTWARE.
 
 #if canImport(SwiftUI) && canImport(Combine)
-import SwiftUI
 import Combine
+import SwiftUI
 
 /// A Kingfisher compatible SwiftUI `View` to load an image from a `Source`.
 /// Declaring a `KFImage` in a `View`'s body to trigger loading from the given `Source`.
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
-struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView {
-    
+struct KFImageRenderer<HoldingView>: View where HoldingView: KFImageHoldingView {
     @StateObject var binder: KFImage.ImageBinder = .init()
     let context: KFImage.Context<HoldingView>
-    
+
     var body: some View {
         ZStack {
             context.configurations

--- a/Sources/Utility/Box.swift
+++ b/Sources/Utility/Box.swift
@@ -27,7 +27,7 @@ import Foundation
 
 class Box<T> {
     var value: T
-    
+
     init(_ value: T) {
         self.value = value
     }

--- a/Sources/Utility/CallbackQueue.swift
+++ b/Sources/Utility/CallbackQueue.swift
@@ -45,7 +45,7 @@ public enum CallbackQueue {
     case untouch
     /// Dispatches to a specified `DispatchQueue`.
     case dispatch(DispatchQueue)
-    
+
     public func execute(_ block: @escaping () -> Void) {
         switch self {
         case .mainAsync:

--- a/Sources/Utility/Delegate.swift
+++ b/Sources/Utility/Delegate.swift
@@ -125,8 +125,8 @@ extension Delegate where Output: OptionalProtocol {
 public protocol OptionalProtocol {
     static var _createNil: Self { get }
 }
-extension Optional : OptionalProtocol {
-    public static var _createNil: Optional<Wrapped> {
+extension Optional: OptionalProtocol {
+    public static var _createNil: Wrapped? {
          return nil
     }
 }

--- a/Sources/Utility/ExtensionHelpers.swift
+++ b/Sources/Utility/ExtensionHelpers.swift
@@ -36,25 +36,24 @@ extension CGFloat {
 import AppKit
 extension NSBezierPath {
     convenience init(roundedRect rect: NSRect, topLeftRadius: CGFloat, topRightRadius: CGFloat,
-                     bottomLeftRadius: CGFloat, bottomRightRadius: CGFloat)
-    {
+                     bottomLeftRadius: CGFloat, bottomRightRadius: CGFloat) {
         self.init()
-        
+
         let maxCorner = min(rect.width, rect.height) / 2
-        
+
         let radiusTopLeft = min(maxCorner, max(0, topLeftRadius))
         let radiusTopRight = min(maxCorner, max(0, topRightRadius))
         let radiusBottomLeft = min(maxCorner, max(0, bottomLeftRadius))
         let radiusBottomRight = min(maxCorner, max(0, bottomRightRadius))
-        
+
         guard !rect.isEmpty else {
             return
         }
-        
+
         let topLeft = NSPoint(x: rect.minX, y: rect.maxY)
         let topRight = NSPoint(x: rect.maxX, y: rect.maxY)
         let bottomRight = NSPoint(x: rect.maxX, y: rect.minY)
-        
+
         move(to: NSPoint(x: rect.midX, y: rect.maxY))
         appendArc(from: topLeft, to: rect.origin, radius: radiusTopLeft)
         appendArc(from: rect.origin, to: bottomRight, radius: radiusBottomLeft)
@@ -62,13 +61,13 @@ extension NSBezierPath {
         appendArc(from: topRight, to: topLeft, radius: radiusTopRight)
         close()
     }
-    
+
     convenience init(roundedRect rect: NSRect, byRoundingCorners corners: RectCorner, radius: CGFloat) {
         let radiusTopLeft = corners.contains(.topLeft) ? radius : 0
         let radiusTopRight = corners.contains(.topRight) ? radius : 0
         let radiusBottomLeft = corners.contains(.bottomLeft) ? radius : 0
         let radiusBottomRight = corners.contains(.bottomRight) ? radius : 0
-        
+
         self.init(roundedRect: rect, topLeftRadius: radiusTopLeft, topRightRadius: radiusTopRight,
                   bottomLeftRadius: radiusBottomLeft, bottomRightRadius: radiusBottomRight)
     }
@@ -86,14 +85,13 @@ extension KFCrossPlatformImage {
 import UIKit
 extension RectCorner {
     var uiRectCorner: UIRectCorner {
-        
         var result: UIRectCorner = []
-        
+
         if contains(.topLeft) { result.insert(.topLeft) }
         if contains(.topRight) { result.insert(.topRight) }
         if contains(.bottomLeft) { result.insert(.bottomLeft) }
         if contains(.bottomRight) { result.insert(.bottomRight) }
-        
+
         return result
     }
 }

--- a/Sources/Utility/Result.swift
+++ b/Sources/Utility/Result.swift
@@ -29,7 +29,6 @@ import Foundation
 // These helper methods are not public since we do not want them to be exposed or cause any conflicting.
 // However, they are just wrapper of `ResultUtil` static methods.
 extension Result where Failure: Error {
-
     /// Evaluates the given transform closures to create a single output value.
     ///
     /// - Parameters:
@@ -38,8 +37,7 @@ extension Result where Failure: Error {
     /// - Returns: A single `Output` value.
     func match<Output>(
         onSuccess: (Success) -> Output,
-        onFailure: (Failure) -> Output) -> Output
-    {
+        onFailure: (Failure) -> Output) -> Output {
         switch self {
         case let .success(value):
             return onSuccess(value)

--- a/Sources/Utility/SizeExtensions.swift
+++ b/Sources/Utility/SizeExtensions.swift
@@ -28,7 +28,6 @@ import CoreGraphics
 
 extension CGSize: KingfisherCompatibleValue {}
 extension KingfisherWrapper where Base == CGSize {
-    
     /// Returns a size by resizing the `base` size to a target size under a given content mode.
     ///
     /// - Parameters:
@@ -45,7 +44,7 @@ extension KingfisherWrapper where Base == CGSize {
             return size
         }
     }
-    
+
     /// Returns a size by resizing the `base` size by making it aspect fitting the given `size`.
     ///
     /// - Parameter size: The size in which the `base` should fit in.
@@ -53,12 +52,12 @@ extension KingfisherWrapper where Base == CGSize {
     public func constrained(_ size: CGSize) -> CGSize {
         let aspectWidth = round(aspectRatio * size.height)
         let aspectHeight = round(size.width / aspectRatio)
-        
+
         return aspectWidth > size.width ?
             CGSize(width: size.width, height: aspectHeight) :
             CGSize(width: aspectWidth, height: size.height)
     }
-    
+
     /// Returns a size by resizing the `base` size by making it aspect filling the given `size`.
     ///
     /// - Parameter size: The size in which the `base` should fill.
@@ -66,12 +65,12 @@ extension KingfisherWrapper where Base == CGSize {
     public func filling(_ size: CGSize) -> CGSize {
         let aspectWidth = round(aspectRatio * size.height)
         let aspectHeight = round(size.width / aspectRatio)
-        
+
         return aspectWidth < size.width ?
             CGSize(width: size.width, height: aspectHeight) :
             CGSize(width: aspectWidth, height: size.height)
     }
-    
+
     /// Returns a `CGRect` for which the `base` size is constrained to an input `size` at a given `anchor` point.
     ///
     /// - Parameters:
@@ -79,18 +78,17 @@ extension KingfisherWrapper where Base == CGSize {
     ///   - anchor: An anchor point in which the size constraint should happen.
     /// - Returns: The result `CGRect` for the constraint operation.
     public func constrainedRect(for size: CGSize, anchor: CGPoint) -> CGRect {
-        
         let unifiedAnchor = CGPoint(x: anchor.x.clamped(to: 0.0...1.0),
                                     y: anchor.y.clamped(to: 0.0...1.0))
-        
+
         let x = unifiedAnchor.x * base.width - unifiedAnchor.x * size.width
         let y = unifiedAnchor.y * base.height - unifiedAnchor.y * size.height
         let r = CGRect(x: x, y: y, width: size.width, height: size.height)
-        
+
         let ori = CGRect(origin: .zero, size: base)
         return ori.intersection(r)
     }
-    
+
     private var aspectRatio: CGFloat {
         return base.height == 0.0 ? 1.0 : base.width / base.height
     }

--- a/Sources/Utility/String+MD5.swift
+++ b/Sources/Utility/String+MD5.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import Foundation
 import CommonCrypto
+import Foundation
 
 extension String: KingfisherCompatibleValue { }
 extension KingfisherWrapper where Base == String {
@@ -50,7 +50,7 @@ extension KingfisherWrapper where Base == String {
 
     var ext: String? {
         var ext = ""
-        if let index  = base.lastIndex(of: ".") {
+        if let index = base.lastIndex(of: ".") {
             let extRange = base.index(index, offsetBy: 1)..<base.endIndex
             ext = String(base[extRange])
         }
@@ -75,7 +75,7 @@ func arrayOfBytes<T>(_ value: T, length: Int? = nil) -> [UInt8] {
         }
         return bytes
     }
-    
+
     valuePointer.deinitialize(count: 1)
     valuePointer.deallocate()
 
@@ -87,16 +87,13 @@ extension Int {
     func bytes(_ totalBytes: Int = MemoryLayout<Int>.size) -> [UInt8] {
         return arrayOfBytes(self, length: totalBytes)
     }
-
 }
 
 extension NSMutableData {
-
     // Convenient way to append bytes
     func appendBytes(_ arrayOfBytes: [UInt8]) {
         append(arrayOfBytes, length: arrayOfBytes.count)
     }
-
 }
 
 protocol HashProtocol {
@@ -106,7 +103,6 @@ protocol HashProtocol {
 }
 
 extension HashProtocol {
-
     func prepare(_ len: Int) -> [UInt8] {
         var tmpMessage = message
 
@@ -144,7 +140,6 @@ func toUInt32Array(_ slice: ArraySlice<UInt8>) -> [UInt32] {
 }
 
 struct BytesIterator: IteratorProtocol {
-
     let chunkSize: Int
     let data: [UInt8]
 
@@ -177,7 +172,6 @@ func rotateLeft(_ value: UInt32, bits: UInt32) -> UInt32 {
 }
 
 class MD5: HashProtocol {
-
     static let size = 16 // 128 / 8
     let message: [UInt8]
 

--- a/Sources/Utility/String+MD5.swift
+++ b/Sources/Utility/String+MD5.swift
@@ -57,7 +57,7 @@ extension KingfisherWrapper where Base == String {
         guard let firstSeg = ext.split(separator: "@").first else {
             return nil
         }
-        return firstSeg.count > 0 ? String(firstSeg) : nil
+        return firstSeg.isEmpty ? nil : String(firstSeg)
     }
 }
 
@@ -159,7 +159,7 @@ struct BytesIterator: IteratorProtocol {
         let end = min(chunkSize, data.count - offset)
         let result = data[offset..<offset + end]
         offset += result.count
-        return result.count > 0 ? result : nil
+        return result.isEmpty ? nil : result
     }
 }
 

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -33,12 +33,11 @@
 
 #if !os(watchOS)
 #if canImport(UIKit)
-import UIKit
 import ImageIO
+import UIKit
 
 /// Protocol of `AnimatedImageView`.
 public protocol AnimatedImageViewDelegate: AnyObject {
-
     /// Called after the animatedImageView has finished each animation loop.
     ///
     /// - Parameters:
@@ -71,11 +70,11 @@ open class AnimatedImageView: UIImageView {
     /// Proxy object for preventing a reference cycle between the `CADDisplayLink` and `AnimatedImageView`.
     class TargetProxy {
         private weak var target: AnimatedImageView?
-        
+
         init(target: AnimatedImageView) {
             self.target = target
         }
-        
+
         @objc func onScreenUpdate() {
             target?.updateFrameIfNeeded()
         }
@@ -104,14 +103,14 @@ open class AnimatedImageView: UIImageView {
             }
         }
     }
-    
+
     // MARK: - Public property
     /// Whether automatically play the animation when the view become visible. Default is `true`.
     public var autoPlayAnimatedImage = true
-    
+
     /// The count of the frames should be preloaded before shown.
     public var framePreloadCount = 10
-    
+
     /// Specifies whether the GIF frames should be pre-scaled to the image view's size or not.
     /// If the downloaded image is larger than the image view's size, it will help to reduce some memory use.
     /// Default is `true`.
@@ -132,7 +131,7 @@ open class AnimatedImageView: UIImageView {
             startAnimating()
         }
     }
-    
+
     /// The repeat count. The animated image will keep animate until it the loop count reaches this value.
     /// Setting this value to another one will reset current animation.
     ///
@@ -158,10 +157,10 @@ open class AnimatedImageView: UIImageView {
     private lazy var preloadQueue: DispatchQueue = {
         return DispatchQueue(label: "com.onevcat.Kingfisher.Animator.preloadQueue")
     }()
-    
+
     // A flag to avoid invalidating the displayLink on deinit if it was never created, because displayLink is so lazy.
-    private var isDisplayLinkInitialized: Bool = false
-    
+    private var isDisplayLinkInitialized = false
+
     // A display link that keeps calling the `updateFrame` method on every screen refresh.
     private lazy var displayLink: CADisplayLink = {
         isDisplayLinkInitialized = true
@@ -170,7 +169,7 @@ open class AnimatedImageView: UIImageView {
         displayLink.isPaused = true
         return displayLink
     }()
-    
+
     // MARK: - Override
     override open var image: KFCrossPlatformImage? {
         didSet {
@@ -181,8 +180,8 @@ open class AnimatedImageView: UIImageView {
             layer.setNeedsDisplay()
         }
     }
-    
-    open override var isHighlighted: Bool {
+
+    override open var isHighlighted: Bool {
         get {
             super.isHighlighted
         }
@@ -194,13 +193,13 @@ open class AnimatedImageView: UIImageView {
             }
         }
     }
-    
+
     deinit {
         if isDisplayLinkInitialized {
             displayLink.invalidate()
         }
     }
-    
+
     override open var isAnimating: Bool {
         if isDisplayLinkInitialized {
             return !displayLink.isPaused
@@ -208,7 +207,7 @@ open class AnimatedImageView: UIImageView {
             return super.isAnimating
         }
     }
-    
+
     /// Starts the animation.
     override open func startAnimating() {
         guard !isAnimating else { return }
@@ -217,7 +216,7 @@ open class AnimatedImageView: UIImageView {
 
         displayLink.isPaused = false
     }
-    
+
     /// Stops the animation.
     override open func stopAnimating() {
         super.stopAnimating()
@@ -225,16 +224,16 @@ open class AnimatedImageView: UIImageView {
             displayLink.isPaused = true
         }
     }
-    
+
     override open func display(_ layer: CALayer) {
         layer.contents = animator?.currentFrameImage?.cgImage ?? image?.cgImage
     }
-    
+
     override open func didMoveToWindow() {
         super.didMoveToWindow()
         didMove()
     }
-    
+
     override open func didMoveToSuperview() {
         super.didMoveToSuperview()
         didMove()
@@ -267,7 +266,7 @@ open class AnimatedImageView: UIImageView {
         }
         didMove()
     }
-    
+
     private func didMove() {
         if autoPlayAnimatedImage && animator != nil {
             if let _ = superview, let _ = window {
@@ -277,7 +276,7 @@ open class AnimatedImageView: UIImageView {
             }
         }
     }
-    
+
     /// Update the current frame with the displayLink duration.
     private func updateFrameIfNeeded() {
         guard let animator = animator else {
@@ -324,10 +323,8 @@ extension AnimatedImageView: AnimatorDelegate {
 }
 
 extension AnimatedImageView {
-
     // Represents a single frame in a GIF.
     struct AnimatedFrame {
-
         // The image to display for this frame. Its value is nil when the frame is removed from the buffer.
         let image: UIImage?
 
@@ -356,7 +353,6 @@ extension AnimatedImageView {
 }
 
 extension AnimatedImageView {
-
     // MARK: - Animator
 
     /// An animator which used to drive the data behind `AnimatedImageView`.
@@ -378,7 +374,7 @@ extension AnimatedImageView {
         private var timeSinceLastFrameChange: TimeInterval = 0.0
         private var currentRepeatCount: UInt = 0
 
-        var isFinished: Bool = false
+        var isFinished = false
 
         var needsPrescaling = true
 
@@ -467,10 +463,10 @@ extension AnimatedImageView {
             self.maxFrameCount = count
             self.maxRepeatCount = repeatCount
             self.preloadQueue = preloadQueue
-            
+
             GraphicsContext.begin(size: imageSize, scale: imageScale)
         }
-        
+
         deinit {
             GraphicsContext.end()
         }
@@ -546,14 +542,14 @@ extension AnimatedImageView {
             }
 
             let image = KFCrossPlatformImage(cgImage: cgImage)
-            
+
             guard let context = GraphicsContext.current(size: imageSize, scale: imageScale, inverting: true, cgImage: cgImage) else {
                 return image
             }
-            
+
             return backgroundDecode ? image.kf.decoded(on: context) : image
         }
-        
+
         private func updatePreloadedFrames() {
             guard preloadingIsNeeded else {
                 return
@@ -580,7 +576,6 @@ extension AnimatedImageView {
                     delegate?.animator(self, didPlayAnimationLoops: currentRepeatCount)
                 }
             } else if wasLastFrame {
-
                 // Notify the delegate that the loop completed
                 delegate?.animator(self, didPlayAnimationLoops: currentRepeatCount)
             }
@@ -612,16 +607,16 @@ extension AnimatedImageView {
 }
 
 class SafeArray<Element> {
-    private var array: Array<Element> = []
+    private var array: [Element] = []
     private let lock = NSLock()
-    
+
     subscript(index: Int) -> Element? {
         get {
             lock.lock()
             defer { lock.unlock() }
             return array.indices ~= index ? array[index] : nil
         }
-        
+
         set {
             lock.lock()
             defer { lock.unlock() }
@@ -630,25 +625,25 @@ class SafeArray<Element> {
             }
         }
     }
-    
-    var count : Int {
+
+    var count: Int {
         lock.lock()
         defer { lock.unlock() }
         return array.count
     }
-    
+
     func reserveCapacity(_ count: Int) {
         lock.lock()
         defer { lock.unlock() }
         array.reserveCapacity(count)
     }
-    
+
     func append(_ element: Element) {
         lock.lock()
         defer { lock.unlock() }
         array += [element]
     }
-    
+
     func removeAll() {
         lock.lock()
         defer { lock.unlock() }

--- a/Sources/Views/Indicator.swift
+++ b/Sources/Views/Indicator.swift
@@ -54,17 +54,16 @@ public enum IndicatorType {
 
 /// An indicator type which can be used to show the download task is in progress.
 public protocol Indicator {
-    
     /// Called when the indicator should start animating.
     func startAnimatingView()
-    
+
     /// Called when the indicator should stop animating.
     func stopAnimatingView()
 
     /// Center offset of the indicator. Kingfisher will use this value to determine the position of
     /// indicator in the super view.
     var centerOffset: CGPoint { get }
-    
+
     /// The indicator view which would be added to the super view.
     var view: IndicatorView { get }
 
@@ -80,11 +79,9 @@ public enum IndicatorSizeStrategy {
 }
 
 extension Indicator {
-    
     /// Default implementation of `centerOffset` of `Indicator`. The default value is `.zero`, means that there is
     /// no offset for the indicator view.
     public var centerOffset: CGPoint { return .zero }
-
 
     /// Default implementation of `centerOffset` of `Indicator`. The default value is `.full`, means that the indicator
     /// will pin to the same height and width as the image view.
@@ -95,7 +92,6 @@ extension Indicator {
 
 // Displays a NSProgressIndicator / UIActivityIndicatorView
 final class ActivityIndicator: Indicator {
-
     #if os(macOS)
     private let activityIndicatorView: NSProgressIndicator
     #else
@@ -186,21 +182,20 @@ final class ImageIndicator: Indicator {
     init?(
         imageData data: Data,
         processor: ImageProcessor = DefaultImageProcessor.default,
-        options: KingfisherParsedOptionsInfo? = nil)
-    {
+        options: KingfisherParsedOptionsInfo? = nil) {
         var options = options ?? KingfisherParsedOptionsInfo(nil)
         // Use normal image view to show animations, so we need to preload all animation data.
         if !options.preloadAllAnimationData {
             options.preloadAllAnimationData = true
         }
-        
+
         guard let image = processor.process(item: .data(data), options: options) else {
             return nil
         }
 
         animatedImageIndicatorView = KFCrossPlatformImageView()
         animatedImageIndicatorView.image = image
-        
+
         #if os(macOS)
             // Need for gif to animate on macOS
             animatedImageIndicatorView.imageScaling = .scaleNone

--- a/Tests/KingfisherTests/DataReceivingSideEffectTests.swift
+++ b/Tests/KingfisherTests/DataReceivingSideEffectTests.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class DataReceivingSideEffectTests: XCTestCase {
 
@@ -94,7 +94,7 @@ class DataReceivingSideEffectTests: XCTestCase {
 }
 
 class DataReceivingStub: DataReceivingSideEffect {
-    var called: Bool = false
+    var called = false
     var onShouldApply: () -> Bool = { return true }
     func onDataReceived(_ session: URLSession, task: SessionDataTask, data: Data) {
         self.called = true
@@ -102,9 +102,8 @@ class DataReceivingStub: DataReceivingSideEffect {
 }
 
 class DataReceivingNotAppyStub: DataReceivingSideEffect {
-
-    var called: Bool = false
-    var appied: Bool = false
+    var called = false
+    var appied = false
 
     var onShouldApply: () -> Bool = { return false }
 

--- a/Tests/KingfisherTests/DiskStorageTests.swift
+++ b/Tests/KingfisherTests/DiskStorageTests.swift
@@ -175,7 +175,7 @@ class DiskStorageTests: XCTestCase {
 
         let urls = try! storage.removeSizeExceededValues()
         XCTAssertTrue(urls.count < count)
-        XCTAssertTrue(urls.count > 0)
+        XCTAssertTrue(!urls.isEmpty)
     }
 
     func testConfigUsesHashedFileName() {

--- a/Tests/KingfisherTests/DiskStorageTests.swift
+++ b/Tests/KingfisherTests/DiskStorageTests.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 extension String: DataTransformable {
     public func toData() throws -> Data {
@@ -100,7 +100,6 @@ class DiskStorageTests: XCTestCase {
     }
 
     func testConfigExpiration() {
-
         let now = Date()
 
         storage.config.expiration = .seconds(1)
@@ -110,7 +109,6 @@ class DiskStorageTests: XCTestCase {
     }
 
     func testExtendExpirationByAccessing() {
-
         let exp = expectation(description: #function)
         let now = Date()
         try! storage.store(value: "1", forKey: "1", expiration: .seconds(2))
@@ -132,7 +130,6 @@ class DiskStorageTests: XCTestCase {
     }
 
     func testNotExtendExpirationByAccessing() {
-
         let exp = expectation(description: #function)
         let now = Date()
         try! storage.store(value: "1", forKey: "1", expiration: .seconds(2))
@@ -154,7 +151,6 @@ class DiskStorageTests: XCTestCase {
     }
 
     func testRemoveExpired() {
-
         let expiration = StorageExpiration.seconds(1)
         try! storage.store(value: "1", forKey: "1", expiration: expiration)
         try! storage.store(value: "2", forKey: "2", expiration: expiration)
@@ -210,11 +206,11 @@ class DiskStorageTests: XCTestCase {
         let originalFileName = storage.cacheFileName(forKey: key)
         XCTAssertEqual(originalFileName, key)
     }
-    
+
     func testConfigUsesHashedFileNameWithAutoExtAndProcessor() {
         // The key of an image with processor will be as this format.
         let key = "test.jpeg@abc"
-        
+
         // hashed fileName
         storage.config.usesHashedFileName = true
         storage.config.autoExtAfterHashedFileName = true

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -24,14 +24,13 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class ImageCacheTests: XCTestCase {
+    private var cache: ImageCache!
+    private var observer: NSObjectProtocol!
 
-    var cache: ImageCache!
-    var observer: NSObjectProtocol!
-    
     override func setUp() {
         super.setUp()
 
@@ -39,7 +38,7 @@ class ImageCacheTests: XCTestCase {
         let cacheName = "test-\(uuid)"
         cache = ImageCache(name: cacheName)
     }
-    
+
     override func tearDown() {
         clearCaches([cache])
         cache = nil
@@ -47,7 +46,7 @@ class ImageCacheTests: XCTestCase {
 
         super.tearDown()
     }
-    
+
     func testInvalidCustomCachePath() {
         let customPath = "/path/to/image/cache"
         let url = URL(fileURLWithPath: customPath)
@@ -72,7 +71,7 @@ class ImageCacheTests: XCTestCase {
             (customPath as NSString).appendingPathComponent("com.onevcat.Kingfisher.ImageCache.test"))
         clearCaches([cache])
     }
-    
+
     func testCustomCachePathByBlock() {
         let cache = try! ImageCache(name: "test", cacheDirectoryURL: nil, diskCachePathClosure: { (url, path) -> URL in
             let modifiedPath = path + "-modified"
@@ -85,22 +84,22 @@ class ImageCacheTests: XCTestCase {
             (cacheURL.path as NSString).appendingPathComponent("com.onevcat.Kingfisher.ImageCache.test-modified"))
         clearCaches([cache])
     }
-    
+
     func testMaxCachePeriodInSecond() {
         cache.diskStorage.config.expiration = .seconds(1)
         XCTAssertEqual(cache.diskStorage.config.expiration.timeInterval, 1)
     }
-    
+
     func testMaxMemorySize() {
         cache.memoryStorage.config.totalCostLimit = 1
         XCTAssert(cache.memoryStorage.config.totalCostLimit == 1, "maxMemoryCost should be able to be set.")
     }
-    
+
     func testMaxDiskCacheSize() {
         cache.diskStorage.config.sizeLimit = 1
         XCTAssert(cache.diskStorage.config.sizeLimit == 1, "maxDiskCacheSize should be able to be set.")
     }
-    
+
     func testClearDiskCache() {
         let exp = expectation(description: #function)
         let key = testKeys[0]
@@ -109,16 +108,16 @@ class ImageCacheTests: XCTestCase {
             let cacheResult = self.cache.imageCachedType(forKey: key)
             XCTAssertTrue(cacheResult.cached)
             XCTAssertEqual(cacheResult, .disk)
-        
+
             self.cache.clearDiskCache {
                 let cacheResult = self.cache.imageCachedType(forKey: key)
                 XCTAssertFalse(cacheResult.cached)
                 exp.fulfill()
             }
         }
-        waitForExpectations(timeout: 3, handler:nil)
+        waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testClearMemoryCache() {
         let exp = expectation(description: #function)
         let key = testKeys[0]
@@ -132,7 +131,7 @@ class ImageCacheTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testNoImageFound() {
         let exp = expectation(description: #function)
         cache.retrieveImage(forKey: testKeys[0]) { result in
@@ -150,7 +149,7 @@ class ImageCacheTests: XCTestCase {
         let exists = cache.imageCachedType(forKey: url.cacheKey).cached
         XCTAssertFalse(exists)
     }
-    
+
     func testStoreImageInMemory() {
         let exp = expectation(description: #function)
         let key = testKeys[0]
@@ -163,7 +162,7 @@ class ImageCacheTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testStoreMultipleImages() {
         let exp = expectation(description: #function)
         storeMultipleImages {
@@ -179,15 +178,15 @@ class ImageCacheTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testCachedFileExists() {
         let exp = expectation(description: #function)
         let key = testKeys[0]
         let url = URL(string: key)!
-        
+
         let exists = cache.imageCachedType(forKey: url.cacheKey).cached
         XCTAssertFalse(exists)
-        
+
         cache.retrieveImage(forKey: key) { result in
             switch result {
             case .success(let value):
@@ -200,7 +199,6 @@ class ImageCacheTests: XCTestCase {
 
             self.cache.store(testImage, forKey: key, toDisk: true) { _ in
                 self.cache.retrieveImage(forKey: key) { result in
-
                     XCTAssertNotNil(result.value?.image)
                     XCTAssertEqual(result.value?.cacheType, .memory)
 
@@ -214,14 +212,14 @@ class ImageCacheTests: XCTestCase {
                 }
             }
         }
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
 
     func testCachedFileWithCustomPathExtensionExists() {
         cache.diskStorage.config.pathExtension = "jpg"
         let exp = expectation(description: #function)
-        
+
         let key = testKeys[0]
         let url = URL(string: key)!
 
@@ -230,11 +228,10 @@ class ImageCacheTests: XCTestCase {
             XCTAssertTrue(cachePath.hasSuffix(".jpg"))
             exp.fulfill()
         }
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
 
-  
     func testCachedImageIsFetchedSyncronouslyFromTheMemoryCache() {
         cache.store(testImage, forKey: testKeys[0], toDisk: false)
         var foundImage: KFCrossPlatformImage?
@@ -254,7 +251,7 @@ class ImageCacheTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testCleanDiskCacheNotification() {
         let exp = expectation(description: #function)
         let key = testKeys[0]
@@ -270,19 +267,19 @@ class ImageCacheTests: XCTestCase {
                     let receivedCache = noti.object as? ImageCache
                     XCTAssertNotNil(receivedCache)
                     XCTAssertTrue(receivedCache === self.cache)
-                
+
                     guard let hashes = noti.userInfo?[KingfisherDiskCacheCleanedHashKey] as? [String] else {
                         XCTFail("Notification should contains Strings in key 'KingfisherDiskCacheCleanedHashKey'")
                         exp.fulfill()
                         return
                     }
-                
+
                     XCTAssertEqual(hashes.count, 1)
                     XCTAssertEqual(hashes.first!, self.cache.hash(forKey: key))
                     guard let o = self.observer else { return }
                     NotificationCenter.default.removeObserver(o)
                     exp.fulfill()
-                }
+            }
 
             delay(1) {
                 self.cache.cleanExpiredDiskCache()
@@ -290,7 +287,7 @@ class ImageCacheTests: XCTestCase {
         }
         waitForExpectations(timeout: 5, handler: nil)
     }
-    
+
     func testCannotRetrieveCacheWithProcessorIdentifier() {
         let exp = expectation(description: #function)
         let key = testKeys[0]
@@ -314,8 +311,7 @@ class ImageCacheTests: XCTestCase {
             original: testImageData,
             forKey: key,
             processorIdentifier: p.identifier,
-            toDisk: true)
-        {
+            toDisk: true) {
             _ in
             self.cache.retrieveImage(forKey: key, options: [.processor(p)]) { result in
                 XCTAssertNotNil(result.value?.image)
@@ -337,21 +333,21 @@ class ImageCacheTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testRetrieveDiskCacheSynchronously() {
         let exp = expectation(description: #function)
         let key = testKeys[0]
         cache.store(testImage, forKey: key, toDisk: true) { _ in
             var cacheType = self.cache.imageCachedType(forKey: key)
             XCTAssertEqual(cacheType, .memory)
-            
+
             self.cache.memoryStorage.remove(forKey: key)
             cacheType = self.cache.imageCachedType(forKey: key)
             XCTAssertEqual(cacheType, .disk)
-            
+
             var dispatched = false
-            self.cache.retrieveImageInDiskCache(forKey: key, options:  [.loadDiskFileSynchronously]) {
-                result in
+            self.cache.retrieveImageInDiskCache(forKey: key, options: [.loadDiskFileSynchronously]) {
+                _ in
                 XCTAssertFalse(dispatched)
                 exp.fulfill()
             }
@@ -360,21 +356,21 @@ class ImageCacheTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testRetrieveDiskCacheAsynchronously() {
         let exp = expectation(description: #function)
         let key = testKeys[0]
         cache.store(testImage, forKey: key, toDisk: true) { _ in
             var cacheType = self.cache.imageCachedType(forKey: key)
             XCTAssertEqual(cacheType, .memory)
-            
+
             self.cache.memoryStorage.remove(forKey: key)
             cacheType = self.cache.imageCachedType(forKey: key)
             XCTAssertEqual(cacheType, .disk)
-            
+
             var dispatched = false
-            self.cache.retrieveImageInDiskCache(forKey: key, options:  nil) {
-                result in
+            self.cache.retrieveImageInDiskCache(forKey: key, options: nil) {
+                _ in
                 XCTAssertTrue(dispatched)
                 exp.fulfill()
             }
@@ -426,7 +422,7 @@ class ImageCacheTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 #endif
-    
+
     func testStoreToMemoryWithExpiration() {
         let exp = expectation(description: #function)
         let key = testKeys[0]
@@ -435,8 +431,7 @@ class ImageCacheTests: XCTestCase {
             original: testImageData,
             forKey: key,
             options: KingfisherParsedOptionsInfo([.memoryCacheExpiration(.seconds(0.2))]),
-            toDisk: true)
-        {
+            toDisk: true) {
             _ in
             XCTAssertEqual(self.cache.imageCachedType(forKey: key), .memory)
             delay(1) {
@@ -446,7 +441,7 @@ class ImageCacheTests: XCTestCase {
         }
         waitForExpectations(timeout: 5, handler: nil)
     }
-    
+
     func testStoreToDiskWithExpiration() {
         let exp = expectation(description: #function)
         let key = testKeys[0]
@@ -455,8 +450,7 @@ class ImageCacheTests: XCTestCase {
             original: testImageData,
             forKey: key,
             options: KingfisherParsedOptionsInfo([.diskCacheExpiration(.expired)]),
-            toDisk: true)
-        {
+            toDisk: true) {
             _ in
             XCTAssertEqual(self.cache.imageCachedType(forKey: key), .memory)
             self.cache.clearMemoryCache()

--- a/Tests/KingfisherTests/ImageDataProviderTests.swift
+++ b/Tests/KingfisherTests/ImageDataProviderTests.swift
@@ -24,21 +24,20 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class ImageDataProviderTests: XCTestCase {
-    
     func testLocalFileImageDataProvider() {
         let fm = FileManager.default
         let document = try! fm.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
         let fileURL = document.appendingPathComponent("test")
         try! testImageData.write(to: fileURL)
-        
+
         let provider = LocalFileImageDataProvider(fileURL: fileURL)
         XCTAssertEqual(provider.cacheKey, fileURL.localFileCacheKey)
         XCTAssertEqual(provider.fileURL, fileURL)
-        
+
         let exp = expectation(description: #function)
         provider.data { result in
             XCTAssertEqual(result.value, testImageData)
@@ -48,17 +47,17 @@ class ImageDataProviderTests: XCTestCase {
 
         waitForExpectations(timeout: 1, handler: nil)
     }
-    
+
     func testLocalFileImageDataProviderMainQueue() {
         let fm = FileManager.default
         let document = try! fm.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
         let fileURL = document.appendingPathComponent("test")
         try! testImageData.write(to: fileURL)
-        
+
         let provider = LocalFileImageDataProvider(fileURL: fileURL, loadingQueue: .mainCurrentOrAsync)
         XCTAssertEqual(provider.cacheKey, fileURL.localFileCacheKey)
         XCTAssertEqual(provider.fileURL, fileURL)
-        
+
         var called = false
         provider.data { result in
             XCTAssertEqual(result.value, testImageData)
@@ -68,24 +67,24 @@ class ImageDataProviderTests: XCTestCase {
 
         XCTAssertTrue(called)
     }
-    
+
     func testLocalFileCacheKey() {
         let url1 = URL(string: "file:///Users/onevcat/Library/Developer/CoreSimulator/Devices/ABC/data/Containers/Bundle/Application/DEF/Kingfisher-Demo.app/images/kingfisher-1.jpg")!
         XCTAssertEqual(url1.localFileCacheKey, "\(URL.localFileCacheKeyPrefix)/Kingfisher-Demo.app/images/kingfisher-1.jpg")
-    
+
         let url2 = URL(string: "file:///private/var/containers/Bundle/Application/ABC/Kingfisher-Demo.app/images/kingfisher-1.jpg")!
         XCTAssertEqual(url2.localFileCacheKey, "\(URL.localFileCacheKeyPrefix)/Kingfisher-Demo.app/images/kingfisher-1.jpg")
-        
+
         let url3 = URL(string: "file:///private/var/containers/Bundle/Application/ABC/Kingfisher-Demo.app/images/kingfisher-1.jpg?foo=bar")!
         XCTAssertEqual(url3.localFileCacheKey, "\(URL.localFileCacheKeyPrefix)/Kingfisher-Demo.app/images/kingfisher-1.jpg?foo=bar")
-        
+
         let url4 = URL(string: "file:///private/var/containers/Bundle/Application/ABC/Kingfisher-Demo.appex/images/kingfisher-1.jpg")!
         XCTAssertEqual(url4.localFileCacheKey, "\(URL.localFileCacheKeyPrefix)/Kingfisher-Demo.appex/images/kingfisher-1.jpg")
-        
+
         let url5 = URL(string: "file:///private/var/containers/Bundle/Application/ABC/Kingfisher-Demo.other/images/kingfisher-1.jpg")!
         XCTAssertEqual(url5.localFileCacheKey, "\(URL.localFileCacheKeyPrefix)///private/var/containers/Bundle/Application/ABC/Kingfisher-Demo.other/images/kingfisher-1.jpg")
     }
-    
+
     func testBase64ImageDataProvider() {
         let base64String = testImageData.base64EncodedString()
         let provider = Base64ImageDataProvider(base64String: base64String, cacheKey: "123")
@@ -95,8 +94,7 @@ class ImageDataProviderTests: XCTestCase {
             XCTAssertEqual(result.value, testImageData)
             syncCalled = true
         }
-        
+
         XCTAssertTrue(syncCalled)
     }
-    
 }

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -24,9 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class ImageDownloaderTests: XCTestCase {
 
@@ -37,26 +36,26 @@ class ImageDownloaderTests: XCTestCase {
         super.setUp()
         LSNocilla.sharedInstance().start()
     }
-    
+
     override class func tearDown() {
         LSNocilla.sharedInstance().stop()
         super.tearDown()
     }
-    
+
     override func setUp() {
         super.setUp()
         downloader = ImageDownloader(name: "test")
     }
-    
+
     override func tearDown() {
         LSNocilla.sharedInstance().clearStubs()
         downloader = nil
         super.tearDown()
     }
-    
+
     func testDownloadAnImage() {
         let exp = expectation(description: #function)
-        
+
         let url = testURLs[0]
         stub(url, data: testImageData)
 
@@ -66,11 +65,11 @@ class ImageDownloaderTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testDownloadMultipleImages() {
         let exp = expectation(description: #function)
         let group = DispatchGroup()
-        
+
         for url in testURLs {
             group.enter()
             stub(url, data: testImageData)
@@ -79,14 +78,14 @@ class ImageDownloaderTests: XCTestCase {
                 group.leave()
             }
         }
-        
+
         group.notify(queue: .main, execute: exp.fulfill)
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testDownloadAnImageWithMultipleCallback() {
         let exp = expectation(description: #function)
-        
+
         let group = DispatchGroup()
         let url = testURLs[0]
         stub(url, data: testImageData)
@@ -102,15 +101,15 @@ class ImageDownloaderTests: XCTestCase {
         group.notify(queue: .main, execute: exp.fulfill)
         waitForExpectations(timeout: 5, handler: nil)
     }
-    
+
     func testDownloadWithModifyingRequest() {
         let exp = expectation(description: #function)
 
         let url = testURLs[0]
         stub(url, data: testImageData)
-        
+
         modifier.url = url
-        
+
         let someURL = URL(string: "some_strange_url")!
         let task = downloader.downloadImage(with: someURL, options: [.requestModifier(modifier)]) { result in
             XCTAssertNotNil(result.value)
@@ -135,7 +134,6 @@ class ImageDownloaderTests: XCTestCase {
             XCTAssertNotNil(task)
             downloadTaskCalled = true
         }
-
 
         let someURL = URL(string: "some_strage_url")!
         let task = downloader.downloadImage(with: someURL, options: [.requestModifier(asyncModifier)]) { result in
@@ -166,31 +164,31 @@ class ImageDownloaderTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testServerInvalidStatusCode() {
         let exp = expectation(description: #function)
-        
+
         let url = testURLs[0]
         stub(url, data: testImageData, statusCode: 404)
-        
+
         downloader.downloadImage(with: url) { result in
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error!.isInvalidResponseStatusCode(404))
             exp.fulfill()
         }
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testDownloadResultErrorAndRetry() {
         let exp = expectation(description: #function)
-        
+
         let url = testURLs[0]
 
         stub(url, errorCode: -1)
         downloader.downloadImage(with: url) { result in
             XCTAssertNotNil(result.error)
-            
+
             LSNocilla.sharedInstance().clearStubs()
 
             stub(url, data: testImageData)
@@ -200,15 +198,15 @@ class ImageDownloaderTests: XCTestCase {
                 exp.fulfill()
             }
         }
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testDownloadEmptyURL() {
         let exp = expectation(description: #function)
-        
+
         modifier.url = nil
-        
+
         let url = URL(string: "http://onevcat.com")!
         downloader.downloadImage(
             with: url,
@@ -224,35 +222,34 @@ class ImageDownloaderTests: XCTestCase {
             }
             exp.fulfill()
         }
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testDownloadTaskProperty() {
         let task = downloader.downloadImage(with: URL(string: "1234")!)
         XCTAssertNotNil(task, "The task should exist.")
     }
-    
+
     func testCancelDownloadTask() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         let stub = delayedStub(url, data: testImageData, length: 123)
-        
+
         let task = downloader.downloadImage(
             with: url,
-            progressBlock: { _, _ in XCTFail() })
-        {
+            progressBlock: { _, _ in XCTFail() }) {
             result in
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error!.isTaskCancelled)
             delay(0.1) { exp.fulfill() }
         }
-        
+
         XCTAssertNotNil(task)
         task!.cancel()
 
         _ = stub.go()
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
 
@@ -282,7 +279,7 @@ class ImageDownloaderTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testCancelAllDownloadTasks() {
         let exp = expectation(description: #function)
 
@@ -314,75 +311,74 @@ class ImageDownloaderTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testCancelDownloadTaskForURL() {
         let exp = expectation(description: #function)
-        
+
         let url1 = testURLs[0]
         let stub1 = delayedStub(url1, data: testImageData)
-        
+
         let url2 = testURLs[1]
         let stub2 = delayedStub(url2, data: testImageData)
-        
+
         let group = DispatchGroup()
-        
+
         group.enter()
         downloader.downloadImage(with: url1) { result in
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error!.isTaskCancelled)
             group.leave()
         }
-        
+
         group.enter()
         downloader.downloadImage(with: url1) { result in
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error!.isTaskCancelled)
             group.leave()
         }
-        
+
         group.enter()
         downloader.downloadImage(with: url2) { result in
             XCTAssertNotNil(result.value)
             group.leave()
         }
-        
+
         delay(0.1) {
             self.downloader.cancel(url: url1)
             _ = stub1.go()
             _ = stub2.go()
         }
-        
+
         group.notify(queue: .main) {
             delay(0.1) { exp.fulfill() }
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     // Issue 532 https://github.com/onevcat/Kingfisher/issues/532#issuecomment-305644311
     func testCancelThenRestartSameDownload() {
         let exp = expectation(description: #function)
-        
+
         let url = testURLs[0]
         let stub = delayedStub(url, data: testImageData, length: 123)
 
         let group = DispatchGroup()
-        
+
         group.enter()
         let downloadTask = downloader.downloadImage(
             with: url,
-            progressBlock: { _, _ in XCTFail()})
-        {
+            progressBlock: { _, _ in XCTFail() }) {
             result in
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error!.isTaskCancelled)
             group.leave()
         }
-        
+
         XCTAssertNotNil(downloadTask)
-        
+
         downloadTask!.cancel()
         _ = stub.go()
-        
+
         group.enter()
         downloader.downloadImage(with: url) {
             result in
@@ -392,28 +388,28 @@ class ImageDownloaderTests: XCTestCase {
             }
             group.leave()
         }
-        
+
         group.notify(queue: .main) {
             delay(0.1) { exp.fulfill() }
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testDownloadTaskNil() {
         modifier.url = nil
         let downloadTask = downloader.downloadImage(with: URL(string: "url")!, options: [.requestModifier(modifier)])
         XCTAssertNil(downloadTask)
     }
-    
+
     func testDownloadWithProcessor() {
         let exp = expectation(description: #function)
-        
+
         let url = testURLs[0]
         stub(url, data: testImageData)
 
         let p = RoundCornerImageProcessor(cornerRadius: 40)
         let roundcornered = testImage.kf.image(withRoundRadius: 40, fit: testImage.kf.size)
-        
+
         downloader.downloadImage(with: url, options: [.processor(p)]) { result in
             XCTAssertNotNil(result.value)
             let image = result.value!.image
@@ -422,10 +418,10 @@ class ImageDownloaderTests: XCTestCase {
             XCTAssertEqual(result.value!.originalData, testImageData)
             exp.fulfill()
         }
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testDownloadWithDifferentProcessors() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
@@ -436,7 +432,7 @@ class ImageDownloaderTests: XCTestCase {
 
         let p2 = BlurImageProcessor(blurRadius: 3.0)
         let blurred = testImage.kf.blurred(withRadius: 3.0)
-        
+
         let group = DispatchGroup()
 
         group.enter()
@@ -455,17 +451,17 @@ class ImageDownloaderTests: XCTestCase {
         XCTAssertEqual(task1?.sessionTask.task, task2?.sessionTask.task)
 
         _ = stub.go()
-        
+
         group.notify(queue: .main, execute: exp.fulfill)
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testDownloadedDataCouldBeModified() {
         let exp = expectation(description: #function)
-        
+
         let url = testURLs[0]
         stub(url, data: testImageData)
-        
+
         let modifier = URLNilDataModifier()
 
         downloader.delegate = modifier
@@ -486,10 +482,10 @@ class ImageDownloaderTests: XCTestCase {
 
     func testDownloadedDataCouldBeModifiedWithTask() {
         let exp = expectation(description: #function)
-        
+
         let url = testURLs[0]
         stub(url, data: testImageData)
-        
+
         let modifier = TaskNilDataModifier()
 
         downloader.delegate = modifier
@@ -507,7 +503,7 @@ class ImageDownloaderTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
 #if os(iOS) || os(tvOS) || os(watchOS)
     func testModifierShouldOnlyApplyForFinalResultWhenDownload() {
         let exp = expectation(description: #function)
@@ -530,27 +526,25 @@ class ImageDownloaderTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 #endif
-    
+
     func testDownloadTaskTakePriorityOption() {
         let exp = expectation(description: #function)
-        
+
         let url = testURLs[0]
         stub(url, data: testImageData)
-        let task = downloader.downloadImage(with: url, options: [.downloadPriority(URLSessionTask.highPriority)])
-        {
+        let task = downloader.downloadImage(with: url, options: [.downloadPriority(URLSessionTask.highPriority)]) {
             _ in
             exp.fulfill()
         }
         XCTAssertEqual(task?.sessionTask.task.priority, URLSessionTask.highPriority)
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
-    
+
     func testSessionDelegate() {
-        class ExtensionDelegate:SessionDelegate {
-            //'exp' only for test
-            public let exp:XCTestExpectation
-            init(_ expectation:XCTestExpectation) {
+        class ExtensionDelegate: SessionDelegate {
+            // 'exp' only for test
+            public let exp: XCTestExpectation
+            init(_ expectation: XCTestExpectation) {
                 exp = expectation
             }
             func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
@@ -558,7 +552,7 @@ class ImageDownloaderTests: XCTestCase {
             }
         }
         downloader.sessionDelegate = ExtensionDelegate(expectation(description: #function))
-        
+
         let url = testURLs[0]
         stub(url, data: testImageData)
         downloader.downloadImage(with: url) { result in
@@ -581,7 +575,7 @@ class TaskNilDataModifier: ImageDownloaderDelegate {
 }
 
 class URLModifier: ImageDownloadRequestModifier {
-    var url: URL? = nil
+    var url: URL?
     func modified(for request: URLRequest) -> URLRequest? {
         var r = request
         r.url = url
@@ -590,7 +584,7 @@ class URLModifier: ImageDownloadRequestModifier {
 }
 
 class AsyncURLModifier: AsyncImageDownloadRequestModifier {
-    var url: URL? = nil
+    var url: URL?
     var onDownloadTaskStarted: ((DownloadTask?) -> Void)?
 
     func modified(for request: URLRequest, reportModified: @escaping (URLRequest?) -> Void) {

--- a/Tests/KingfisherTests/ImageDrawingTests.swift
+++ b/Tests/KingfisherTests/ImageDrawingTests.swift
@@ -24,21 +24,20 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class ImageDrawingTests: XCTestCase {
-
     func testImageResizing() {
         let result = testImage.kf.resize(to: CGSize(width: 20, height: 20))
         XCTAssertEqual(result.size, CGSize(width: 20, height: 20))
     }
-    
+
     func testImageCropping() {
         let result = testImage.kf.crop(to: CGSize(width: 20, height: 20), anchorOn: .zero)
         XCTAssertEqual(result.size, CGSize(width: 20, height: 20))
     }
-    
+
     func testImageScaling() {
         XCTAssertEqual(testImage.kf.scale, 1)
         let result = testImage.kf.scaled(to: 2.0)

--- a/Tests/KingfisherTests/ImageExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageExtensionTests.swift
@@ -24,28 +24,27 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 import ImageIO
 @testable import Kingfisher
+import XCTest
 
 class ImageExtensionTests: XCTestCase {
-
     func testImageFormat() {
         var format: ImageFormat
         format = testImageJEPGData.kf.imageFormat
         XCTAssertEqual(format, .JPEG)
-        
+
         format = testImagePNGData.kf.imageFormat
         XCTAssertEqual(format, .PNG)
-        
+
         format = testImageGIFData.kf.imageFormat
         XCTAssertEqual(format, .GIF)
-        
+
         let raw: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8]
         format = Data(raw).kf.imageFormat
         XCTAssertEqual(format, .unknown)
     }
-    
+
     func testGenerateJPEGImage() {
         let options = ImageCreatingOptions()
         let image = KingfisherWrapper<KFCrossPlatformImage>.image(data: testImageJEPGData, options: options)
@@ -53,7 +52,7 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertNil(image?.kf.imageFrameCount)
         XCTAssertTrue(image!.renderEqual(to: KFCrossPlatformImage(data: testImageJEPGData)!))
     }
-    
+
     func testGenerateGIFImage() {
         let options = ImageCreatingOptions()
         let image = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageGIFData, options: options)
@@ -79,17 +78,17 @@ class ImageExtensionTests: XCTestCase {
         let options = ImageCreatingOptions()
         let image = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageGIFData, options: options)!
         let data = image.kf.gifRepresentation()
-        
+
         XCTAssertNotNil(data)
         XCTAssertEqual(data?.kf.imageFormat, ImageFormat.GIF)
-        
+
         let preloadOptions = ImageCreatingOptions(preloadAll: true)
         let allLoadImage = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: data!, options: preloadOptions)!
         let allLoadData = allLoadImage.kf.gifRepresentation()
         XCTAssertNotNil(allLoadData)
         XCTAssertEqual(allLoadData?.kf.imageFormat, ImageFormat.GIF)
     }
-    
+
     func testGenerateSingleFrameGIFImage() {
         let options = ImageCreatingOptions()
         let image = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageSingleFrameGIFData, options: options)
@@ -101,14 +100,14 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertEqual(image!.kf.duration, Double.infinity)
         #endif
     }
-    
+
     func testGenerateFromNonImage() {
         let data = "hello".data(using: .utf8)!
         let options = ImageCreatingOptions()
         let image = KingfisherWrapper<KFCrossPlatformImage>.image(data: data, options: options)
         XCTAssertNil(image)
     }
-    
+
     func testPreloadAllAnimationData() {
         let preloadOptions = ImageCreatingOptions(preloadAll: true)
         let image = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageSingleFrameGIFData, options: preloadOptions)!
@@ -119,47 +118,47 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertEqual(image.kf.duration, image.kf.duration)
         XCTAssertEqual(image.kf.images!.count, image.kf.images!.count)
     }
-    
+
     func testLoadOnlyFirstFrame() {
         let preloadOptions = ImageCreatingOptions(preloadAll: true, onlyFirstFrame: true)
         let image = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageGIFData, options: preloadOptions)!
         XCTAssertNotNil(image, "The image should be initiated.")
         XCTAssertNil(image.kf.images, "The image should be nil")
     }
-    
+
     func testSizeContent() {
         func getRatio(image: KFCrossPlatformImage) -> CGFloat {
             return image.size.height / image.size.width
         }
-        
+
         let image = testImage
         let ratio = getRatio(image: image)
-        
+
         let targetSize = CGSize(width: 100, height: 50)
-        
+
         let fillImage = image.kf.resize(to: targetSize, for: .aspectFill)
         XCTAssertEqual(getRatio(image: fillImage), ratio)
         XCTAssertEqual(max(fillImage.size.width, fillImage.size.height), 100)
-        
+
         let fitImage = image.kf.resize(to: targetSize, for: .aspectFit)
         XCTAssertEqual(getRatio(image: fitImage), ratio)
         XCTAssertEqual(max(fitImage.size.width, fitImage.size.height), 50)
-        
+
         let resizeImage = image.kf.resize(to: targetSize)
         XCTAssertEqual(resizeImage.size.width, 100)
         XCTAssertEqual(resizeImage.size.height, 50)
     }
-    
+
     func testSizeConstraintByAnchor() {
         let size = CGSize(width: 100, height: 100)
-        
+
         let topLeft = CGPoint(x: 0, y: 0)
         let top = CGPoint(x: 0.5, y: 0)
         let topRight = CGPoint(x: 1, y: 0)
         let center = CGPoint(x: 0.5, y: 0.5)
         let bottomRight = CGPoint(x: 1, y: 1)
         let invalidAnchor = CGPoint(x: -1, y: 2)
-        
+
         let inSize = CGSize(width: 20, height: 20)
         let outX = CGSize(width: 120, height: 20)
         let outY = CGSize(width: 20, height: 120)
@@ -179,7 +178,7 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertEqual(
             kf.constrainedRect(for: outSize, anchor: topLeft),
             CGRect(x: 0, y: 0, width: 100, height: 100))
-        
+
         XCTAssertEqual(
             kf.constrainedRect(for: inSize, anchor: top),
             CGRect(x: 40, y: 0, width: 20, height: 20))
@@ -192,7 +191,7 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertEqual(
             kf.constrainedRect(for: outSize, anchor: top),
             CGRect(x: 0, y: 0, width: 100, height: 100))
-        
+
         XCTAssertEqual(
             kf.constrainedRect(for: inSize, anchor: topRight),
             CGRect(x: 80, y: 0, width: 20, height: 20))
@@ -205,7 +204,7 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertEqual(
             kf.constrainedRect(for: outSize, anchor: topRight),
             CGRect(x: 0, y: 0, width: 100, height: 100))
-        
+
         XCTAssertEqual(
             kf.constrainedRect(for: inSize, anchor: center),
             CGRect(x: 40, y: 40, width: 20, height: 20))
@@ -218,7 +217,7 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertEqual(
             kf.constrainedRect(for: outSize, anchor: center),
             CGRect(x: 0, y: 0, width: 100, height: 100))
-        
+
         XCTAssertEqual(
             kf.constrainedRect(for: inSize, anchor: bottomRight),
             CGRect(x: 80, y: 80, width: 20, height: 20))
@@ -227,11 +226,11 @@ class ImageExtensionTests: XCTestCase {
             CGRect(x: 0, y: 80, width: 100, height: 20))
         XCTAssertEqual(
             kf.constrainedRect(for: outY, anchor: bottomRight),
-            CGRect(x:80, y: 0, width: 20, height: 100))
+            CGRect(x: 80, y: 0, width: 20, height: 100))
         XCTAssertEqual(
             kf.constrainedRect(for: outSize, anchor: bottomRight),
             CGRect(x: 0, y: 0, width: 100, height: 100))
-        
+
         XCTAssertEqual(
             kf.constrainedRect(for: inSize, anchor: invalidAnchor),
             CGRect(x: 0, y: 80, width: 20, height: 20))
@@ -240,12 +239,12 @@ class ImageExtensionTests: XCTestCase {
             CGRect(x: 0, y: 80, width: 100, height: 20))
         XCTAssertEqual(
             kf.constrainedRect(for: outY, anchor: invalidAnchor),
-            CGRect(x:0, y: 0, width: 20, height: 100))
+            CGRect(x: 0, y: 0, width: 20, height: 100))
         XCTAssertEqual(
             kf.constrainedRect(for: outSize, anchor: invalidAnchor),
             CGRect(x: 0, y: 0, width: 100, height: 100))
     }
-    
+
     func testDecodeScale() {
         #if os(iOS) || os(tvOS)
         let image = testImage
@@ -255,29 +254,29 @@ class ImageExtensionTests: XCTestCase {
         let image_2x = KingfisherWrapper<KFCrossPlatformImage>.image(cgImage: image.cgImage!, scale: 2.0, refImage: image)
         XCTAssertEqual(image_2x.size, CGSize(width: 32, height: 32))
         XCTAssertEqual(image_2x.scale, 2.0)
-        
+
         let decoded = image.kf.decoded
         XCTAssertEqual(decoded.size, CGSize(width: 64, height: 64))
         XCTAssertEqual(decoded.scale, 1.0)
-        
+
         let decodedDifferentScale = image.kf.decoded(scale: 2.0)
         XCTAssertEqual(decodedDifferentScale.size, CGSize(width: 32, height: 32))
         XCTAssertEqual(decodedDifferentScale.scale, 2.0)
-        
+
         let decoded_2x = image_2x.kf.decoded
         XCTAssertEqual(decoded_2x.size, CGSize(width: 32, height: 32))
         XCTAssertEqual(decoded_2x.scale, 2.0)
         #endif
     }
-    
+
     func testNormalized() {
         // Full loaded GIF image should not be normalized since it is a set of images.
         let options = ImageCreatingOptions()
         let gifImage = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageGIFData, options: options)
-        
+
         XCTAssertNotNil(gifImage)
         XCTAssertEqual(gifImage!.kf.normalized, gifImage!)
-        
+
         #if os(iOS) || os(tvOS)
         // No need to normalize up orientation image.
         let normalImage = testImage
@@ -294,22 +293,22 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertEqual(rotatedNormalizedImage.size, CGSize(width: 200, height: 100))
         #endif
     }
-    
+
     func testDownsampling() {
         let size = CGSize(width: 15, height: 15)
         XCTAssertEqual(testImage.size, CGSize(width: 64, height: 64))
         XCTAssertEqual(testImage.kf.scale, 1.0)
-        
+
         let image = KingfisherWrapper<KFCrossPlatformImage>.downsampledImage(data: testImageData, to: size, scale: 1)
         XCTAssertEqual(image?.size, size)
         XCTAssertEqual(image?.kf.scale, 1.0)
     }
-    
+
     func testDownsamplingWithScale() {
         let size = CGSize(width: 15, height: 15)
         XCTAssertEqual(testImage.size, CGSize(width: 64, height: 64))
         XCTAssertEqual(testImage.kf.scale, 1.0)
-        
+
         let image2x = KingfisherWrapper<KFCrossPlatformImage>.downsampledImage(data: testImageData, to: size, scale: 2)
         #if os(macOS)
         XCTAssertEqual(image2x?.size, CGSize(width: 30, height: 30))
@@ -318,7 +317,7 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertEqual(image2x?.size, size)
         XCTAssertEqual(image2x?.kf.scale, 2.0)
         #endif
-        
+
         let image3x = KingfisherWrapper<KFCrossPlatformImage>.downsampledImage(data: testImageData, to: size, scale: 3)
         #if os(macOS)
         XCTAssertEqual(image3x?.size, CGSize(width: 45, height: 45))
@@ -330,7 +329,6 @@ class ImageExtensionTests: XCTestCase {
     }
 
     func testDownsamplingWithEdgeCaseSize() {
-
         // Zero size would fail downsampling.
         let nilImage = KingfisherWrapper<KFCrossPlatformImage>.downsampledImage(data: testImageData, to: .zero, scale: 1)
         XCTAssertNil(nilImage)

--- a/Tests/KingfisherTests/ImageModifierTests.swift
+++ b/Tests/KingfisherTests/ImageModifierTests.swift
@@ -24,11 +24,10 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 import Kingfisher
+import XCTest
 
 class ImageModifierTests: XCTestCase {
-
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -77,5 +76,4 @@ class ImageModifierTests: XCTestCase {
     }
 
 #endif
-
 }

--- a/Tests/KingfisherTests/ImageProcessorTests.swift
+++ b/Tests/KingfisherTests/ImageProcessorTests.swift
@@ -24,11 +24,10 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class ImageProcessorTests: XCTestCase {
-
     // Issue 1125. https://github.com/onevcat/Kingfisher/issues/1125
     func testDownsamplingSizes() {
         XCTAssertEqual(testImage.size, CGSize(width: 64, height: 64))
@@ -43,7 +42,6 @@ class ImageProcessorTests: XCTestCase {
 
         let resultFromImage = downsamplingProcessor.process(item: .image(testImage), options: emptyOption)
         XCTAssertEqual(resultFromImage!.size, CGSize(width: 40, height: 40))
-
     }
 
     func testProcessorConcating() {
@@ -57,7 +55,7 @@ class ImageProcessorTests: XCTestCase {
         XCTAssertNotNil(two)
         XCTAssertNotNil(three)
     }
-    
+
     func testParsingColorRGBA() {
         let sRGB = KFCrossPlatformColor(red: 0.5, green: 0.6, blue: 0.7, alpha: 0.8)
         let rgba = sRGB.rgba
@@ -65,7 +63,7 @@ class ImageProcessorTests: XCTestCase {
         XCTAssertEqual(rgba.g, 0.6, accuracy: 0.01)
         XCTAssertEqual(rgba.b, 0.7, accuracy: 0.01)
         XCTAssertEqual(rgba.a, 0.8, accuracy: 0.01)
-        
+
         let extended = KFCrossPlatformColor(displayP3Red: 0, green: 1, blue: 0, alpha: 0.8)
         let rgbaExt = extended.rgba
         // extended sRGB
@@ -73,7 +71,7 @@ class ImageProcessorTests: XCTestCase {
         XCTAssertTrue(rgbaExt.g > 1)
         XCTAssertTrue(rgbaExt.b < 0)
         XCTAssertEqual(rgbaExt.a, 0.8)
-        
+
         let blackWhite = KFCrossPlatformColor(white: 0.3, alpha: 1.0)
         let rgbaBlackWhite = blackWhite.rgba
         XCTAssertEqual(rgbaBlackWhite.r, 0.3, accuracy: 0.01)

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class KingfisherManagerTests: XCTestCase {
     
@@ -35,23 +35,23 @@ class KingfisherManagerTests: XCTestCase {
         super.setUp()
         LSNocilla.sharedInstance().start()
     }
-    
+
     override class func tearDown() {
         LSNocilla.sharedInstance().stop()
         super.tearDown()
     }
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
         let uuid = UUID()
         let downloader = ImageDownloader(name: "test.manager.\(uuid.uuidString)")
         let cache = ImageCache(name: "test.cache.\(uuid.uuidString)")
-        
+
         manager = KingfisherManager(downloader: downloader, cache: cache)
         manager.defaultOptions = [.waitForCache]
     }
-    
+
     override func tearDown() {
         LSNocilla.sharedInstance().clearStubs()
         clearCaches([manager.cache])
@@ -59,7 +59,7 @@ class KingfisherManagerTests: XCTestCase {
         manager = nil
         super.tearDown()
     }
-    
+
     func testRetrieveImage() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
@@ -85,10 +85,14 @@ class KingfisherManagerTests: XCTestCase {
                 XCTAssertNotNil(result.value?.image)
                 XCTAssertEqual(result.value!.cacheType, .none)
                 exp.fulfill()
-        }}}}}
+            }
+        }
+        }
+        }
+        }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testRetrieveImageWithProcessor() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
@@ -99,7 +103,7 @@ class KingfisherManagerTests: XCTestCase {
         manager.retrieveImage(with: url, options: [.processor(p)]) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none)
-            
+
         manager.retrieveImage(with: url) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none,
@@ -108,12 +112,12 @@ class KingfisherManagerTests: XCTestCase {
         manager.retrieveImage(with: url, options: [.processor(p)]) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .memory)
-                    
+
         self.manager.cache.clearMemoryCache()
         manager.retrieveImage(with: url, options: [.processor(p)]) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .disk)
-                        
+
         self.manager.cache.clearMemoryCache()
         self.manager.cache.clearDiskCache {
             self.manager.retrieveImage(with: url, options: [.processor(p)]) { result in
@@ -121,23 +125,27 @@ class KingfisherManagerTests: XCTestCase {
                 XCTAssertEqual(result.value!.cacheType, .none)
 
                 exp.fulfill()
-        }}}}}}
+            }
+        }
+        }
+        }
+        }
+        }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testRetrieveImageForceRefresh() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData)
-        
+
         manager.cache.store(
             testImage,
             original: testImageData,
             forKey: url.cacheKey,
             processorIdentifier: DefaultImageProcessor.default.identifier,
             cacheSerializer: DefaultCacheSerializer.default,
-            toDisk: true)
-        {
+            toDisk: true) {
             _ in
             XCTAssertTrue(self.manager.cache.imageCachedType(forKey: url.cacheKey).cached)
             self.manager.retrieveImage(with: url, options: [.forceRefresh]) { result in
@@ -148,18 +156,17 @@ class KingfisherManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testSuccessCompletionHandlerRunningOnMainQueueDefaultly() {
         let progressExpectation = expectation(description: "progressBlock running on main queue")
         let completionExpectation = expectation(description: "completionHandler running on main queue")
 
         let url = testURLs[0]
         stub(url, data: testImageData, length: 123)
-        
+
         manager.retrieveImage(with: url, options: nil, progressBlock: { _, _ in
             XCTAssertTrue(Thread.isMainThread)
-            progressExpectation.fulfill()})
-        {
+            progressExpectation.fulfill()}) {
             result in
             XCTAssertNil(result.error)
             XCTAssertTrue(Thread.isMainThread)
@@ -212,8 +219,7 @@ class KingfisherManagerTests: XCTestCase {
         manager.retrieveImage(with: url, options: options, progressBlock: { _, _ in
             XCTAssertTrue(Thread.isMainThread)
             progressExpectation.fulfill()
-        })
-        {
+        }) {
             result in
             XCTAssertNil(result.error)
             dispatchPrecondition(condition: .onQueue(customQueue))
@@ -237,12 +243,12 @@ class KingfisherManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testDefaultOptionCouldApply() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData)
-        
+
         manager.defaultOptions = [.scaleFactor(2)]
         manager.retrieveImage(with: url, completionHandler: { result in
             #if !os(macOS)
@@ -252,7 +258,7 @@ class KingfisherManagerTests: XCTestCase {
         })
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testOriginalImageCouldBeStored() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
@@ -272,19 +278,19 @@ class KingfisherManagerTests: XCTestCase {
 
             delay(0.1) {
                 manager.cache.clearMemoryCache()
-                
+
                 imageCached = manager.cache.imageCachedType(forKey: url.cacheKey, processorIdentifier: p.identifier)
                 originalCached = manager.cache.imageCachedType(forKey: url.cacheKey)
                 XCTAssertEqual(imageCached, .disk)
                 XCTAssertEqual(originalCached, .disk)
-                
+
                 exp.fulfill()
             }
         }
 
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testOriginalImageNotBeStoredWithoutOptionSet() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
@@ -298,46 +304,45 @@ class KingfisherManagerTests: XCTestCase {
             result in
             var imageCached = self.manager.cache.imageCachedType(forKey: url.cacheKey, processorIdentifier: p.identifier)
             var originalCached = self.manager.cache.imageCachedType(forKey: url.cacheKey)
-            
+
             XCTAssertEqual(imageCached, .memory)
             XCTAssertEqual(originalCached, .none)
-            
+
             self.manager.cache.clearMemoryCache()
-            
+
             imageCached = self.manager.cache.imageCachedType(forKey: url.cacheKey, processorIdentifier: p.identifier)
             originalCached = self.manager.cache.imageCachedType(forKey: url.cacheKey)
             XCTAssertEqual(imageCached, .disk)
             XCTAssertEqual(originalCached, .none)
-            
+
             exp.fulfill()
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testCouldProcessOnOriginalImage() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
-        
+
         manager.cache.store(
             testImage,
             original: testImageData,
             forKey: url.cacheKey,
             processorIdentifier: DefaultImageProcessor.default.identifier,
             cacheSerializer: DefaultCacheSerializer.default,
-            toDisk: true)
-        {
+            toDisk: true) {
             _ in
             let p = SimpleProcessor()
-            
+
             let cached = self.manager.cache.imageCachedType(forKey: url.cacheKey, processorIdentifier: p.identifier)
             XCTAssertFalse(cached.cached)
-            
+
             // No downloading will happen
             self.manager.retrieveImage(with: url, options: [.processor(p)]) { result in
                 XCTAssertNotNil(result.value?.image)
                 XCTAssertEqual(result.value!.cacheType, .none)
                 XCTAssertTrue(p.processed)
-                
+
                 // The processed image should be cached
                 let cached = self.manager.cache.imageCachedType(forKey: url.cacheKey, processorIdentifier: p.identifier)
                 XCTAssertTrue(cached.cached)
@@ -346,25 +351,24 @@ class KingfisherManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testFailingProcessOnOriginalImage() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
-        
+
         manager.cache.store(
             testImage,
             original: testImageData,
             forKey: url.cacheKey,
             processorIdentifier: DefaultImageProcessor.default.identifier,
             cacheSerializer: DefaultCacheSerializer.default,
-            toDisk: true)
-        {
+            toDisk: true) {
             _ in
             let p = FailingProcessor()
-            
+
             let cached = self.manager.cache.imageCachedType(forKey: url.cacheKey, processorIdentifier: p.identifier)
             XCTAssertFalse(cached.cached)
-            
+
             // No downloading will happen
             self.manager.retrieveImage(with: url, options: [.processor(p)]) { result in
                 XCTAssertNotNil(result.error)
@@ -379,7 +383,7 @@ class KingfisherManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testFailingProcessOnDataProviderImage() {
         let provider = SimpleImageDataProvider(cacheKey: "key") { .success(testImageData) }
         var called = false
@@ -396,21 +400,20 @@ class KingfisherManagerTests: XCTestCase {
         }
         XCTAssertTrue(called)
     }
-    
+
     func testCacheOriginalImageWithOriginalCache() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
-        
+
         let originalCache = ImageCache(name: "test-originalCache")
-        
+
         // Clear original cache first.
         originalCache.clearMemoryCache()
         originalCache.clearDiskCache {
-            
             XCTAssertEqual(originalCache.imageCachedType(forKey: url.cacheKey), .none)
-            
+
             stub(url, data: testImageData)
-            
+
             let p = RoundCornerImageProcessor(cornerRadius: 20)
             self.manager.retrieveImage(
                 with: url,
@@ -424,13 +427,13 @@ class KingfisherManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 5, handler: nil)
     }
-    
+
     func testCouldProcessOnOriginalImageWithOriginalCache() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
-        
+
         let originalCache = ImageCache(name: "test-originalCache")
-        
+
         // Clear original cache first.
         originalCache.clearMemoryCache()
         originalCache.clearDiskCache {
@@ -440,21 +443,20 @@ class KingfisherManagerTests: XCTestCase {
                 forKey: url.cacheKey,
                 processorIdentifier: DefaultImageProcessor.default.identifier,
                 cacheSerializer: DefaultCacheSerializer.default,
-                toDisk: true)
-            {
+                toDisk: true) {
                 _ in
                 let p = SimpleProcessor()
-                
+
                 let cached = self.manager.cache.imageCachedType(forKey: url.cacheKey, processorIdentifier: p.identifier)
                 XCTAssertFalse(cached.cached)
-                
+
                 // No downloading will happen
                 self.manager.retrieveImage(with: url, options: [.processor(p), .originalCache(originalCache)]) {
                     result in
                     XCTAssertNotNil(result.value?.image)
                     XCTAssertEqual(result.value!.cacheType, .none)
                     XCTAssertTrue(p.processed)
-                    
+
                     // The processed image should be cached
                     let cached = self.manager.cache.imageCachedType(forKey: url.cacheKey, processorIdentifier: p.identifier)
                     XCTAssertTrue(cached.cached)
@@ -464,25 +466,25 @@ class KingfisherManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testWaitForCacheOnRetrieveImage() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData)
-        
+
         self.manager.retrieveImage(with: url) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none)
-            
+
             self.manager.cache.clearMemoryCache()
             let cached = self.manager.cache.imageCachedType(forKey: url.cacheKey)
             XCTAssertEqual(cached, .disk)
-            
+
             exp.fulfill()
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testNotWaitForCacheOnRetrieveImage() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
@@ -492,10 +494,10 @@ class KingfisherManagerTests: XCTestCase {
         self.manager.retrieveImage(with: url, options: [.callbackQueue(.untouch)]) { result in
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none)
-            
+
             // We are not waiting for cache finishing here. So only sync memory cache is done.
             XCTAssertEqual(self.manager.cache.imageCachedType(forKey: url.cacheKey), .memory)
-            
+
             // Clear the memory cache.
             self.manager.cache.clearMemoryCache()
             // After some time, the disk cache should be done.
@@ -506,7 +508,7 @@ class KingfisherManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testWaitForCacheOnRetrieveImageWithProcessor() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
@@ -529,18 +531,18 @@ class KingfisherManagerTests: XCTestCase {
             // Can be downloaded and cached normally.
             XCTAssertNotNil(result.value?.image)
             XCTAssertEqual(result.value!.cacheType, .none)
-            
+
             // Can still be got from memory even when disk cache cleared.
             self.manager.cache.clearDiskCache {
                 self.manager.retrieveImage(with: url, options: [.fromMemoryCacheOrRefresh]) { result in
                     XCTAssertNotNil(result.value?.image)
                     XCTAssertEqual(result.value!.cacheType, .memory)
-                    
+
                     exp.fulfill()
                 }
             }
         }
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
 
@@ -556,7 +558,7 @@ class KingfisherManagerTests: XCTestCase {
 
             self.manager.cache.clearMemoryCache()
             XCTAssertEqual(self.manager.cache.imageCachedType(forKey: url.cacheKey), .disk)
-            
+
             // Should skip disk cache and download again.
             self.manager.retrieveImage(with: url, options: [.fromMemoryCacheOrRefresh]) { result in
                 XCTAssertNotNil(result.value?.image)
@@ -622,7 +624,7 @@ class KingfisherManagerTests: XCTestCase {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData)
-        
+
         var modifierCalled = false
         let modifier = AnyImageModifier { image in
             modifierCalled = true
@@ -687,12 +689,12 @@ class KingfisherManagerTests: XCTestCase {
                 exp.fulfill()
             }
         }
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
 
 #endif
-    
+
     func testRetrieveWithImageProvider() {
         let provider = SimpleImageDataProvider(cacheKey: "key") { .success(testImageData) }
         var called = false
@@ -705,7 +707,7 @@ class KingfisherManagerTests: XCTestCase {
         }
         XCTAssertTrue(called)
     }
-    
+
     func testRetrieveWithImageProviderFail() {
         let provider = SimpleImageDataProvider(cacheKey: "key") { .failure(SimpleImageDataProvider.E()) }
         var called = false
@@ -759,8 +761,7 @@ class KingfisherManagerTests: XCTestCase {
 
         _ = manager.retrieveImage(
             with: .network(brokenURL),
-            options: [.alternativeSources([.network(url)])])
-        {
+            options: [.alternativeSources([.network(url)])]) {
             result in
 
             XCTAssertNotNil(result.value)
@@ -786,8 +787,7 @@ class KingfisherManagerTests: XCTestCase {
 
         _ = manager.retrieveImage(
             with: .network(brokenURL),
-            options: [.alternativeSources([.network(anotherBrokenURL), .network(url)])])
-        {
+            options: [.alternativeSources([.network(anotherBrokenURL), .network(url)])]) {
             result in
 
             defer { exp.fulfill() }
@@ -852,8 +852,7 @@ class KingfisherManagerTests: XCTestCase {
         let task = manager.retrieveImage(
             with: .network(brokenURL),
             options: [.alternativeSources([.network(url)])]
-        )
-        {
+        ) {
             result in
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error!.isTaskCancelled)
@@ -880,8 +879,7 @@ class KingfisherManagerTests: XCTestCase {
                 task = newTask
                 task.cancel()
             }
-        )
-        {
+        ) {
             result in
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error?.isTaskCancelled ?? false)
@@ -894,21 +892,20 @@ class KingfisherManagerTests: XCTestCase {
 
         waitForExpectations(timeout: 1, handler: nil)
     }
-    
+
     func testDownsamplingHandleScale2x() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData)
-        
+
         _ = manager.retrieveImage(
             with: .network(url),
-            options: [.processor(DownsamplingImageProcessor(size: .init(width: 4, height: 4))), .scaleFactor(2)])
-        {
+            options: [.processor(DownsamplingImageProcessor(size: .init(width: 4, height: 4))), .scaleFactor(2)]) {
             result in
 
             let image = result.value?.image
             XCTAssertNotNil(image)
-            
+
             #if os(macOS)
             XCTAssertEqual(image?.size, .init(width: 8, height: 8))
             XCTAssertEqual(image?.kf.scale, 1)
@@ -916,22 +913,21 @@ class KingfisherManagerTests: XCTestCase {
             XCTAssertEqual(image?.size, .init(width: 4, height: 4))
             XCTAssertEqual(image?.kf.scale, 2)
             #endif
-            
+
             exp.fulfill()
         }
 
         waitForExpectations(timeout: 1, handler: nil)
     }
-    
+
     func testDownsamplingHandleScale3x() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData)
-        
+
         _ = manager.retrieveImage(
             with: .network(url),
-            options: [.processor(DownsamplingImageProcessor(size: .init(width: 4, height: 4))), .scaleFactor(3)])
-        {
+            options: [.processor(DownsamplingImageProcessor(size: .init(width: 4, height: 4))), .scaleFactor(3)]) {
             result in
 
             let image = result.value?.image
@@ -943,7 +939,7 @@ class KingfisherManagerTests: XCTestCase {
             XCTAssertEqual(image?.size, .init(width: 4, height: 4))
             XCTAssertEqual(image?.kf.scale, 3)
             #endif
-            
+
             exp.fulfill()
         }
 
@@ -1022,7 +1018,7 @@ class KingfisherManagerTests: XCTestCase {
                 XCTAssertEqual(data, testImageData)
 
                 exp.fulfill()
-            }
+        }
         waitForExpectations(timeout: 1.0)
     }
 
@@ -1048,7 +1044,7 @@ class KingfisherManagerTests: XCTestCase {
                 XCTAssertEqual(data, testImage.kf.jpegRepresentation(compressionQuality: 0.8))
 
                 exp.fulfill()
-            }
+        }
         waitForExpectations(timeout: 1.0)
     }
 }
@@ -1058,7 +1054,7 @@ class SimpleProcessor: ImageProcessor {
     var processed = false
     /// Initialize a `DefaultImageProcessor`
     public init() {}
-    
+
     /// Process an input `ImageProcessItem` item to an image for this processor.
     ///
     /// - parameter item:    Input item which will be processed by `self`
@@ -1091,10 +1087,10 @@ class FailingProcessor: ImageProcessor {
 struct SimpleImageDataProvider: ImageDataProvider {
     let cacheKey: String
     let provider: () -> (Result<Data, Error>)
-    
+
     func data(handler: @escaping (Result<Data, Error>) -> Void) {
         handler(provider())
     }
-    
+
     struct E: Error {}
 }

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -30,7 +30,7 @@ import XCTest
 class KingfisherManagerTests: XCTestCase {
     
     var manager: KingfisherManager!
-    
+
     override class func setUp() {
         super.setUp()
         LSNocilla.sharedInstance().start()

--- a/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
+++ b/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
@@ -24,12 +24,10 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class KingfisherOptionsInfoTests: XCTestCase {
-
     func testEmptyOptionsShouldParseCorrectly() {
         let options = KingfisherParsedOptionsInfo(KingfisherOptionsInfo.empty)
         XCTAssertTrue(options.targetCache === nil)
@@ -41,7 +39,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         default: XCTFail("The transition for empty option should be .None. But \(options.transition)")
         }
 #endif
-        
+
         XCTAssertEqual(options.downloadPriority, URLSessionTask.defaultPriority)
         XCTAssertFalse(options.forceRefresh)
         XCTAssertFalse(options.fromMemoryCacheOrRefresh)
@@ -54,11 +52,11 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertFalse(options.cacheOriginalImage)
         XCTAssertEqual(options.diskStoreWriteOptions, [])
     }
-    
+
     func testSetOptionsShouldParseCorrectly() {
         let cache = ImageCache(name: "com.onevcat.Kingfisher.KingfisherOptionsInfoTests")
         let downloader = ImageDownloader(name: "com.onevcat.Kingfisher.KingfisherOptionsInfoTests")
-        
+
         let queue = DispatchQueue.global(qos: .default)
         let testModifier = TestModifier()
         let testRedirectHandler = TestRedirectHandler()
@@ -94,7 +92,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
             .alternativeSources([alternativeSource]),
             .retryStrategy(DelayRetryStrategy(maxRetryCount: 10))
         ])
-        
+
         XCTAssertTrue(options.targetCache === cache)
         XCTAssertTrue(options.originalCache === cache)
         XCTAssertTrue(options.downloader === downloader)
@@ -107,7 +105,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         default: XCTFail()
         }
         #endif
-        
+
         XCTAssertEqual(options.downloadPriority, 0.8)
         XCTAssertTrue(options.forceRefresh)
         XCTAssertTrue(options.fromMemoryCacheOrRefresh)
@@ -116,7 +114,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertTrue(options.waitForCache)
         XCTAssertTrue(options.onlyFromCache)
         XCTAssertTrue(options.backgroundDecode)
-        
+
         XCTAssertEqual(options.callbackQueue.queue.label, queue.label)
         XCTAssertEqual(options.scaleFactor, 2.0)
         XCTAssertTrue(options.preloadAllAnimationData)
@@ -136,7 +134,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertNotNil(retry)
         XCTAssertEqual(retry?.maxRetryCount, 10)
     }
-    
+
     func testOptionCouldBeOverwritten() {
         var options = KingfisherParsedOptionsInfo([.downloadPriority(0.5), .onlyFromCache])
         XCTAssertEqual(options.downloadPriority, 0.5)

--- a/Tests/KingfisherTests/KingfisherTestHelper.swift
+++ b/Tests/KingfisherTests/KingfisherTestHelper.swift
@@ -24,9 +24,9 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+import CoreGraphics
 import Foundation
 @testable import Kingfisher
-import CoreGraphics
 
 let testImageString =
     "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAD8GlDQ1BJQ0MgUHJvZmlsZQAAOI2NVd1v21QUP4lvXKQWP6Cxjg4Vi69VU1u5GxqtxgZJk6XpQhq5zdgqpMl1bhpT1za2021V" +
@@ -105,75 +105,69 @@ func delay(_ time: Double, block: @escaping () -> Void) {
 
 extension KFCrossPlatformImage {
     func renderEqual(to image: KFCrossPlatformImage, withinTolerance tolerance: UInt8 = 3) -> Bool {
-        
         guard size == image.size else { return false }
         guard let imageData1 = kf.pngRepresentation(),
-              let imageData2 = image.kf.pngRepresentation() else
-        {
+              let imageData2 = image.kf.pngRepresentation() else {
             return false
         }
         guard let unifiedImage1 = KFCrossPlatformImage(data: imageData1),
-              let unifiedImage2 = KFCrossPlatformImage(data: imageData2) else
-        {
+              let unifiedImage2 = KFCrossPlatformImage(data: imageData2) else {
             return false
         }
-        
+
         guard let rendered1 = unifiedImage1.rendered(),
-              let rendered2 = unifiedImage2.rendered() else
-        {
+              let rendered2 = unifiedImage2.rendered() else {
             return false
         }
         guard let data1 = rendered1.kf.cgImage?.dataProvider?.data,
-              let data2 = rendered2.kf.cgImage?.dataProvider?.data else
-        {
+              let data2 = rendered2.kf.cgImage?.dataProvider?.data else {
             return false
         }
-        
+
         let length1 = CFDataGetLength(data1)
         let length2 = CFDataGetLength(data2)
         guard length1 == length2 else { return false }
-        
+
         let dataPtr1: UnsafePointer<UInt8> = CFDataGetBytePtr(data1)
         let dataPtr2: UnsafePointer<UInt8> = CFDataGetBytePtr(data2)
-        
+
         for index in 0..<length1 {
             let byte1 = dataPtr1[index]
             let byte2 = dataPtr2[index]
             let delta = UInt8(abs(Int(byte1) - Int(byte2)))
-            
+
             guard delta <= tolerance else {
                 return false
             }
         }
-        
+
         return true
     }
-    
+
     func rendered() -> KFCrossPlatformImage? {
         // Ignore non CG images
         guard let cgImage = kf.cgImage else {
             return nil
         }
-        
+
         var bitmapInfo = cgImage.bitmapInfo
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let alpha = (bitmapInfo.rawValue & CGBitmapInfo.alphaInfoMask.rawValue)
-        
+
         let w = cgImage.width
         let h = cgImage.height
-        
+
         let size = CGSize(width: w, height: h)
-        
+
         if alpha == CGImageAlphaInfo.none.rawValue {
             bitmapInfo.remove(.alphaInfoMask)
             bitmapInfo = CGBitmapInfo(rawValue: bitmapInfo.rawValue | CGImageAlphaInfo.noneSkipFirst.rawValue)
         } else if !(alpha == CGImageAlphaInfo.noneSkipFirst.rawValue) ||
-                  !(alpha == CGImageAlphaInfo.noneSkipLast.rawValue)
-        {
+                  !(alpha == CGImageAlphaInfo.noneSkipLast.rawValue) {
             bitmapInfo.remove(.alphaInfoMask)
             bitmapInfo = CGBitmapInfo(rawValue: bitmapInfo.rawValue | CGImageAlphaInfo.premultipliedFirst.rawValue)
         }
-        
+
         // Render the image
         guard let context = CGContext(data: nil,
                                       width: w,
@@ -181,13 +175,12 @@ extension KFCrossPlatformImage {
                                       bitsPerComponent: cgImage.bitsPerComponent,
                                       bytesPerRow: 0,
                                       space: colorSpace,
-                                      bitmapInfo: bitmapInfo.rawValue) else
-        {
+                                      bitmapInfo: bitmapInfo.rawValue) else {
             return nil
         }
-        
+
         context.draw(cgImage, in: CGRect(origin: CGPoint.zero, size: size))
-        
+
         #if os(macOS)
         return context.makeImage().flatMap { KFCrossPlatformImage(cgImage: $0, size: kf.size) }
         #else
@@ -218,7 +211,7 @@ extension Data {
         guard comp.count == 2 else { fatalError() }
         self.init(named: comp[0], type: comp[1])
     }
-    
+
     init(named name: String, type: String) {
         guard let path = Bundle.test.path(forResource: name, ofType: type) else {
             fatalError()
@@ -228,7 +221,7 @@ extension Data {
 }
 
 extension Bundle {
-    static let test: Bundle = Bundle(for: ImageExtensionTests.self)
+    static let test = Bundle(for: ImageExtensionTests.self)
 }
 
 // Make tests happier with old Result type

--- a/Tests/KingfisherTests/MemoryStorageTests.swift
+++ b/Tests/KingfisherTests/MemoryStorageTests.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 extension Int: CacheCostCalculable {
     public var cacheCost: Int {
@@ -138,55 +138,55 @@ class MemoryStorageTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testStoreWithExpirationExtending() {
         let exp = expectation(description: #function)
-        
+
         XCTAssertFalse(storage.isCached(forKey: "1"))
         storage.store(value: 1, forKey: "1", expiration: .seconds(1))
         XCTAssertTrue(storage.isCached(forKey: "1"))
-        
+
         delay(0.1) {
             let expirationDate1 = self.storage.storage.object(forKey: "1")?.estimatedExpiration
             XCTAssertNotNil(expirationDate1)
-            
+
             // Request for the object to extend it's expiration date
             let obj = self.storage.value(forKey: "1", extendingExpiration: .expirationTime(.seconds(5)))
             XCTAssertNotNil(obj)
-            
+
             let expirationDate2 = self.storage.storage.object(forKey: "1")?.estimatedExpiration
             XCTAssertNotNil(expirationDate2)
-            
+
             XCTAssertNotEqual(expirationDate1!, expirationDate2!)
             XCTAssert(expirationDate1!.isPast(referenceDate: expirationDate2!))
             exp.fulfill()
         }
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testStoreWithExpirationNotExtending() {
         let exp = expectation(description: #function)
-        
+
         XCTAssertFalse(storage.isCached(forKey: "1"))
         storage.store(value: 1, forKey: "1", expiration: .seconds(1))
         XCTAssertTrue(storage.isCached(forKey: "1"))
-        
+
         delay(0.1) {
             let expirationDate1 = self.storage.storage.object(forKey: "1")?.estimatedExpiration
             XCTAssertNotNil(expirationDate1)
-            
+
             // Request for the object to extend it's expiration date
             let obj = self.storage.value(forKey: "1", extendingExpiration: .none)
             XCTAssertNotNil(obj)
-            
+
             let expirationDate2 = self.storage.storage.object(forKey: "1")?.estimatedExpiration
             XCTAssertNotNil(expirationDate2)
-            
+
             XCTAssertEqual(expirationDate1, expirationDate2)
             exp.fulfill()
         }
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
 
@@ -227,7 +227,7 @@ class MemoryStorageTests: XCTestCase {
             // Accessing `isCached` does not extend expiration
             XCTAssertTrue(self.storage.isCached(forKey: "1"))
         }
-        
+
         delay(1) {
             XCTAssertFalse(self.storage.isCached(forKey: "1"))
             exp.fulfill()
@@ -243,7 +243,7 @@ class MemoryStorageTests: XCTestCase {
         storage.store(value: 1, forKey: "1", expiration: .seconds(0.1))
         XCTAssertTrue(storage.isCached(forKey: "1"))
         XCTAssertEqual(self.storage.keys.count, 1)
-        
+
         delay(0.2) {
             XCTAssertFalse(self.storage.isCached(forKey: "1"))
             XCTAssertNil(self.storage.storage.object(forKey: "1"))

--- a/Tests/KingfisherTests/NSButtonExtensionTests.swift
+++ b/Tests/KingfisherTests/NSButtonExtensionTests.swift
@@ -26,8 +26,8 @@
 
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class NSButtonExtensionTests: XCTestCase {
 
@@ -45,11 +45,11 @@ class NSButtonExtensionTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        
+
         button = NSButton()
         KingfisherManager.shared.downloader = ImageDownloader(name: "testDownloader")
         KingfisherManager.shared.defaultOptions = [.waitForCache]
-        
+
         cleanDefaultCache()
     }
 
@@ -66,20 +66,20 @@ class NSButtonExtensionTests: XCTestCase {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData, length: 123)
-        
+
         var progressBlockIsCalled = false
 
         button.kf.setImage(with: url, progressBlock: { _, _ in progressBlockIsCalled = true }) {
             result in
             XCTAssertTrue(progressBlockIsCalled)
-            
+
             let image = result.value?.image
             XCTAssertNotNil(image)
             XCTAssertTrue(image!.renderEqual(to: testImage))
             XCTAssertTrue(self.button.image!.renderEqual(to: testImage))
-            //XCTAssertEqual(self.button.kf.taskIdentifier, Source.Identifier.current)
+            // XCTAssertEqual(self.button.kf.taskIdentifier, Source.Identifier.current)
             XCTAssertEqual(result.value!.cacheType, .none)
-            
+
             exp.fulfill()
         }
         waitForExpectations(timeout: 3, handler: nil)
@@ -94,16 +94,15 @@ class NSButtonExtensionTests: XCTestCase {
         button.kf.setAlternateImage(with: url, progressBlock: { _, _ in progressBlockIsCalled = true }) {
             result in
             XCTAssertTrue(progressBlockIsCalled)
-            
+
             let image = result.value?.image
             XCTAssertNotNil(image)
             XCTAssertTrue(image!.renderEqual(to: testImage))
             XCTAssertTrue(self.button.alternateImage!.renderEqual(to: testImage))
-            //XCTAssertEqual(self.button.kf.alternateTaskIdentifier, Source.Identifier.current)
+            // XCTAssertEqual(self.button.kf.alternateTaskIdentifier, Source.Identifier.current)
             XCTAssertEqual(result.value!.cacheType, .none)
-            
-            exp.fulfill()
 
+            exp.fulfill()
         }
         waitForExpectations(timeout: 5, handler: nil)
     }
@@ -112,13 +111,13 @@ class NSButtonExtensionTests: XCTestCase {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         let stub = delayedStub(url, data: testImageData)
-        
+
         button.kf.setImage(with: url, completionHandler: { result in
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error!.isTaskCancelled)
             delay(0.1) { exp.fulfill() }
         })
-        
+
         self.button.kf.cancelImageDownloadTask()
         _ = stub.go()
 
@@ -129,19 +128,19 @@ class NSButtonExtensionTests: XCTestCase {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         let stub = delayedStub(url, data: testImageData)
-        
+
         button.kf.setAlternateImage(with: url, completionHandler: { result in
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error!.isTaskCancelled)
             delay(0.1) { exp.fulfill() }
         })
-        
+
         self.button.kf.cancelAlternateImageDownloadTask()
         _ = stub.go()
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testSettingNilURL() {
         let exp = expectation(description: #function)
         let url: URL? = nil
@@ -149,46 +148,45 @@ class NSButtonExtensionTests: XCTestCase {
             result in
             XCTAssertNil(result.value)
             XCTAssertNotNil(result.error)
-            
+
             guard case .imageSettingError(reason: .emptySource) = result.error! else {
                 XCTFail()
                 fatalError()
             }
             exp.fulfill()
         }
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testSettingNonWorkingImageWithFailureImage() {
         let expectation = self.expectation(description: "wait for downloading image")
         let url = testURLs[0]
         stub(url, errorCode: 404)
-        
+
         button.kf.setImage(with: url, options: [.onFailureImage(testImage)], completionHandler: { result in
             XCTAssertNil(result.value)
             expectation.fulfill()
         })
-        
+
         XCTAssertNil(button.image)
         waitForExpectations(timeout: 5, handler: nil)
         XCTAssertEqual(testImage, button.image)
     }
-    
+
     func testSettingNonWorkingAlternateImageWithFailureImage() {
         let expectation = self.expectation(description: "wait for downloading image")
         let url = testURLs[0]
         stub(url, errorCode: 404)
-        
-        button.kf.setAlternateImage(with: url, options: [.onFailureImage(testImage)], completionHandler:  { result in
+
+        button.kf.setAlternateImage(with: url, options: [.onFailureImage(testImage)], completionHandler: { result in
             XCTAssertNil(result.value)
             expectation.fulfill()
         })
-        
+
         XCTAssertNil(button.alternateImage)
         waitForExpectations(timeout: 5, handler: nil)
         XCTAssertEqual(testImage, button.alternateImage)
     }
-
 }
 #endif

--- a/Tests/KingfisherTests/RetryStrategyTests.swift
+++ b/Tests/KingfisherTests/RetryStrategyTests.swift
@@ -24,8 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class RetryStrategyTests: XCTestCase {
 
@@ -65,7 +65,6 @@ class RetryStrategyTests: XCTestCase {
         XCTAssertEqual(strategy.retryInterval.timeInterval(for: 0), 5)
     }
 
-
     func testDelayRetryIntervalCalculating() {
         let secondInternal = DelayRetryStrategy.Interval.seconds(10)
         XCTAssertEqual(secondInternal.timeInterval(for: 0), 10)
@@ -103,7 +102,6 @@ class RetryStrategyTests: XCTestCase {
     }
 
     func testDelayRetryStrategyExceededCount() {
-
         var blockCalled: [Bool] = []
 
         let source = Source.network(URL(string: "url")!)
@@ -200,11 +198,9 @@ class RetryStrategyTests: XCTestCase {
 private struct E: Error {}
 
 class StubRetryStrategy: RetryStrategy {
-
     var count = 0
 
     func retry(context: RetryContext, retryHandler: @escaping (RetryDecision) -> Void) {
-
         if count == 0 {
             XCTAssertNil(context.userInfo)
         } else {

--- a/Tests/KingfisherTests/StorageExpirationTests.swift
+++ b/Tests/KingfisherTests/StorageExpirationTests.swift
@@ -24,11 +24,10 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class StorageExpirationTests: XCTestCase {
-
     func testExpirationNever() {
         let e = StorageExpiration.never
         XCTAssertEqual(e.estimatedExpirationSinceNow, .distantFuture)
@@ -45,7 +44,7 @@ class StorageExpirationTests: XCTestCase {
         XCTAssertEqual(e.timeInterval, 100)
         XCTAssertFalse(e.isExpired)
     }
-    
+
     func testExpirationDays() {
         let e = StorageExpiration.days(1)
         let oneDayInSecond = TimeInterval(TimeConstants.secondsInOneDay)
@@ -56,7 +55,7 @@ class StorageExpirationTests: XCTestCase {
         XCTAssertEqual(e.timeInterval, oneDayInSecond, accuracy: 0.1)
         XCTAssertFalse(e.isExpired)
     }
-    
+
     func testExpirationDate() {
         let oneDayInSecond = TimeInterval(TimeConstants.secondsInOneDay)
         let targetDate = Date().addingTimeInterval(oneDayInSecond)
@@ -68,7 +67,7 @@ class StorageExpirationTests: XCTestCase {
         XCTAssertEqual(e.timeInterval, oneDayInSecond, accuracy: 0.1)
         XCTAssertFalse(e.isExpired)
     }
-    
+
     func testAlreadyExpired() {
         let e = StorageExpiration.expired
         XCTAssertTrue(e.isExpired)

--- a/Tests/KingfisherTests/StringExtensionTests.swift
+++ b/Tests/KingfisherTests/StringExtensionTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2019 Wei Wang. All rights reserved.
 //
 
-import XCTest
 @testable import Kingfisher
+import XCTest
 
 class StringExtensionTests: XCTestCase {
     func testStringMD5() {

--- a/Tests/KingfisherTests/UIButtonExtensionTests.swift
+++ b/Tests/KingfisherTests/UIButtonExtensionTests.swift
@@ -25,33 +25,32 @@
 //  THE SOFTWARE.
 
 #if canImport(UIKit)
+@testable import Kingfisher
 import UIKit
 import XCTest
-@testable import Kingfisher
 
 class UIButtonExtensionTests: XCTestCase {
+    private var button: UIButton!
 
-    var button: UIButton!
-    
     override class func setUp() {
         super.setUp()
         LSNocilla.sharedInstance().start()
     }
-    
+
     override class func tearDown() {
         LSNocilla.sharedInstance().stop()
         super.tearDown()
     }
-    
+
     override func setUp() {
         super.setUp()
         button = UIButton()
         KingfisherManager.shared.downloader = ImageDownloader(name: "testDownloader")
         KingfisherManager.shared.defaultOptions = [.waitForCache]
-        
+
         cleanDefaultCache()
     }
-    
+
     override func tearDown() {
         LSNocilla.sharedInstance().clearStubs()
         button = nil
@@ -85,12 +84,12 @@ class UIButtonExtensionTests: XCTestCase {
 
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testDownloadAndSetBackgroundImage() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
         stub(url, data: testImageData, length: 123)
-        
+
         var progressBlockIsCalled = false
         KF.url(url)
             .onProgress { _, _ in
@@ -109,7 +108,7 @@ class UIButtonExtensionTests: XCTestCase {
             .setBackground(to: button, for: .normal)
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testCacnelImageTask() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
@@ -121,13 +120,13 @@ class UIButtonExtensionTests: XCTestCase {
                 delay(0.1) { exp.fulfill() }
             }
             .set(to: button, for: .highlighted)
-        
+
         self.button.kf.cancelImageDownloadTask()
         _ = stub.go()
 
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testCacnelBackgroundImageTask() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
@@ -139,18 +138,18 @@ class UIButtonExtensionTests: XCTestCase {
                 delay(0.1) { exp.fulfill() }
             }
             .setBackground(to: button, for: .highlighted)
-        
+
         self.button.kf.cancelBackgroundImageDownloadTask()
         _ = stub.go()
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testSettingNilURL() {
         let exp = expectation(description: #function)
-        
+
         let url: URL? = nil
-        button.kf.setBackgroundImage(with: url, for: .normal, completionHandler:  { result in
+        button.kf.setBackgroundImage(with: url, for: .normal, completionHandler: { result in
             XCTAssertNil(result.value)
             XCTAssertNotNil(result.error)
             guard case .imageSettingError(reason: .emptySource) = result.error! else {
@@ -159,10 +158,10 @@ class UIButtonExtensionTests: XCTestCase {
             }
             exp.fulfill()
         })
-        
+
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
+
     func testSettingNonWorkingImageWithFailureImage() {
         let expectation = self.expectation(description: "wait for downloading image")
         let url = testURLs[0]
@@ -179,7 +178,7 @@ class UIButtonExtensionTests: XCTestCase {
         XCTAssertNil(button.image(for: state))
         waitForExpectations(timeout: 5, handler: nil)
     }
-    
+
     func testSettingNonWorkingBackgroundImageWithFailureImage() {
         let expectation = self.expectation(description: "wait for downloading image")
         let url = testURLs[0]
@@ -196,7 +195,6 @@ class UIButtonExtensionTests: XCTestCase {
 
         XCTAssertNil(button.backgroundImage(for: state))
         waitForExpectations(timeout: 5, handler: nil)
-
     }
 }
 #endif


### PR DESCRIPTION
Fix swift lint warnings. Most of warnings have been fixed by the Swift Lint Auto correct tool.