### PR TITLE
Added a public init to ImageDownloadResult

### DIFF
--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -43,6 +43,17 @@ public struct ImageLoadingResult {
 
     /// The raw data received from downloader.
     public let originalData: Data
+
+    /// Creates an `ImageDownloadResult`
+    ///
+    /// - parameter image: Image of the download result
+    /// - parameter url: URL from where the image was downloaded from
+    /// - parameter originalData: The image's binary data
+    public init(image: KFCrossPlatformImage, url: URL? = nil, originalData: Data) {
+        self.image = image
+        self.url = url
+        self.originalData = originalData
+    }
 }
 
 /// Represents a task of an image downloading process.


### PR DESCRIPTION
In order to be able to implement a customized `ImageDownloader` I need to be able to create an `ImageDownloadResult` outside of the framework itself. Because the struct has no public init defined so far, there is no way for me to create a result in my customization. So I simply added the public init here.

Background:
In my app we use as custom scheme, like `myappasset://` in order to display images that are added as assets to the app's bundle. The view layer just has URLs for all image types, either a bundled one (`myappasset://someiconname`) or a normal remote URL (`https://somewebsite.com/image.png`). My first idea was to add a custom `ImageDataProvider`, but that would have made it necessary to either
- evaluate the URL type (asset or remote) with every `kf.setImage()` call, or
- having to add additional `KingfisherWrapper` extensions for all supported view types that would evaluate the URL type.

Writing a custom `ImageDownloader` like this seemed to be a lot less effort:
```Swift
class MyImageDownloader: ImageDownloader {
    override func downloadImage(with url: URL, options: KingfisherParsedOptionsInfo, completionHandler: ((Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil) -> DownloadTask? {
        if url.scheme == "myappasset",
           let imageName = url.host,
           let image = UIImage.iconNamed(imageName) {
            completionHandler?(.success(ImageLoadingResult(image: image, url: url, originalData: Data())))
            return nil
        }
        return super.downloadImage(with: url, options: options, completionHandler: completionHandler)
    }
}
```
In `AppDelegate`:
```Swift
KingfisherManager.shared.downloader = MyImageDownloader(name: "MyDownloader")
```

If there is a more convenient way to achieve what I need, please let me know.