### PR TITLE
Includes iOS-specific code paths on visionOS

### DIFF
--- a/Sources/General/ImageSource/AVAssetImageDataProvider.swift
+++ b/Sources/General/ImageSource/AVAssetImageDataProvider.swift
@@ -127,7 +127,7 @@ extension CGImage {
         guard let mutableData = CFDataCreateMutable(nil, 0) else {
             return nil
         }
-#if os(xrOS)
+#if os(visionOS)
         guard let destination = CGImageDestinationCreateWithData(
             mutableData, UTType.jpeg.identifier as CFString , 1, nil
         ) else {

--- a/Sources/General/KF.swift
+++ b/Sources/General/KF.swift
@@ -313,7 +313,7 @@ extension KF.Builder {
 
 #if !os(watchOS)
 extension KF.Builder {
-    #if os(iOS) || os(tvOS)
+    #if os(iOS) || os(tvOS) || os(visionOS)
 
     /// Sets a placeholder which is used while retrieving the image.
     /// - Parameter placeholder: A placeholder to show while retrieving the image from its source.
@@ -336,7 +336,7 @@ extension KF.Builder {
 
 extension KF.Builder {
 
-    #if os(iOS) || os(tvOS)
+    #if os(iOS) || os(tvOS) || os(visionOS)
     /// Sets the transition for the image task.
     /// - Parameter transition: The desired transition effect when setting the image to image view.
     /// - Returns: A `KF.Builder` with changes applied.

--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -278,7 +278,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     /// - Returns: An `Image` object represents the animated image. It is in form of an array of image frames with a
     ///            certain duration. `nil` if anything wrong when creating animated image.
     public static func animatedImage(data: Data, options: ImageCreatingOptions) -> KFCrossPlatformImage? {
-        #if os(xrOS)
+        #if os(visionOS)
         let info: [String: Any] = [
             kCGImageSourceShouldCache as String: true,
             kCGImageSourceTypeIdentifierHint as String: UTType.gif.identifier

--- a/Sources/Image/ImageDrawing.swift
+++ b/Sources/Image/ImageDrawing.swift
@@ -201,7 +201,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     }
     #endif
     
-    #if os(iOS) || os(tvOS)
+    #if os(iOS) || os(tvOS) || os(visionOS)
     func resize(to size: CGSize, for contentMode: UIView.ContentMode) -> KFCrossPlatformImage {
         switch contentMode {
         case .scaleAspectFit:
@@ -513,7 +513,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     ///         For any non-CG-based image or animated image, `base` itself is returned.
     public func decoded(scale: CGFloat) -> KFCrossPlatformImage {
         // Prevent animated image (GIF) losing it's images
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         if frameSource != nil { return base }
         #else
         if images != nil { return base }
@@ -542,7 +542,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     ///         For any non-CG-based image or animated image, `base` itself is returned.
     public func decoded(on context: CGContext) -> KFCrossPlatformImage {
         // Prevent animated image (GIF) losing it's images
-        #if os(iOS)
+        #if os(iOS) || os(visionOS)
         if frameSource != nil { return base }
         #else
         if images != nil { return base }

--- a/Sources/Image/ImageTransition.swift
+++ b/Sources/Image/ImageTransition.swift
@@ -25,7 +25,7 @@
 //  THE SOFTWARE.
 
 import Foundation
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
 
 /// Transition effect which will be used when an image downloaded and set by `UIImageView`

--- a/Sources/Networking/ImageModifier.swift
+++ b/Sources/Networking/ImageModifier.swift
@@ -63,7 +63,7 @@ public struct AnyImageModifier: ImageModifier {
     }
 }
 
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import UIKit
 
 /// Modifier for setting the rendering mode of images.

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -265,7 +265,7 @@ open class AnimatedImageView: UIImageView {
     private func reset() {
         animator = nil
         if let image = image, let frameSource = image.kf.frameSource {
-            #if os(xrOS)
+            #if os(visionOS)
             let targetSize = bounds.scaled(UITraitCollection.current.displayScale).size
             #else
             let targetSize = bounds.scaled(UIScreen.main.scale).size

--- a/Sources/Views/Indicator.swift
+++ b/Sources/Views/Indicator.swift
@@ -148,7 +148,7 @@ final class ActivityIndicator: Indicator {
             } else {
                 indicatorStyle = UIActivityIndicatorView.Style.white
             }
-            #elseif os(xrOS)
+            #elseif os(visionOS)
             indicatorStyle = UIActivityIndicatorView.Style.medium
             #else
             if #available(iOS 13.0, * ) {

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -384,7 +384,7 @@ class ImageCacheTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     func testModifierShouldOnlyApplyForFinalResultWhenMemoryLoad() {
         let exp = expectation(description: #function)
         let key = testKeys[0]

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -508,7 +508,7 @@ class ImageDownloaderTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
     
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     func testModifierShouldOnlyApplyForFinalResultWhenDownload() {
         let exp = expectation(description: #function)
 

--- a/Tests/KingfisherTests/ImageExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageExtensionTests.swift
@@ -58,7 +58,7 @@ class ImageExtensionTests: XCTestCase {
         let options = ImageCreatingOptions()
         let image = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageGIFData, options: options)
         XCTAssertNotNil(image)
-        #if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         XCTAssertEqual(image!.kf.imageFrameCount!, 8)
         #else
         XCTAssertEqual(image!.kf.images!.count, 8)
@@ -66,7 +66,7 @@ class ImageExtensionTests: XCTestCase {
         #endif
     }
 
-    #if os(iOS) || os(tvOS)
+    #if os(iOS) || os(tvOS) || os(visionOS)
     func testScaleForGIFImage() {
         let options = ImageCreatingOptions(scale: 2.0, duration: 0.0, preloadAll: false, onlyFirstFrame: false)
         let image = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageGIFData, options: options)
@@ -94,7 +94,7 @@ class ImageExtensionTests: XCTestCase {
         let options = ImageCreatingOptions()
         let image = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageSingleFrameGIFData, options: options)
         XCTAssertNotNil(image)
-        #if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         XCTAssertEqual(image!.kf.imageFrameCount!, 1)
         #else
         XCTAssertEqual(image!.kf.images!.count, 1)
@@ -113,7 +113,7 @@ class ImageExtensionTests: XCTestCase {
         let preloadOptions = ImageCreatingOptions(preloadAll: true)
         let image = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageSingleFrameGIFData, options: preloadOptions)!
         XCTAssertNotNil(image, "The image should be initiated.")
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
         XCTAssertNil(image.kf.imageSource, "Image source should be nil")
 #endif
         XCTAssertEqual(image.kf.duration, image.kf.duration)
@@ -247,7 +247,7 @@ class ImageExtensionTests: XCTestCase {
     }
     
     func testDecodeScale() {
-        #if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         let image = testImage
         XCTAssertEqual(image.size, CGSize(width: 64, height: 64))
         XCTAssertEqual(image.scale, 1.0)
@@ -278,7 +278,7 @@ class ImageExtensionTests: XCTestCase {
         XCTAssertNotNil(gifImage)
         XCTAssertEqual(gifImage!.kf.normalized, gifImage!)
         
-        #if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         // No need to normalize up orientation image.
         let normalImage = testImage
         XCTAssertEqual(normalImage.imageOrientation, .up)

--- a/Tests/KingfisherTests/ImageModifierTests.swift
+++ b/Tests/KingfisherTests/ImageModifierTests.swift
@@ -48,7 +48,7 @@ class ImageModifierTests: XCTestCase {
         XCTAssert(modifiedImage == image)
     }
 
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 
     func testRenderingModeImageModifier() {
         let m1 = RenderingModeImageModifier(renderingMode: .alwaysOriginal)

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -656,7 +656,7 @@ class KingfisherManagerTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     func testShouldApplyImageModifierWhenDownload() {
         let exp = expectation(description: #function)
         let url = testURLs[0]

--- a/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
+++ b/Tests/KingfisherTests/KingfisherOptionsInfoTests.swift
@@ -35,7 +35,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertTrue(options.targetCache === nil)
         XCTAssertTrue(options.downloader === nil)
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
         switch options.transition {
         case .none: break
         default: XCTFail("The transition for empty option should be .None. But \(options.transition)")
@@ -99,7 +99,7 @@ class KingfisherOptionsInfoTests: XCTestCase {
         XCTAssertTrue(options.originalCache === cache)
         XCTAssertTrue(options.downloader === downloader)
 
-        #if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
         let transition = ImageTransition.fade(0.5)
         options.transition = transition
         switch options.transition {

--- a/Tests/KingfisherTests/KingfisherTestHelper.swift
+++ b/Tests/KingfisherTests/KingfisherTestHelper.swift
@@ -196,7 +196,7 @@ extension KFCrossPlatformImage {
     }
 }
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
 extension KFCrossPlatformImage {
     static func from(color: KFCrossPlatformColor, size: CGSize) -> KFCrossPlatformImage {


### PR DESCRIPTION
This PR fixes an issue where Kingfisher no longer compiles with Xcode 15 beta 6.

Up until Xcode beta 5, any changes wrapped in `#if os(iOS) ... #endif` would be included on visionOS, however, that is no longer the case in beta 6. Therefore we need to ensure that any existing iOS-specific code paths are included on visionOS.