### PR TITLE
make removeSizeExceededValues public in disc storage

### DIFF
--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -395,7 +395,7 @@ public enum DiskStorage {
         /// - Returns: The URLs for removed files.
         ///
         /// - Note: This method checks `config.sizeLimit` and remove cached files in an LRU (Least Recently Used) way.
-        func removeSizeExceededValues() throws -> [URL] {
+        public func removeSizeExceededValues() throws -> [URL] {
 
             if config.sizeLimit == 0 { return [] } // Back compatible. 0 means no limit.
 


### PR DESCRIPTION
Much of the `DiscStorage.Backend` functionality was made public after this issue was raised https://github.com/onevcat/Kingfisher/issues/1602

`removeSizeExceededValues` is still `internal` and is not directly used anywhere within the class. As such, the sizeLimit set on the on the DiscStorage.Config is not respected.

I've created a fork do this for now - it would be great if this could be added. 