### PR TITLE
Fix SwiftUI life cycle when in List 

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/MainView.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/MainView.swift
@@ -31,23 +31,32 @@ import Kingfisher
 struct MainView: View {
     var body: some View {
         List {
-            Button(
-                action: {
-                    KingfisherManager.shared.cache.clearMemoryCache()
-                    KingfisherManager.shared.cache.clearDiskCache()
-                },
-                label: {
-                    Text("Clear Cache").foregroundColor(.blue)
-                }
-            )
-            NavigationLink(destination: SingleViewDemo()) { Text("Basic Image") }
-            NavigationLink(destination: SizingAnimationDemo()) { Text("Sizing Toggle") }
-            NavigationLink(destination: ListDemo()) { Text("List") }
-            NavigationLink(destination: LazyVStackDemo()) { Text("Stack") }
-            NavigationLink(destination: GridDemo()) { Text("Grid") }
-            NavigationLink(destination: AnimatedImageDemo()) { Text("Animated Image") }
-            NavigationLink(destination: GeometryReaderDemo()) { Text("Geometry Reader") }
-            NavigationLink(destination: TransitionViewDemo()) { Text("Transition") }
+            Section {
+                Button(
+                    action: {
+                        KingfisherManager.shared.cache.clearMemoryCache()
+                        KingfisherManager.shared.cache.clearDiskCache()
+                    },
+                    label: {
+                        Text("Clear Cache").foregroundColor(.blue)
+                    }
+                )
+            }
+            
+            Section(header: Text("Demo")) {
+                NavigationLink(destination: SingleViewDemo()) { Text("Basic Image") }
+                NavigationLink(destination: SizingAnimationDemo()) { Text("Sizing Toggle") }
+                NavigationLink(destination: ListDemo()) { Text("List") }
+                NavigationLink(destination: LazyVStackDemo()) { Text("Stack") }
+                NavigationLink(destination: GridDemo()) { Text("Grid") }
+                NavigationLink(destination: AnimatedImageDemo()) { Text("Animated Image") }
+                NavigationLink(destination: GeometryReaderDemo()) { Text("Geometry Reader") }
+                NavigationLink(destination: TransitionViewDemo()) { Text("Transition") }
+            }
+            
+            Section(header: Text("Regression Cases")) {
+                NavigationLink(destination: SingleListDemo()) { Text("#1998") }
+            }
         }.navigationBarTitle(Text("SwiftUI Sample"))
     }
 }

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SingleListDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/SingleListDemo.swift
@@ -1,0 +1,50 @@
+//
+//  SingleListDemo.swift
+//  Kingfisher
+//
+//  Created by jp20028 on 2022/09/21.
+//
+//  Copyright (c) 2022 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import SwiftUI
+import Kingfisher
+
+@available(iOS 14.0, *)
+struct SingleListDemo: View {
+    var body: some View {
+        Text("This is a test case for #1988")
+        
+        List {
+            ForEach(1...100, id: \.self) { idx in
+                KFImage(ImageLoader.sampleImageURLs.first)
+                    .resizable()
+                    .frame(width: 48, height: 48)
+            }
+        }
+    }
+}
+
+@available(iOS 14.0, *)
+struct SingleListDemo_Previews: PreviewProvider {
+    static var previews: some View {
+        SingleListDemo()
+    }
+}

--- a/Demo/Kingfisher-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Kingfisher-Demo.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		4B120CA726B91BB70060B092 /* TransitionViewDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B120CA626B91BB70060B092 /* TransitionViewDemo.swift */; };
 		4B1C7A3D21A256E300CE9D31 /* InfinityCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1C7A3C21A256E300CE9D31 /* InfinityCollectionViewController.swift */; };
 		4B4307A51D87E6A700ED2DA9 /* loader.gif in Resources */ = {isa = PBXBuildFile; fileRef = 4B7742461D87E42E0077024E /* loader.gif */; };
