### PR TITLE
local cache missed when reinstall and start app during the development phase

### DIFF
--- a/Sources/General/ImageSource/AVAssetImageDataProvider.swift
+++ b/Sources/General/ImageSource/AVAssetImageDataProvider.swift
@@ -53,7 +53,10 @@ public struct AVAssetImageDataProvider: ImageDataProvider {
     public let time: CMTime
 
     private var internalKey: String {
-        return (assetImageGenerator.asset as? AVURLAsset)?.url.absoluteString ?? UUID().uuidString
+        guard let url = (assetImageGenerator.asset as? AVURLAsset)?.url else {
+            return UUID().uuidString
+        }
+        return url.isFileURL ? url.localFileCacheKey : url.absoluteString
     }
 
     /// The cache key used by `self`.

--- a/Sources/General/ImageSource/Resource.swift
+++ b/Sources/General/ImageSource/Resource.swift
@@ -98,14 +98,7 @@ extension URL {
     //
     // See #1825 (https://github.com/onevcat/Kingfisher/issues/1825)
     var localFileCacheKey: String {
-        var validComponents: [String] = []
-        for part in pathComponents.reversed() {
-            validComponents.append(part)
-            if part.hasSuffix(".app") || part.hasSuffix(".appex") {
-                break
-            }
-        }
-        let fixedPath = "\(Self.localFileCacheKeyPrefix)/\(validComponents.reversed().joined(separator: "/"))"
+        let fixedPath = "\(Self.localFileCacheKeyPrefix)/\((path as NSString).abbreviatingWithTildeInPath)"
         if let q = query {
             return "\(fixedPath)?\(q)"
         } else {


### PR DESCRIPTION
Problem:
With the issue https://github.com/onevcat/Kingfisher/issues/1825 you fixed some issues, but i I found that there is still a problem.

The original solution does not cover the situation of reinstall the app during the development phase. Every time i reintall and start the app from Xcode, the cache is missed due to dynamic sandbox path and there are tons of duplicate thumbnails in the sandbox.

The new `cacheKey` may as follow:
`kingfisher.local.cacheKey/~/Documents/dir/file.ext`