### PR TITLE
Add `originalDataUsed` to serializer

### DIFF
--- a/Sources/Cache/CacheSerializer.swift
+++ b/Sources/Cache/CacheSerializer.swift
@@ -53,6 +53,11 @@ public protocol CacheSerializer {
     ///            could be deserialized.
     func image(with data: Data, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage?
     
+    /// Whether this serializer prefers to cache the original data in its implementation.
+    /// If `true`, after creating the image from the disk data, Kingfisher will continue to apply the processor to get
+    /// the final image.
+    ///
+    /// By default, it is `false` and the actual processed image is assumed to be serialized to the disk.
     var originalDataUsed: Bool { get }
 }
 
@@ -76,6 +81,8 @@ public struct DefaultCacheSerializer: CacheSerializer {
     /// In that case, the serialization will fall back to creating data from image.
     public var preferCacheOriginalData: Bool = false
 
+    /// Returnes the `preferCacheOriginalData` value. When the original data is used, Kingfisher needs to re-apply the
+    /// processors to get the desired final image.
     public var originalDataUsed: Bool { preferCacheOriginalData }
     
     /// Creates a cache serializer that serialize and deserialize images in PNG, JPEG and GIF format.

--- a/Sources/Cache/CacheSerializer.swift
+++ b/Sources/Cache/CacheSerializer.swift
@@ -52,6 +52,12 @@ public protocol CacheSerializer {
     /// - Returns: An image deserialized or `nil` when no valid image
     ///            could be deserialized.
     func image(with data: Data, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage?
+    
+    var originalDataUsed: Bool { get }
+}
+
+public extension CacheSerializer {
+    var originalDataUsed: Bool { false }
 }
 
 /// Represents a basic and default `CacheSerializer` used in Kingfisher disk cache system.
@@ -70,6 +76,8 @@ public struct DefaultCacheSerializer: CacheSerializer {
     /// In that case, the serialization will fall back to creating data from image.
     public var preferCacheOriginalData: Bool = false
 
+    public var originalDataUsed: Bool { preferCacheOriginalData }
+    
     /// Creates a cache serializer that serialize and deserialize images in PNG, JPEG and GIF format.
     ///
     /// - Note:

--- a/Tests/KingfisherTests/ImageProcessorTests.swift
+++ b/Tests/KingfisherTests/ImageProcessorTests.swift
@@ -43,7 +43,6 @@ class ImageProcessorTests: XCTestCase {
 
         let resultFromImage = downsamplingProcessor.process(item: .image(testImage), options: emptyOption)
         XCTAssertEqual(resultFromImage!.size, CGSize(width: 40, height: 40))
-
     }
 
     func testProcessorConcating() {


### PR DESCRIPTION
This allows the processor to apply again if the original data is cached & used instead of the processed image data stored on the disk. 

#1912