### PR TITLE
Do not trigger view refresh if loading failure

### DIFF
--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -122,7 +122,7 @@ extension KFImage {
                                 if let image = context.options.onFailureImage {
                                     self.loadedImage = image
                                 }
-                                self.markLoaded(sendChangeEvent: true)
+                                self.markLoaded(sendChangeEvent: false)
                             }
                             
                             CallbackQueue.mainAsync.execute {


### PR DESCRIPTION
This can be considered an edge case and fixes #2167 

If the failure image exists, it will be set with `loadedImage` and not trigger the binder loading again. So there should be no need to send the change event in the general failure case (since there is nothing to update). This avoid unnecessary rendering and a case when `startLoadingBeforeViewAppear` is set (and loading errored).