### PR TITLE
[Issue #1880] - Image cost should account for number of image frames

### DIFF
--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -103,7 +103,11 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         guard let cgImage = cgImage else {
             return pixel * 4
         }
-        return pixel * cgImage.bitsPerPixel / 8
+        let bytesPerPixel = cgImage.bitsPerPixel / 8
+        guard let imageCount = images?.count else {
+            return pixel * bytesPerPixel
+        }
+        return pixel * bytesPerPixel * imageCount
     }
 }
 


### PR DESCRIPTION
[Addressing issue #1880](https://github.com/onevcat/Kingfisher/issues/1880)

When we calculate the Image cost for cache purposes, we should take into account how many frames make up the Image to get an accurate cost.