### PR TITLE
Fix a crash on AnimatedImageView

### DIFF
--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -560,7 +560,8 @@ extension AnimatedImageView {
                 return
             }
 
-            animatedFrames[previousFrameIndex] = animatedFrames[previousFrameIndex]?.placeholderFrame
+            let previousFrame = animatedFrames[previousFrameIndex]
+            animatedFrames[previousFrameIndex] = previousFrame?.placeholderFrame
 
             preloadIndexes(start: currentFrameIndex).forEach { index in
                 guard let currentAnimatedFrame = animatedFrames[index] else { return }

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -562,6 +562,14 @@ extension AnimatedImageView {
 
             let previousFrame = animatedFrames[previousFrameIndex]
             animatedFrames[previousFrameIndex] = previousFrame?.placeholderFrame
+            // ensure the image dealloc in main thread
+            defer {
+                if let image = previousFrame?.image {
+                    DispatchQueue.main.async {
+                        _ = image
+                    }
+                }
+            }
 
             preloadIndexes(start: currentFrameIndex).forEach { index in
                 guard let currentAnimatedFrame = animatedFrames[index] else { return }


### PR DESCRIPTION
Fix a crash report in this thread https://github.com/onevcat/Kingfisher/issues/1844
Add a workaround to ensure the image instance dealloc in main thread.
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/801838/174423040-df457ef9-2286-4aa6-b8c2-cc0a96188699.png">