### PR TITLE
Change `swift(>=6)` to use `compiler`

### DIFF
--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -835,7 +835,7 @@ open class ImageCache: @unchecked Sendable {
         cleanExpiredDiskCache {
             Task {
                 guard let bgTask = await taskActor.value, bgTask != .invalid else { return }
-                #if swift(>=6)
+                #if compiler(>=6)
                 sharedApplication.endBackgroundTask(bgTask)
                 #else
                 await sharedApplication.endBackgroundTask(bgTask)

--- a/Sources/General/ImageSource/AVAssetImageDataProvider.swift
+++ b/Sources/General/ImageSource/AVAssetImageDataProvider.swift
@@ -35,7 +35,7 @@ import MobileCoreServices
 import CoreServices
 #endif
 
-#if swift(>=6)
+#if compiler(>=6)
 extension AVAssetImageGenerator: @unchecked @retroactive Sendable { }
 #else
 extension AVAssetImageGenerator: @unchecked Sendable { }

--- a/Sources/General/ImageSource/PHPickerResultImageDataProvider.swift
+++ b/Sources/General/ImageSource/PHPickerResultImageDataProvider.swift
@@ -30,7 +30,7 @@ import Foundation
 
 import PhotosUI
 
-#if swift(>=6)
+#if compiler(>=6)
 @available(iOS 14.0, macOS 13.0, *)
 extension PHPickerResult: @unchecked @retroactive Sendable { }
 #else

--- a/Sources/General/Kingfisher.swift
+++ b/Sources/General/Kingfisher.swift
@@ -36,11 +36,11 @@ public typealias KFCrossPlatformImageView   = NSImageView
 public typealias KFCrossPlatformButton      = NSButton
 
 // `NSImage` is not yet Sendable. We have to assume it sendable to resolve warnings in Kingfisher.
-#if swift(>=6)
+#if compiler(>=6)
 extension KFCrossPlatformImage: @retroactive @unchecked Sendable { }
 #else
 extension KFCrossPlatformImage: @unchecked Sendable { }
-#endif // swift(>=6)
+#endif // compiler(>=6)
 #else // os(macOS)
 import UIKit
 public typealias KFCrossPlatformImage       = UIImage

--- a/Sources/Utility/DisplayLink.swift
+++ b/Sources/Utility/DisplayLink.swift
@@ -52,7 +52,7 @@ extension UIView {
     }
 }
 
-#if swift(>=6)
+#if compiler(>=6)
 extension CADisplayLink: DisplayLinkCompatible, @retroactive @unchecked Sendable {}
 #else
 extension CADisplayLink: DisplayLinkCompatible, @unchecked Sendable {}
@@ -78,13 +78,13 @@ extension NSView {
 extension CADisplayLink: DisplayLinkCompatible {
     var preferredFramesPerSecond: NSInteger { return 0 }
 }
-#if swift(>=6)
+#if compiler(>=6)
 @available(macOS 14.0, *)
 extension CADisplayLink: @retroactive @unchecked Sendable { }
-#else // swift(>=6)
+#else // compiler(>=6)
 @available(macOS 14.0, *)
 extension CADisplayLink: @unchecked Sendable { }
-#endif // swift(>=6)
+#endif // compiler(>=6)
 #endif // swift(>=5.9)
 
 final class DisplayLink: DisplayLinkCompatible, @unchecked Sendable {

--- a/Tests/KingfisherTests/DiskStorageTests.swift
+++ b/Tests/KingfisherTests/DiskStorageTests.swift
@@ -27,7 +27,7 @@
 import XCTest
 @testable import Kingfisher
 
-#if swift(>=6)
+#if compiler(>=6)
 extension String: @retroactive DataTransformable { }
 #else
 extension String: DataTransformable { }

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -922,7 +922,7 @@ class ImageViewExtensionTests: XCTestCase {
 
 }
 
-#if swift(>=6)
+#if compiler(>=6)
 extension KFCrossPlatformView: @retroactive Placeholder {}
 #else
 extension KFCrossPlatformView: Placeholder {}

--- a/Tests/KingfisherTests/MemoryStorageTests.swift
+++ b/Tests/KingfisherTests/MemoryStorageTests.swift
@@ -33,7 +33,7 @@ extension Int {
     }
 }
 
-#if swift(>=6)
+#if compiler(>=6)
 extension Int: @retroactive CacheCostCalculable { }
 #else
 extension Int: CacheCostCalculable { }


### PR DESCRIPTION
`@retroactive` is necessary when compiling with Swift 6, regardless of whether it's on Swift 5 mode.