### PR TITLE
Rewrite the blur rendering method without deprecated UIGraphicsBeginImageContextWithOptions

### DIFF
--- a/Sources/Image/GraphicsContext.swift
+++ b/Sources/Image/GraphicsContext.swift
@@ -35,8 +35,10 @@ enum GraphicsContext {
     static func begin(size: CGSize, scale: CGFloat) {
         #if os(macOS)
         NSGraphicsContext.saveGraphicsState()
-        #else
+        #elseif os(watchOS)
         UIGraphicsBeginImageContextWithOptions(size, false, scale)
+        #else
+        assertionFailure("This method is deprecated on the current platform and should not be used.")
         #endif
     }
     
@@ -65,7 +67,7 @@ enum GraphicsContext {
         
         NSGraphicsContext.current = context
         return context.cgContext
-        #else
+        #elseif os(watchOS)
         guard let context = UIGraphicsGetCurrentContext() else {
             return nil
         }
@@ -74,14 +76,19 @@ enum GraphicsContext {
             context.translateBy(x: 0, y: -size.height)
         }
         return context
+        #else
+        assertionFailure("This method is deprecated on the current platform and should not be used.")
+        return nil
         #endif
     }
     
     static func end() {
         #if os(macOS)
         NSGraphicsContext.restoreGraphicsState()
-        #else
+        #elseif os(watchOS)
         UIGraphicsEndImageContext()
+        #else
+        assertionFailure("This method is deprecated on the current platform and should not be used.")
         #endif
     }
 }

--- a/Sources/Image/GraphicsContext.swift
+++ b/Sources/Image/GraphicsContext.swift
@@ -24,6 +24,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if os(macOS) || os(watchOS)
+
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 #endif
@@ -93,3 +95,4 @@ enum GraphicsContext {
     }
 }
 
+#endif

--- a/Sources/Image/ImageDrawing.swift
+++ b/Sources/Image/ImageDrawing.swift
@@ -344,6 +344,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         var inBuffer = vImage_Buffer(data: inData, height: height, width: width, rowBytes: rowBytes)
 
         let outData = malloc(cgImage.bytesPerRow * cgImage.height)
+        defer { free(outData) }
         var outBuffer = vImage_Buffer(data: outData, height: height, width: width, rowBytes: rowBytes)
         
         for _ in 0 ..< iterations {

--- a/Sources/Image/ImageDrawing.swift
+++ b/Sources/Image/ImageDrawing.swift
@@ -355,13 +355,13 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         }
         guard let outContext = CGContext(
             data: outBuffer.data,
-            width: Int(outBuffer.width),
-            height: Int(outBuffer.height),
-            bitsPerComponent: 8,
-            bytesPerRow: outBuffer.rowBytes,
+            width: cgImage.width,
+            height: cgImage.height,
+            bitsPerComponent: cgImage.bitsPerComponent,
+            bytesPerRow: cgImage.bytesPerRow,
             space: colorSpace,
             bitmapInfo: cgImage.bitmapInfo.rawValue
-        ) else {
+        ) ?? .fallback(data: outBuffer.data, cgImage: cgImage) else {
             assertionFailure("[Kingfisher] Creating CG context failed.")
             return base
         }
@@ -692,4 +692,18 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         }
     }
     #endif
+}
+
+extension CGContext {
+    fileprivate static func fallback(data: UnsafeMutableRawPointer?, cgImage: CGImage) -> CGContext? {
+        return CGContext(
+            data: data,
+            width: cgImage.width,
+            height: cgImage.height,
+            bitsPerComponent: 8,
+            bytesPerRow: 4 * cgImage.width,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+    }
 }

--- a/Sources/Image/ImageDrawing.swift
+++ b/Sources/Image/ImageDrawing.swift
@@ -370,6 +370,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         }
         #endif
         guard let blurredImage = result else {
+            assertionFailure("[Kingfisher] Can not make an blurred image within this context.")
             return base
         }
         return blurredImage


### PR DESCRIPTION
This fixes #2200 with another (identical) implementation for blur image method. Now a pure CG based way is used so it won't use the deprecated `UIGraphicsBeginImageContextWithOptions` and related context methods anymore.