### PR TITLE
fix add explicit type warning

### DIFF
--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -364,12 +364,13 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         }
         
         let maxDimensionInPixels = max(pointSize.width, pointSize.height) * scale
-        let downsampleOptions = [
+        let downsampleOptions: [CFString : Any] = [
             kCGImageSourceCreateThumbnailFromImageAlways: true,
             kCGImageSourceShouldCacheImmediately: true,
             kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxDimensionInPixels] as CFDictionary
-        guard let downsampledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, downsampleOptions) else {
+            kCGImageSourceThumbnailMaxPixelSize: maxDimensionInPixels
+        ]
+        guard let downsampledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, downsampleOptions as CFDictionary) else {
             return nil
         }
         return KingfisherWrapper.image(cgImage: downsampledImage, scale: scale, refImage: nil)


### PR DESCRIPTION
I fixed warning `Heterogeneous collection literal could only be inferred to '[CFString : Any]'; add explicit type annotation if this is intentional`

Issue: #2059 

<img width="826" alt="screenshot" src="https://user-images.githubusercontent.com/47569369/230776099-197021f0-117d-4ca5-b6da-f237fc2a2b2a.png">


