### PR TITLE
ImagePrefetcher update: resources mapping out of the main thread

### DIFF
--- a/Sources/Networking/ImagePrefetcher.swift
+++ b/Sources/Networking/ImagePrefetcher.swift
@@ -389,21 +389,18 @@ public class ImagePrefetcher: CustomStringConvertible {
     }
     
     private func reportProgress() {
-
         if progressBlock == nil && progressSourceBlock == nil {
             return
         }
-
         let skipped = self.skippedSources
         let failed = self.failedSources
         let completed = self.completedSources
+        let skippedResources = skipped.compactMap { $0.asResource }
+        let failedResources = failed.compactMap { $0.asResource }
+        let completedResources = completed.compactMap { $0.asResource }
         CallbackQueue.mainCurrentOrAsync.execute {
             self.progressSourceBlock?(skipped, failed, completed)
-            self.progressBlock?(
-                skipped.compactMap { $0.asResource },
-                failed.compactMap { $0.asResource },
-                completed.compactMap { $0.asResource }
-            )
+            self.progressBlock?(skippedResources, failedResources, completedResources)
         }
     }
     


### PR DESCRIPTION
There is an issue with progress block in ImagePrefetcher, in case of a huge amount of resources.
In case of 10k+ sources that are all already in cache, the RAM usage gets very high.
As it does trigger reportProgress() for each out of 10k+ resources, iterate over all of them, and all of that happens in the main thread, so app just crashes after a few seconds.
The easy solution to the crash (and memory usage) is to not iterate on the main thread. 
