### PR TITLE
Fix wrong key override when created by `ImageResource`

### DIFF
--- a/Sources/General/ImageSource/Resource.swift
+++ b/Sources/General/ImageSource/Resource.swift
@@ -44,9 +44,10 @@ extension Resource {
     /// `LocalFileImageDataProvider` associated will be returned if the URL points to a local file. Otherwise,
     /// `.network` is returned.
     public func convertToSource(overrideCacheKey: String? = nil) -> Source {
+        let key = overrideCacheKey ?? cacheKey
         return downloadURL.isFileURL ?
-            .provider(LocalFileImageDataProvider(fileURL: downloadURL, cacheKey: overrideCacheKey ?? downloadURL.localFileCacheKey)) :
-            .network(ImageResource(downloadURL: downloadURL, cacheKey: overrideCacheKey ?? cacheKey))
+            .provider(LocalFileImageDataProvider(fileURL: downloadURL, cacheKey: key)) :
+            .network(ImageResource(downloadURL: downloadURL, cacheKey: key))
     }
 }
 
@@ -65,7 +66,7 @@ public struct ImageResource: Resource {
     ///               Default is `nil`.
     public init(downloadURL: URL, cacheKey: String? = nil) {
         self.downloadURL = downloadURL
-        self.cacheKey = cacheKey ?? downloadURL.absoluteString
+        self.cacheKey = cacheKey ?? (downloadURL.isFileURL ? downloadURL.localFileCacheKey : downloadURL.absoluteString)
     }
 
     // MARK: Protocol Conforming

--- a/Tests/KingfisherTests/ImageDataProviderTests.swift
+++ b/Tests/KingfisherTests/ImageDataProviderTests.swift
@@ -86,6 +86,13 @@ class ImageDataProviderTests: XCTestCase {
         XCTAssertEqual(url5.localFileCacheKey, "\(URL.localFileCacheKeyPrefix)///private/var/containers/Bundle/Application/ABC/Kingfisher-Demo.other/images/kingfisher-1.jpg")
     }
     
+    func testLocalFileExplicitKey() {
+        let url1 = URL(string: "file:///Users/onevcat/Library/Developer/CoreSimulator/Devices/ABC/data/Containers/Bundle/Application/DEF/Kingfisher-Demo.app/images/kingfisher-1.jpg")!
+        let imageResource = ImageResource(downloadURL: url1, cacheKey: "hello")
+        let source = imageResource.convertToSource()
+        XCTAssertEqual(source.cacheKey, "hello")
+    }
+    
     func testBase64ImageDataProvider() {
         let base64String = testImageData.base64EncodedString()
         let provider = Base64ImageDataProvider(base64String: base64String, cacheKey: "123")


### PR DESCRIPTION
This should be a fix for #1902 