### PR TITLE
Use the unretained version of CGImage to avoid racing

### DIFF
--- a/Sources/Image/ImageDrawing.swift
+++ b/Sources/Image/ImageDrawing.swift
@@ -567,6 +567,25 @@ extension CGImage {
         }
         return decodedImageRef
     }
+    
+    static func create(ref: CGImage) -> CGImage? {
+        guard let space = ref.colorSpace, let provider = ref.dataProvider else {
+            return nil
+        }
+        return CGImage(
+            width: ref.width,
+            height: ref.height,
+            bitsPerComponent: ref.bitsPerComponent,
+            bitsPerPixel: ref.bitsPerPixel,
+            bytesPerRow: ref.bytesPerRow,
+            space: space,
+            bitmapInfo: ref.bitmapInfo,
+            provider: provider,
+            decode: ref.decode,
+            shouldInterpolate: ref.shouldInterpolate,
+            intent: ref.renderingIntent
+        )
+    }
 }
 
 extension KingfisherWrapper where Base: KFCrossPlatformImage {

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -524,13 +524,10 @@ extension AnimatedImageView {
             self.maxFrameCount = count
             self.maxRepeatCount = repeatCount
             self.preloadQueue = preloadQueue
-            
-            GraphicsContext.begin(size: imageSize, scale: imageScale)
         }
         
         deinit {
             resetAnimatedFrames()
-            GraphicsContext.end()
         }
 
         /// Gets the image frame of a given index.
@@ -598,13 +595,11 @@ extension AnimatedImageView {
                 // To get a workaround, create another image ref and use that to create the final image. This leads to
                 // some performance loss, but there is little we can do.
                 // https://github.com/onevcat/Kingfisher/issues/1844
-                guard let context = GraphicsContext.current(size: imageSize, scale: imageScale, inverting: true, cgImage: cgImage),
-                      let decodedImageRef = cgImage.decoded(on: context, scale: imageScale)
-                else {
+                guard let unretainedImage = CGImage.create(ref: cgImage) else {
                     return KFCrossPlatformImage(cgImage: cgImage)
                 }
                 
-                return KFCrossPlatformImage(cgImage: decodedImageRef)
+                return KFCrossPlatformImage(cgImage: unretainedImage)
             } else {
                 let image = KFCrossPlatformImage(cgImage: cgImage)
                 if backgroundDecode {
@@ -730,3 +725,5 @@ class SafeArray<Element> {
 }
 #endif
 #endif
+
+

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -595,6 +595,7 @@ extension AnimatedImageView {
                 // To get a workaround, create another image ref and use that to create the final image. This leads to
                 // some performance loss, but there is little we can do.
                 // https://github.com/onevcat/Kingfisher/issues/1844
+                // https://github.com/onevcat/Kingfisher/pulls/2194
                 guard let unretainedImage = CGImage.create(ref: cgImage) else {
                     return KFCrossPlatformImage(cgImage: cgImage)
                 }


### PR DESCRIPTION
Additional fix for #1844, where the context actually could not be retrieved.