### PR TITLE
Keep symlinks while creating xcframework zip

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -127,7 +127,8 @@ platform :ios do
 
     zip(
       path: "build/#{target_version}",
-      output_path: "build/#{target_version}.zip"
+      output_path: "build/#{target_version}.zip",
+      symlinks: true
     )
   end
 


### PR DESCRIPTION
This should fix #2178 