### PR TITLE
Overlay the placeholder view to allow onAppear executing

### DIFF
--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -46,7 +46,7 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
             if binder.loadedImage == nil {
                 Group {
                     if let placeholder = context.placeholder, let view = placeholder(binder.progress) {
-                        view
+                        Color.clear.overlay(view)
                     } else {
                         Color.clear
                     }


### PR DESCRIPTION
Fix #1972 

If `EmptyView` is used as placeholder, it does not load due to `Group { EmptyView() }` is eliminated and does not trigger `onAppear`.