### PR TITLE
Actually add the privacy manifest to app resource bundle

### DIFF
--- a/Kingfisher.podspec
+++ b/Kingfisher.podspec
@@ -36,6 +36,7 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/onevcat/Kingfisher.git", :tag => s.version }
   s.source_files  = ["Sources/**/*.swift"]
+  s.resource_bundles = {"Kingfisher" => ["Sources/PrivacyInfo.xcprivacy"]}
 
   s.requires_arc = true
   s.frameworks = "CFNetwork", "Accelerate"

--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		D1BA781D2174D07800C69D7B /* CallbackQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BA781C2174D07800C69D7B /* CallbackQueue.swift */; };
 		D1BFED95222ACC6B009330C8 /* ImageProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BFED94222ACC6B009330C8 /* ImageProcessorTests.swift */; };
 		D1D2C32A1C70A3230018F2F9 /* single-frame.gif in Resources */ = {isa = PBXBuildFile; fileRef = D1D2C3291C70A3230018F2F9 /* single-frame.gif */; };
+		D1D550D52AEB9E8700AAD79D /* PrivacyInfo.xcprivacy in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1C04A3E2A45D20500B3775F /* PrivacyInfo.xcprivacy */; };
 		D1DC4B411D60996D00DFDFAA /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1DC4B401D60996D00DFDFAA /* StringExtensionTests.swift */; };
 		D1E564412199C21E0057AAE3 /* StorageExpirationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E564402199C21E0057AAE3 /* StorageExpirationTests.swift */; };
 		D1E56445219B16330057AAE3 /* ImageDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E56444219B16330057AAE3 /* ImageDataProvider.swift */; };
@@ -130,6 +131,19 @@
 			remoteInfo = Kingfisher;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		D1D550D42AEB9E7300AAD79D /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 7;
+			files = (
+				D1D550D52AEB9E8700AAD79D /* PrivacyInfo.xcprivacy in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		07292244263B02F00089E810 /* KFAnimatedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KFAnimatedImage.swift; sourceTree = "<group>"; };
@@ -703,6 +717,7 @@
 			buildConfigurationList = D1ED2D4E1AD2D09F00CFC3EB /* Build configuration list for PBXNativeTarget "Kingfisher" */;
 			buildPhases = (
 				D1ED2D301AD2D09F00CFC3EB /* Sources */,
+				D1D550D42AEB9E7300AAD79D /* CopyFiles */,
 				D1ED2D311AD2D09F00CFC3EB /* Frameworks */,
 				D1ED2D321AD2D09F00CFC3EB /* Headers */,
 			);

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -16,7 +16,8 @@ let package = Package(
     targets: [
         .target(
             name: "Kingfisher",
-            path: "Sources"
+            path: "Sources",
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         )
     ]
 )


### PR DESCRIPTION
This allows Xcode to generate read and generate the report based on Kingfisher's privacy manifest

> Although for now, it only reads the "collecting data" section and Kingfisher does not has one, so there should be no actual affect to the app project. But I can verify the relate file are already under the correct place and be checked by Xcode 15. So in future, if Xcode decides to also generate the report for `NSPrivacyAccessedAPITypes` one day, there should be no additional work required in Kingfisher side.

Ref: #2122 #2155