### PR TITLE
Fix a critical performance issue in GIF playback

### DIFF
--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -623,10 +623,10 @@ extension AnimatedImageView {
                 return
             }
 
-            let previousFrame = animatedFrames[previousFrameIndex]
-            animatedFrames[previousFrameIndex] = previousFrame?.placeholderFrame
-            // ensure the image dealloc in main thread
-            defer {
+            if isReachMaxRepeatCount {
+                let previousFrame = animatedFrames[previousFrameIndex]
+                animatedFrames[previousFrameIndex] = previousFrame?.placeholderFrame
+                // ensure the image dealloc in main thread
                 if let image = previousFrame?.image {
                     DispatchQueue.main.async {
                         _ = image


### PR DESCRIPTION
## Problem
https://github.com/onevcat/Kingfisher/blob/277f1ab2c6664b19b4a412e32b094b201e2d5757/Sources/Views/AnimatedImageView.swift#L627

This line of code results in a major inefficiency where the image of previous frame was released. This behavior was particularly problematic for looping GIF animations. Each loop involved repeatedly extracting the image of each frame, leading to substantial CPU resource consumption.

## Solution
The proposed update introduces the `isReachMaxRepeatCount` condition in the `updatePreloadedFrames()` method. This condition ensures that the Image of the previous Frame is only released when the animation reaches its maximum repeat count. This approach prevents the unnecessary extraction of Images in each loop for infinite animations, significantly reducing CPU usage and optimizing playback performance.

## Impact
* Reduced CPU Usage

### Before

<img width="1062" alt="Before" src="https://github.com/onevcat/Kingfisher/assets/7934444/07dce127-9264-4e01-9452-883056fc9060">

### After
<img width="1019" alt="After" src="https://github.com/onevcat/Kingfisher/assets/7934444/2ad9a1a2-5f03-4520-908f-e4a5649d219f">
