### PR TITLE
[UPDATE] OSX > macOS in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ DerivedData
 Carthage/Build
 Kingfisher.framework.zip
 
-# OSX
+# macOS
 .DS_Store
 .AppleDouble
 .LSOverride


### PR DESCRIPTION
On June 13, 2016, at WWDC16, OS X was renamed macOS.
But here in the gitignore file this hasn't changed.
Plz merge it
