### PR TITLE
fix Any? cast to protocol always nil in ios 13

### DIFF
--- a/Sources/Utility/Runtime.swift
+++ b/Sources/Utility/Runtime.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 func getAssociatedObject<T>(_ object: Any, _ key: UnsafeRawPointer) -> T? {
-    if #available(iOS 14, macOS 11, *) {
+    if #available(iOS 14, macOS 11, watchOS 7, tvOS 14, *) { // swift 5.3 fixed this issue (https://github.com/apple/swift/issues/46456)
         return objc_getAssociatedObject(object, key) as? T
     } else {
         return objc_getAssociatedObject(object, key) as AnyObject as? T

--- a/Sources/Utility/Runtime.swift
+++ b/Sources/Utility/Runtime.swift
@@ -27,7 +27,11 @@
 import Foundation
 
 func getAssociatedObject<T>(_ object: Any, _ key: UnsafeRawPointer) -> T? {
-    return objc_getAssociatedObject(object, key) as? T
+    if #available(iOS 14, macOS 11, *) {
+        return objc_getAssociatedObject(object, key) as? T
+    } else {
+        return objc_getAssociatedObject(object, key) as AnyObject as? T
+    }
 }
 
 func setRetainedAssociatedObject<T>(_ object: Any, _ key: UnsafeRawPointer, _ value: T) {


### PR DESCRIPTION
It is a swift bug, In iOS 13 or earlier versions. 
cast an Any? to protocol will always get nil
[https://stackoverflow.com/questions/42033735/failing-cast-in-swift-from-any-to-protocol](url)

In my case i use backgroundDecode option when download image, and if the image is a GIF the animate will lost, because the `decode` func not return itself
```
public func decoded(scale: CGFloat) -> KFCrossPlatformImage {
        // Prevent animated image (GIF) losing it's images
        #if os(iOS)
        if frameSource != nil { return base }
        #else
        if images != nil { return base }
        #endif
       ....... ........
    }
```
The `frameSource` always get nil, because the `T` in  `getAssociatedObject` func is `ImageFrameSource` it is a protocol, so always return nil
```
func getAssociatedObject<T>(_ object: Any, _ key: UnsafeRawPointer) -> T? {
    return objc_getAssociatedObject(object, key) as? T // T is ImageFrameSource when get frameSource
}
```
The fix is first casting to AnyObject and then casting to the protocol
This swift bug was fixed in ios14 and macos 11 runtime