### PR TITLE
Fix testDownsamplingWithEdgeCaseSize fail

### DIFF
--- a/Tests/KingfisherTests/ImageExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageExtensionTests.swift
@@ -331,9 +331,9 @@ class ImageExtensionTests: XCTestCase {
 
     func testDownsamplingWithEdgeCaseSize() {
 
-        // Zero size would fail downsampling.
-        let nilImage = KingfisherWrapper<KFCrossPlatformImage>.downsampledImage(data: testImageData, to: .zero, scale: 1)
-        XCTAssertNil(nilImage)
+        // Zero size would downsampling to 64x64 (previously nil).
+        let image = KingfisherWrapper<KFCrossPlatformImage>.downsampledImage(data: testImageData, to: .zero, scale: 1)
+        XCTAssertEqual(image?.size, CGSize(width: 64, height: 64))
 
         let largerSize = CGSize(width: 100, height: 100)
         let largerImage = KingfisherWrapper<KFCrossPlatformImage>.downsampledImage(data: testImageData, to: largerSize, scale: 1)

--- a/Tests/KingfisherTests/ImageExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageExtensionTests.swift
@@ -330,10 +330,13 @@ class ImageExtensionTests: XCTestCase {
     }
 
     func testDownsamplingWithEdgeCaseSize() {
-
-        // Zero size would downsampling to 64x64 (previously nil).
-        let image = KingfisherWrapper<KFCrossPlatformImage>.downsampledImage(data: testImageData, to: .zero, scale: 1)
-        XCTAssertEqual(image?.size, CGSize(width: 64, height: 64))
+        // Zero size would fail downsampling before iOS 17,4.
+        let result = KingfisherWrapper<KFCrossPlatformImage>.downsampledImage(data: testImageData, to: .zero, scale: 1)
+        if #available(iOS 17.4, macOS 14.4, tvOS 17.4, *) {
+            XCTAssertEqual(result?.size, CGSize(width: 64, height: 64))
+        } else {
+            XCTAssertNil(result)
+        }
 
         let largerSize = CGSize(width: 100, height: 100)
         let largerImage = KingfisherWrapper<KFCrossPlatformImage>.downsampledImage(data: testImageData, to: largerSize, scale: 1)


### PR DESCRIPTION
In Xcode 15.3 and Swift 5.10, below code does not return `nil` if `kCGImageSourceThumbnailMaxPixelSize` is 0. It returns some image size `64*64` . I am not sure why and it does not make any sense. Maybe a bug from Apple?

```
let downsampleOptions: [CFString : Any] = [
            kCGImageSourceCreateThumbnailFromImageAlways: true,
            kCGImageSourceShouldCacheImmediately: true,
            kCGImageSourceCreateThumbnailWithTransform: true,
            kCGImageSourceThumbnailMaxPixelSize: 0 // even we set it to 0
        ]

public func CGImageSourceCreateThumbnailAtIndex(_ isrc: CGImageSource, _ index: Int, _ options: CFDictionary?) -> CGImage?
```

Before fixing:
<img width="1027" alt="Screenshot 2567-04-05 at 21 18 30" src="https://github.com/onevcat/Kingfisher/assets/15520417/bd0782c6-5163-4557-a15b-9d43172cd2b6">

I just fix the test fail by assert with image size 64*64 and it's passed.