### PR TITLE
fix local cache miss due to dynamic sandbox path

### DIFF
--- a/Sources/General/ImageSource/Resource.swift
+++ b/Sources/General/ImageSource/Resource.swift
@@ -98,8 +98,10 @@ extension URL {
     //
     // See #1825 (https://github.com/onevcat/Kingfisher/issues/1825)
     var localFileCacheKey: String {
+        // We should trans `URL` to `~` format due to dynamic sandbox path mechanism
+        let tildeURL = URL(fileURLWithPath: (path as NSString).abbreviatingWithTildeInPath)
         var validComponents: [String] = []
-        for part in pathComponents.reversed() {
+        for part in tildeURL.pathComponents.reversed() {
             validComponents.append(part)
             if part.hasSuffix(".app") || part.hasSuffix(".appex") {
                 break


### PR DESCRIPTION
Problem:
With the issue https://github.com/onevcat/Kingfisher/issues/1825 you fixed some issues, but i I found that there is still a problem.

My scenario is to generate thumbnails for local images and display them in the `LazyVGrid`. Every time i start the app, the cache is missed due to dynamic sandbox path  and there are tons of duplicate thumbnails in the sandbox.

Although it can be solved by passing in parameter `cacheKey`, it loses ease of use

My code as follow:
```
#if canImport(Kingfisher)
import Kingfisher

public extension KFImage {
    static func local(image url: URL, thumbnailSize: CGSize) -> KFImage {
        Self.init(source: .provider(LocalFileImageDataProvider(fileURL: url)))
        .resizable()
        .setProcessor(DownsamplingImageProcessor(size: thumbnailSize))
    }
    
    static func local(video url: URL, thumbnailSize: CGSize) -> KFImage {
        Self.init(source: .provider(AVAssetImageDataProvider(assetURL: url, time: .zero)))
        .resizable()
        .setProcessor(DownsamplingImageProcessor(size: thumbnailSize))
    }
}

#endif
```

