### PR TITLE
Support KingfisherManager retrieve image using concurrency

### DIFF
--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -669,7 +669,20 @@ open class ImageCache {
             }
         }
     }
-    
+
+    #if swift(>=5.5)
+    #if canImport(_Concurrency)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    open func clearDiskCache() async {
+        await withCheckedContinuation { continuation in
+            clearDiskCache {
+                continuation.resume()
+            }
+        }
+    }
+    #endif
+    #endif
+
     /// Clears the expired images from memory & disk storage. This is an async operation.
     open func cleanExpiredCache(completion handler: (() -> Void)? = nil) {
         cleanExpiredMemoryCache()

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -169,6 +169,34 @@ public class KingfisherManager {
         )
     }
 
+    #if swift(>=5.5)
+    #if canImport(_Concurrency)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    public func retrieveImage(
+        with resource: Resource,
+        options: KingfisherOptionsInfo? = nil,
+        progressBlock: DownloadProgressBlock? = nil,
+        downloadTaskUpdated: DownloadTaskUpdatedBlock? = nil) async throws -> RetrieveImageResult
+    {
+        var task: DownloadTask?
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                task = retrieveImage(
+                    with: resource.convertToSource(),
+                    options: options,
+                    progressBlock: progressBlock,
+                    downloadTaskUpdated: downloadTaskUpdated
+                ) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        } onCancel: { [task] in
+            task?.cancel()
+        }
+    }
+    #endif
+    #endif
+
     /// Gets an image from a given resource.
     ///
     /// - Parameters:
@@ -208,6 +236,35 @@ public class KingfisherManager {
             downloadTaskUpdated: downloadTaskUpdated,
             completionHandler: completionHandler)
     }
+
+    #if swift(>=5.5)
+    #if canImport(_Concurrency)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    @discardableResult
+    public func retrieveImage(
+        with source: Source,
+        options: KingfisherOptionsInfo? = nil,
+        progressBlock: DownloadProgressBlock? = nil,
+        downloadTaskUpdated: DownloadTaskUpdatedBlock? = nil) async throws -> RetrieveImageResult
+    {
+        var task: DownloadTask?
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                task = retrieveImage(
+                    with: source,
+                    options: options,
+                    progressBlock: progressBlock,
+                    downloadTaskUpdated: downloadTaskUpdated
+                ) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        } onCancel: { [task] in
+            task?.cancel()
+        }
+    }
+    #endif
+    #endif
 
     func retrieveImage(
         with source: Source,

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -89,6 +89,38 @@ class KingfisherManagerTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
     
+    #if swift(>=5.5)
+    #if canImport(_Concurrency)
+    @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+    func testRetrieveImageAsync() async throws {
+        let url = testURLs[0]
+        stub(url, data: testImageData)
+
+        let manager = self.manager!
+
+        let noneResult = try await manager.retrieveImage(with: url)
+        XCTAssertNotNil(noneResult.image)
+        XCTAssertEqual(noneResult.cacheType, .none)
+
+        let memoryResult = try await manager.retrieveImage(with: url)
+        XCTAssertNotNil(memoryResult.image)
+        XCTAssertEqual(memoryResult.cacheType, .memory)
+
+        manager.cache.clearMemoryCache()
+
+        let diskResult = try await manager.retrieveImage(with: url)
+        XCTAssertNotNil(diskResult.image)
+        XCTAssertEqual(diskResult.cacheType, .disk)
+
+        manager.cache.clearMemoryCache()
+        await manager.cache.clearDiskCache()
+        let noneResult2 = try await manager.retrieveImage(with: url)
+        XCTAssertNotNil(noneResult2.image)
+        XCTAssertEqual(noneResult2.cacheType, .none)
+    }
+    #endif
+    #endif
+
     func testRetrieveImageWithProcessor() {
         let exp = expectation(description: #function)
         let url = testURLs[0]


### PR DESCRIPTION
Hi. Thank you for Kingfisher.

This PR provides Concurrency support for KingfisherManager completionHandler API: `retrieveImage(with:options:progressBlock:downloadTaskUpdated:)`

I confirmed the same behavior with Async by referring to existing tests.
