### PR TITLE
UsesHashedFileNameWithAutoExtAndProcessor does not retrieve the correct file extension.

### DIFF
--- a/Sources/Utility/String+MD5.swift
+++ b/Sources/Utility/String+MD5.swift
@@ -49,15 +49,16 @@ extension KingfisherWrapper where Base == String {
     }
 
     var ext: String? {
-        var ext = ""
-        if let index = base.lastIndex(of: ".") {
-            let extRange = base.index(index, offsetBy: 1)..<base.endIndex
-            ext = String(base[extRange])
-        }
-        guard let firstSeg = ext.split(separator: "@").first else {
+        guard let firstSeg = base.split(separator: "@").first else {
             return nil
         }
-        return firstSeg.count > 0 ? String(firstSeg) : nil
+        
+        var ext = ""
+        if let index = firstSeg.lastIndex(of: ".") {
+            let extRange = firstSeg.index(index, offsetBy: 1)..<firstSeg.endIndex
+            ext = String(firstSeg[extRange])
+        }
+        return ext.count > 0 ? ext : nil
     }
 }
 

--- a/Tests/KingfisherTests/DiskStorageTests.swift
+++ b/Tests/KingfisherTests/DiskStorageTests.swift
@@ -213,7 +213,7 @@ class DiskStorageTests: XCTestCase {
     
     func testConfigUsesHashedFileNameWithAutoExtAndProcessor() {
         // The key of an image with processor will be as this format.
-        let key = "test.jpeg@abc"
+        let key = "test.jpeg@com.onevcat.Kingfisher.DownsamplingImageProcessor"
         
         // hashed fileName
         storage.config.usesHashedFileName = true


### PR DESCRIPTION
Hello, I found when use `autoExtAfterHashedFileName = true`, the original method `var ext: String?` of finding the last "." to determine the extension is not effective because the field after the "@" symbol may contain a "com.onevcat.Kingfisher.xxx" and even include decimal points.

hope this PR is helpful.