+		4B6E1B6D28DB4E8C0023B54B /* SingleListDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6E1B6C28DB4E8C0023B54B /* SingleListDemo.swift */; };
 		4B7742471D87E42E0077024E /* loader.gif in Resources */ = {isa = PBXBuildFile; fileRef = 4B7742461D87E42E0077024E /* loader.gif */; };
 		4B7742481D87E42E0077024E /* loader.gif in Resources */ = {isa = PBXBuildFile; fileRef = 4B7742461D87E42E0077024E /* loader.gif */; };
 		4B779C8526743C2800FF9C1E /* GeometryReaderDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B779C8426743C2800FF9C1E /* GeometryReaderDemo.swift */; };
@@ -162,6 +163,7 @@
 		4B120CA626B91BB70060B092 /* TransitionViewDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransitionViewDemo.swift; sourceTree = "<group>"; };
 		4B1C7A3C21A256E300CE9D31 /* InfinityCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfinityCollectionViewController.swift; sourceTree = "<group>"; };
 		4B2944551C3D03880088C3E7 /* Kingfisher-macOS-Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Kingfisher-macOS-Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4B6E1B6C28DB4E8C0023B54B /* SingleListDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleListDemo.swift; sourceTree = "<group>"; };
 		4B7742461D87E42E0077024E /* loader.gif */ = {isa = PBXFileReference; lastKnownFileType = image.gif; path = loader.gif; sourceTree = "<group>"; };
 		4B779C8426743C2800FF9C1E /* GeometryReaderDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeometryReaderDemo.swift; sourceTree = "<group>"; };
 		4B92FE5525FF906B00473088 /* AutoSizingTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoSizingTableViewController.swift; sourceTree = "<group>"; };
@@ -420,6 +422,7 @@
 			children = (
 				D1F78A622589F17200930759 /* MainView.swift */,
 				D1F78A612589F17200930759 /* ListDemo.swift */,
+				4B6E1B6C28DB4E8C0023B54B /* SingleListDemo.swift */,
 				D198F42125EDC4B900C53E0D /* GridDemo.swift */,
 				4B779C8426743C2800FF9C1E /* GeometryReaderDemo.swift */,
 				D1F78A632589F17200930759 /* SingleViewDemo.swift */,
@@ -684,6 +687,7 @@
 				D12E0C981C47F91800AC98AD /* ImageCollectionViewCell.swift in Sources */,
 				D198F42025EDC34000C53E0D /* SizingAnimationDemo.swift in Sources */,
 				072922432638639D0089E810 /* AnimatedImageDemo.swift in Sources */,
+				4B6E1B6D28DB4E8C0023B54B /* SingleListDemo.swift in Sources */,
 				D1A1CCA721A18A3200263AD8 /* UIViewController+KingfisherOperation.swift in Sources */,
 				4B92FE5625FF906B00473088 /* AutoSizingTableViewController.swift in Sources */,
 				D1F78A642589F17200930759 /* ListDemo.swift in Sources */,

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -69,6 +69,16 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
                 }
             }
         }
+        // Workaround for https://github.com/onevcat/Kingfisher/issues/1988
+        // on iOS 16 there seems to be a bug that when in a List, the `onAppear` of the `ZStack` above in the
+        // `binder.loadedImage == nil` not get called. Adding this empty `onAppear` fixes it and the life cycle can
+        // work again.
+        //
+        // There is another "fix": adding an `else` clause and put a `Color.clear` there. But I believe this `onAppear`
+        // should work better.
+        //
+        // It should be a bug in iOS 16, I guess it is some kinds of over-optimization in list cell loading caused it.
+        .onAppear()
     }
 }
 


### PR DESCRIPTION
This fixes #1988 

The reason is not quite clear yet, but it seems that SwiftUI on iOS 16 is failing to call the `onAppear` when the view is deeply embedded in a list cell. By force adding an empty `onAppear`, it starts to be recognized again.

