### PR TITLE
A data reader in `RetrieveImageResult`

### DIFF
--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -50,6 +50,15 @@ public struct RetrieveImageResult {
     /// `originalSource` will be kept as the initial `source` which issued the image loading process.
     public let originalSource: Source
     
+    /// Gets the data behind the result.
+    ///
+    /// If this result is from a network downloading (when `cacheType == .none`), calling this returns the downloaded
+    /// data. If the reuslt is from cache, it serializes the image with the given cache serializer in the loading option
+    /// and returns the result.
+    ///
+    /// - Note:
+    /// This can be a time-consuming action, so if you need to use the data for multiple times, it is suggested to hold
+    /// it and prevent keeping calling this too frequently.
     public let data: () -> Data?
 }
 

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -35,7 +35,6 @@ public typealias DownloadProgressBlock = ((_ receivedSize: Int64, _ totalSize: I
 
 /// Represents the result of a Kingfisher retrieving image task.
 public struct RetrieveImageResult {
-
     /// Gets the image object of this result.
     public let image: KFCrossPlatformImage
 
@@ -50,6 +49,8 @@ public struct RetrieveImageResult {
     /// When an alternative source loading happened, the `source` will be the replacing loading target, while the
     /// `originalSource` will be kept as the initial `source` which issued the image loading process.
     public let originalSource: Source
+    
+    public let data: () -> Data?
 }
 
 /// A struct that stores some related information of an `KingfisherError`. It provides some context information for
@@ -419,7 +420,8 @@ public class KingfisherManager {
                 image: options.imageModifier?.modify(value.image) ?? value.image,
                 cacheType: .none,
                 source: source,
-                originalSource: context.originalSource
+                originalSource: context.originalSource,
+                data: {  value.originalData }
             )
             // Add image to cache.
             let targetCache = options.targetCache ?? self.cache
@@ -561,7 +563,8 @@ public class KingfisherManager {
                                         image: image,
                                         cacheType: $0.cacheType,
                                         source: source,
-                                        originalSource: context.originalSource
+                                        originalSource: context.originalSource,
+                                        data: { options.cacheSerializer.data(with: image, original: nil) }
                                     )
                                 }
                             } else {
@@ -624,11 +627,13 @@ public class KingfisherManager {
                             let coordinator = CacheCallbackCoordinator(
                                 shouldWaitForCache: options.waitForCache, shouldCacheOriginal: false)
 
+                            let image = options.imageModifier?.modify(processedImage) ?? processedImage
                             let result = RetrieveImageResult(
-                                image: options.imageModifier?.modify(processedImage) ?? processedImage,
+                                image: image,
                                 cacheType: .none,
                                 source: source,
-                                originalSource: context.originalSource
+                                originalSource: context.originalSource,
+                                data: { options.cacheSerializer.data(with: processedImage, original: nil) }
                             )
 
                             targetCache.store(


### PR DESCRIPTION
As for #1409 it adds a `data` property to get the image data from result easier. 

```swift
imageView.kf.setImage(with: url) { result in
  let data = try? result.get().data()
}
```

However, since the current image cache does not require a data to use, it requires a serialize of image to get the data, which might cause unnecessary performance cost when the images are loaded from cache (when loading from network, the downloaded data is contained in the result so everything is smooth). Changing this behavior would require a change to the public APIs and it has to be postponed to a major version release later.