### PR TITLE
modified Source.Identifier.current access modifier

### DIFF
--- a/Sources/General/ImageSource/Source.swift
+++ b/Sources/General/ImageSource/Source.swift
@@ -41,7 +41,7 @@ public enum Source {
 
         /// The underlying value type of source identifier.
         public typealias Value = UInt
-        static var current: Value = 0
+        static private(set) var current: Value = 0
         static func next() -> Value {
             current += 1
             return current


### PR DESCRIPTION
Source.Identifier.current is a unique value for data processing in UI Components.
this value can be generated using Source.Identifier.next(),
it can also be modified outside of its scope.

To prevent modification of current properties outside of its scope, it is safer to mark it as private(set).