### PR TITLE
fix: always use specified processors to recreate animated image representation

### DIFF
--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -562,7 +562,7 @@ public class KingfisherManager {
                     if image.kf.imageFrameCount != nil && image.kf.imageFrameCount != 1, let data = image.kf.animatedImageData {
                         // Always recreate animated image representation since it is possible to be loaded in different options.
                         // https://github.com/onevcat/Kingfisher/issues/1923
-                        image = KingfisherWrapper.animatedImage(data: data, options: options.imageCreatingOptions) ?? .init()
+                        image = options.processor.process(item: .data(data), options: options) ?? .init()
                     }
                     if let modifier = options.imageModifier {
                         image = modifier.modify(image)


### PR DESCRIPTION
When loading an animated image from the cache, Kingfisher will recreate it using the cached data. To avoid loading failures due to unsupported format with the default processor, we must ensure that the specified processor is always used.