### PR TITLE
Update links for repositories moved to the swiftlang org on GitHub

### DIFF
--- a/Sources/Utility/Runtime.swift
+++ b/Sources/Utility/Runtime.swift
@@ -27,7 +27,7 @@
 import Foundation
 
 func getAssociatedObject<T>(_ object: Any, _ key: UnsafeRawPointer) -> T? {
-    if #available(iOS 14, macOS 11, watchOS 7, tvOS 14, *) { // swift 5.3 fixed this issue (https://github.com/apple/swift/issues/46456)
+    if #available(iOS 14, macOS 11, watchOS 7, tvOS 14, *) { // swift 5.3 fixed this issue (https://github.com/swiftlang/swift/issues/46456)
         return objc_getAssociatedObject(object, key) as? T
     } else {
         return objc_getAssociatedObject(object, key) as AnyObject as? T

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -231,7 +231,7 @@ open class AnimatedImageView: KFCrossPlatformImageView {
     }
 
 // Workaround for Apple xcframework creating issue on Apple TV in Swift 5.8.
-// https://github.com/apple/swift/issues/66015
+// https://github.com/swiftlang/swift/issues/66015
 #if os(tvOS)
     public override init(image: UIImage?, highlightedImage: UIImage?) {
         super.init(image: image, highlightedImage: highlightedImage)
@@ -479,9 +479,9 @@ extension AnimatedImageView {
     // An actor's deinit is nonisolated so we need to cleanup state that needs to exist past this instance's deinit. 
     // Currently there is no way to accomplish this that wouldn't be an error in Swift 6, hopefully that changes at
     // some point. This evolution proposal attempts to address this problem:
-    // https://github.com/apple/swift-evolution/blob/main/proposals/0371-isolated-synchronous-deinit.md
+    // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0371-isolated-synchronous-deinit.md
     // Method influenced from
-    // https://github.com/apple/swift/blob/47803aad3b0d326e5231ad0d7936d40264f56edd/stdlib/public/Concurrency/ExecutorAssertions.swift#L351
+    // https://github.com/swiftlang/swift/blob/47803aad3b0d326e5231ad0d7936d40264f56edd/stdlib/public/Concurrency/ExecutorAssertions.swift#L351
     @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'actor' instead")
     private nonisolated func assumeIsolatedDuringDeinit<T>(_ operation: @MainActor (AnimatedImageView) throws -> T) rethrows -> T {
         typealias Isolated = (AnimatedImageView) throws -> T


### PR DESCRIPTION
### Summary:

Update links for repositories moved to the swiftlang org on GitHub

### Modifications:

Update the link
+ https://github.com/apple/swift/ => https://github.com/swiftlang/swift/
+ https://github.com/apple/swift-evolution/ =>  https://github.com/swiftlang/swift-evolution/

### Result:

Correct the reference
+ https://github.com/apple/swift/ => https://github.com/swiftlang/swift/
+ https://github.com/apple/swift-evolution/  =>  https://github.com/swiftlang/swift-evolution/
