### PR TITLE
fix warning 'UIKit' was not imported

### DIFF
--- a/Sources/Image/ImageProcessor.swift
+++ b/Sources/Image/ImageProcessor.swift
@@ -29,6 +29,8 @@ import CoreGraphics
 
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
+#else
+import UIKit
 #endif
 
 /// Represents an item which could be processed by an `ImageProcessor`.


### PR DESCRIPTION
fix warning `Class property 'black' cannot be used in a default argument value because 'UIKit' was not imported by this file; this is an error in Swift 6`

Issue #2062

<img width="500" alt="screenshot" src="https://user-images.githubusercontent.com/47569369/230885822-8cf02a8e-215e-4749-8585-3ec83fed615c.png">
