### PR TITLE
Give correct cache key for local urls

### DIFF
--- a/Sources/General/ImageSource/ImageDataProvider.swift
+++ b/Sources/General/ImageSource/ImageDataProvider.swift
@@ -109,34 +109,6 @@ public struct LocalFileImageDataProvider: ImageDataProvider {
     }
 }
 
-extension URL {
-    static let localFileCacheKeyPrefix = "kingfisher.local.cacheKey"
-    
-    // The special version of cache key for a local file on disk. Every time the app is reinstalled on the disk,
-    // the system assigns a new container folder to hold the .app (and the extensions, .appex) folder. So the URL for
-    // the same image in bundle might be different.
-    //
-    // This getter only uses the fixed part in the URL (until the bundle name folder) to provide a stable cache key
-    // for the image under the same path inside the bundle.
-    //
-    // See #1825 (https://github.com/onevcat/Kingfisher/issues/1825)
-    var localFileCacheKey: String {
-        var validComponents: [String] = []
-        for part in pathComponents.reversed() {
-            validComponents.append(part)
-            if part.hasSuffix(".app") || part.hasSuffix(".appex") {
-                break
-            }
-        }
-        let fixedPath = "\(Self.localFileCacheKeyPrefix)/\(validComponents.reversed().joined(separator: "/"))"
-        if let q = query {
-            return "\(fixedPath)?\(q)"
-        } else {
-            return fixedPath
-        }
-    }
-}
-
 /// Represents an image data provider for loading image from a given Base64 encoded string.
 public struct Base64ImageDataProvider: ImageDataProvider {
 

--- a/Tests/KingfisherTests/ImageDataProviderTests.swift
+++ b/Tests/KingfisherTests/ImageDataProviderTests.swift
@@ -37,6 +37,8 @@ class ImageDataProviderTests: XCTestCase {
         
         let provider = LocalFileImageDataProvider(fileURL: fileURL)
         XCTAssertEqual(provider.cacheKey, fileURL.localFileCacheKey)
+        XCTAssertEqual(fileURL.cacheKey, fileURL.localFileCacheKey)
+        
         XCTAssertEqual(provider.fileURL, fileURL)
         
         let exp = expectation(description: #function)


### PR DESCRIPTION
This allows users get the correct default cache key even for file URL.

This fixes https://github.com/onevcat/Kingfisher/issues/1825#issuecomment-1052589055