### PR TITLE
Respect layout behavior when explicit placeholder is given

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SingleViewDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SingleViewDemo.swift
@@ -50,13 +50,15 @@ struct SingleViewDemo : View {
                     print("err: \(e)")
                 }
                 .placeholder { progress in
-                    ProgressView(progress)
+                    ProgressView(progress).frame(width: 100, height: 100)
+                        .border(Color.blue)
                 }
                 .fade(duration: index == 1 ? 0 : 1) // Do not animate for the first image. Otherwise it causes an unwanted animation when the page is shown.
                 .forceTransition(forceTransition)
                 .resizable()
                 .frame(width: 300, height: 300)
                 .cornerRadius(20)
+                .border(Color.red)
                 .shadow(radius: 5)
                 .frame(width: 320, height: 320)
 

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -44,9 +44,9 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
                 }
                 .opacity(binder.loaded ? 1.0 : 0.0)
             if binder.loadedImage == nil {
-                Group {
+                ZStack {
                     if let placeholder = context.placeholder, let view = placeholder(binder.progress) {
-                        Color.clear.overlay(view)
+                        view
                     } else {
                         Color.clear
                     }


### PR DESCRIPTION
And this now should align to `AsyncImage`'s layout behavior:

- When not setting a placeholder, `KFImage` takes all available space while loading.
- When a placeholder is set, `KFImage` takes the same layout of the placeholder.
- After loaded, it respects the image's intrinsic size.  

This should fix #1721 again and keep the `EmptyView` loading behavior as in #1972.