### PR TITLE
Use the correct cacheKey of local files for `AVAssetImageDataProvider`

### DIFF
--- a/Sources/General/ImageSource/AVAssetImageDataProvider.swift
+++ b/Sources/General/ImageSource/AVAssetImageDataProvider.swift
@@ -53,7 +53,10 @@ public struct AVAssetImageDataProvider: ImageDataProvider {
     public let time: CMTime
 
     private var internalKey: String {
-        return (assetImageGenerator.asset as? AVURLAsset)?.url.absoluteString ?? UUID().uuidString
+        guard let url = (assetImageGenerator.asset as? AVURLAsset)?.url else {
+            return UUID().uuidString
+        }
+        return url.cacheKey
     }
 
     /// The cache key used by `self`.

--- a/Tests/KingfisherTests/ImageDataProviderTests.swift
+++ b/Tests/KingfisherTests/ImageDataProviderTests.swift
@@ -93,6 +93,29 @@ class ImageDataProviderTests: XCTestCase {
         XCTAssertTrue(called)
     }
     
+    func testAVAssetImageDataProviderCacheKeyVariesForRemote() {
+        let remoteURL1 = URL(string: "https://example.com/1/hello.mp4")!
+        let remoteURL2 = URL(string: "https://example.com/2/hello.mp4")!
+        
+        let provider1 = AVAssetImageDataProvider(assetURL: remoteURL1, seconds: 10)
+        XCTAssertEqual(provider1.cacheKey, "https://example.com/1/hello.mp4_10.0")
+        
+        let provider2 = AVAssetImageDataProvider(assetURL: remoteURL2, seconds: 10)
+        XCTAssertNotEqual(provider1.cacheKey, provider2.cacheKey)
+    }
+    
+    // AVAssetImageDataProvider fix for appending to #1825
+    func testAVAssetImageDataProviderCacheKeyConsistForDifferentAppSandbox() {
+        let localURL1 = URL(string: "file:///Users/onevcat/Library/Developer/CoreSimulator/Devices/ABC/data/Containers/Bundle/Application/DEF/Kingfisher-Demo.app/video/hello.mp4")!
+        let localURL2 = URL(string: "file:///Users/onevcat/Library/Developer/CoreSimulator/Devices/ABC/data/Containers/Bundle/Application/XYZ/Kingfisher-Demo.app/video/hello.mp4")!
+        
+        let provider1 = AVAssetImageDataProvider(assetURL: localURL1, seconds: 10)
+        XCTAssertEqual(provider1.cacheKey, "\(URL.localFileCacheKeyPrefix)/Kingfisher-Demo.app/video/hello.mp4_10.0")
+    
+        let provider2 = AVAssetImageDataProvider(assetURL: localURL2, seconds: 10)
+        XCTAssertEqual(provider1.cacheKey, provider2.cacheKey)
+    }
+    
     #if swift(>=5.5)
     #if canImport(_Concurrency)
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)


### PR DESCRIPTION
In #1825, we fixed an issue that the cache does not work for local files when debugging: the reason was Xcode is trying to copy the app to a new sandbox location when debugging. So the resources inside the app bundle has a different local file URL.

In that issue, we fixed the cases for local images, but not yet for the `AVAssetImageDataProvider`, which still used the plain `absoluteString` as the cache key. Here we switched to use the `url.cacheKey`, which also considering the sandbox changing into account.

This should fix #2002 