### PR TITLE
Comment Modification - Adding Space

### DIFF
--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -178,7 +178,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         #endif
         }
 
-        //Flip image one more time if needed to, this is to prevent flipped image
+        // Flip image one more time if needed to, this is to prevent flipped image
         switch orientation {
         case .upMirrored, .downMirrored:
             transform = transform.translatedBy(x: size.width, y: 0)


### PR DESCRIPTION
- Added space in the comment: "//Flip image one more time if needed to, this is to prevent flipped image"
- Added a space between "//" and the text in the comment to maintain consistency with the existing comment style.

This change aims to improve code readability and maintain consistency.
I hope this helps. Please review when you get a chance.