### PR TITLE
Fix AnimatedView Crash

### DIFF
--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -530,19 +530,16 @@ extension AnimatedImageView {
 
         private func loadFrame(at index: Int) -> UIImage? {
             let resize = needsPrescaling && size != .zero
-            let options: [CFString: Any]?
+            var options: [CFString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceShouldCacheImmediately: true
+            ]
             if resize {
-                options = [
-                    kCGImageSourceCreateThumbnailFromImageIfAbsent: true,
-                    kCGImageSourceCreateThumbnailWithTransform: true,
-                    kCGImageSourceShouldCacheImmediately: true,
-                    kCGImageSourceThumbnailMaxPixelSize: max(size.width, size.height)
-                ]
-            } else {
-                options = nil
+                options[kCGImageSourceThumbnailMaxPixelSize] = max(size.width, size.height)
             }
 
-            guard let cgImage = CGImageSourceCreateImageAtIndex(imageSource, index, options as CFDictionary?) else {
+            guard let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, index, options as CFDictionary) else {
                 return nil
             }
 


### PR DESCRIPTION
Fix a crash in this thread [#1844](https://github.com/onevcat/Kingfisher/issues/1844), replace another method create image by index.
<img width="952" alt="image" src="https://user-images.githubusercontent.com/18661488/178184902-d1698840-6ec4-43e1-a629-564ea2f2c6ba.png">
