### PR TITLE
Fine-tune for the image rendering trigger

### DIFF
--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -37,7 +37,8 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
     let context: KFImage.Context<HoldingView>
     
     var body: some View {
-        if context.startLoadingBeforeViewAppear && !binder.loadingOrSucceeded {
+        if context.startLoadingBeforeViewAppear && !binder.loadingOrSucceeded && !binder.animating {
+            binder.markLoading()
             DispatchQueue.main.async { binder.start(context: context) }
         }
         


### PR DESCRIPTION
Especially when startLoadingBeforeViewAppear is true.

This should improve the general performance a bit and fix #2035