### PR TITLE
Fix 'initializer for conditional binding must have Optional type…' error

### DIFF
--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -45,8 +45,8 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
             renderedImage().opacity(binder.loaded ? 1.0 : 0.0)
             if binder.loadedImage == nil {
                 ZStack {
-                    if let placeholder = context.placeholder, let view = placeholder(binder.progress) {
-                        view
+                    if let placeholder = context.placeholder {
+                        placeholder(binder.progress)
                     } else {
                         Color.clear
                     }


### PR DESCRIPTION
When building under the swift-5.8 development snapshot dated 2/9/2023, I get this error:

```
…/SourcePackages/checkouts/Kingfisher/Sources/SwiftUI/KFImageRenderer.swift:48:63: error: initializer for conditional binding must have Optional type, not 'AnyView'
                    if let placeholder = context.placeholder, let view = placeholder(binder.progress) {
                                                              ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR fixes that, seems to work for both Xcode 14.2 (5.7?) and Swift 5.8 toolchains. Should be applied to 7.6 branch as well as master.