### PR TITLE
Use `UIApplication` instead of `UIScreen.main` on iOS 13.0 and later

### DIFF
--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -268,7 +268,15 @@ open class AnimatedImageView: UIImageView {
             #if os(visionOS)
             let targetSize = bounds.scaled(UITraitCollection.current.displayScale).size
             #else
-            let targetSize = bounds.scaled(UIScreen.main.scale).size
+            var scale: CGFloat = 0
+            
+            if #available(iOS 13.0, *) {
+                let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+                scale = windowScene?.screen.scale ?? .zero
+            } else {
+                scale = UIScreen.main.scale
+            }
+            let targetSize = bounds.scaled(scale).size
             #endif
             let animator = Animator(
                 frameSource: frameSource,

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -272,7 +272,7 @@ open class AnimatedImageView: UIImageView {
             
             if #available(iOS 13.0, *) {
                 let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-                scale = windowScene?.screen.scale ?? .zero
+                scale = windowScene?.screen.scale ?? 1.0
             } else {
                 scale = UIScreen.main.scale
             }


### PR DESCRIPTION
`UIScree.main` will be deprecated in a future version of iOS.
I used `UIAplication` to get display's scale.

developer doc > [mian](https://developer.apple.com/documentation/uikit/uiscreen/1617815-main) already deprecated. It causes serious errors in the near future.

So have to change another way. And `UIApplication` is the one way of getting display's scale. That is available from `iOS 13.0`. This is why control flow has `iOS 13.0` condition.
