### PR TITLE
Error image with custom Placeholder fix

### DIFF
--- a/Sources/Extensions/ImageView+Kingfisher.swift
+++ b/Sources/Extensions/ImageView+Kingfisher.swift
@@ -362,6 +362,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
                         if let image = options.onFailureImage {
                             self.base.image = image
                         }
+                        mutatingSelf.placeholder = nil
                         completionHandler?(result)
                     }
                 }

--- a/Sources/Extensions/ImageView+Kingfisher.swift
+++ b/Sources/Extensions/ImageView+Kingfisher.swift
@@ -359,10 +359,10 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
                         }
 
                     case .failure:
+                        mutatingSelf.placeholder = nil
                         if let image = options.onFailureImage {
                             self.base.image = image
                         }
-                        mutatingSelf.placeholder = nil
                         completionHandler?(result)
                     }
                 }

--- a/Sources/Extensions/ImageView+Kingfisher.swift
+++ b/Sources/Extensions/ImageView+Kingfisher.swift
@@ -359,8 +359,8 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
                         }
 
                     case .failure:
-                        mutatingSelf.placeholder = nil
                         if let image = options.onFailureImage {
+                            mutatingSelf.placeholder = nil
                             self.base.image = image
                         }
                         completionHandler?(result)

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -54,6 +54,10 @@ extension KFImage {
             guard let source = context.source else {
                 CallbackQueue.mainCurrentOrAsync.execute {
                     context.onFailureDelegate.call(KingfisherError.imageSettingError(reason: .emptySource))
+                    if let image = context.options.onFailureImage {
+                        self.loadedImage = image
+                    }
+                    self.loaded = true
                 }
                 return
             }

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -57,6 +57,7 @@ extension KFImage {
                     if let image = context.options.onFailureImage {
                         self.loadedImage = image
                     }
+                    self.loading = false
                     self.loaded = true
                 }
                 return

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -38,6 +38,11 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
     
     var body: some View {
         ZStack {
+            context.configurations
+                .reduce(HoldingView.created(from: binder.loadedImage, context: context)) {
+                    current, config in config(current)
+                }
+                .opacity(binder.loaded ? 1.0 : 0.0)
             if binder.loadedImage == nil {
                 Group {
                     if let placeholder = context.placeholder, let view = placeholder(binder.progress) {
@@ -46,6 +51,7 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
                         Color.clear
                     }
                 }
+                .opacity(binder.loaded ? 0.0 : 1.0)
                 .onAppear { [weak binder = self.binder] in
                     guard let binder = binder else {
                         return
@@ -63,11 +69,6 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
                     }
                 }
             }
-            context.configurations
-                .reduce(HoldingView.created(from: binder.loadedImage, context: context)) {
-                    current, config in config(current)
-                }
-                .opacity(binder.loaded ? 1.0 : 0.0)
         }
     }
 }

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -51,7 +51,6 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
                         Color.clear
                     }
                 }
-                .opacity(binder.loaded ? 0.0 : 1.0)
                 .onAppear { [weak binder = self.binder] in
                     guard let binder = binder else {
                         return

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -38,11 +38,6 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
     
     var body: some View {
         ZStack {
-            context.configurations
-                .reduce(HoldingView.created(from: binder.loadedImage, context: context)) {
-                    current, config in config(current)
-                }
-                .opacity(binder.loaded ? 1.0 : 0.0)
             if binder.loadedImage == nil {
                 Group {
                     if let placeholder = context.placeholder, let view = placeholder(binder.progress) {
@@ -68,6 +63,11 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
                     }
                 }
             }
+            context.configurations
+                .reduce(HoldingView.created(from: binder.loadedImage, context: context)) {
+                    current, config in config(current)
+                }
+                .opacity(binder.loaded ? 1.0 : 0.0)
         }
     }
 }

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -569,6 +569,28 @@ class ImageViewExtensionTests: XCTestCase {
 
         waitForExpectations(timeout: 3, handler: nil)
     }
+
+    func testSettingNonWorkingImageWithCustomizePlaceholderAndFailureImage() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+
+        stub(url, errorCode: 404)
+
+        let view = KFCrossPlatformView()
+
+        imageView.kf.setImage(
+            with: url,
+            placeholder: view,
+            options: [.onFailureImage(testImage)])
+        {
+            result in
+            XCTAssertEqual(self.imageView.image, testImage)
+            XCTAssertFalse(self.imageView.subviews.contains(view))
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
     
     func testSettingNonWorkingImageWithFailureImage() {
         let exp = expectation(description: #function)


### PR DESCRIPTION
This fixes an issue where custom Placeholders are never removed when an error occurs even when there is an Error Image that should be shown instead.

Steps to reproduce:
1. Add custom placeholder
2. Add Error Image
3. Load image with an Error
4. Placeholder always shows because it is never removed

*Note*: Unit Test added for UIKit failed without fix and passes with fix