### PR TITLE
Apply existential any to protocol for Swift 6

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/Extensions/UIViewController+KingfisherOperation.swift
+++ b/Demo/Demo/Kingfisher-Demo/Extensions/UIViewController+KingfisherOperation.swift
@@ -55,7 +55,7 @@ protocol KingfisherActionAlertPopup {
     }
 }
 
-@MainActor func reloadAction(_ reloadable: MainDataViewReloadable) -> UIAlertAction {
+@MainActor func reloadAction(_ reloadable: any MainDataViewReloadable) -> UIAlertAction {
     return UIAlertAction(title: "Reload", style: .default) { _ in
         reloadable.reload()
     }
@@ -76,7 +76,7 @@ protocol KingfisherActionAlertPopup {
 extension UIViewController: KingfisherActionAlertPopup {
     @objc func alertPopup(_ sender: Any) -> UIAlertController {
         let alert = createAlert(sender, actions: [cleanCacheAction(), cancelAction])
-        if let r = self as? MainDataViewReloadable {
+        if let r = self as? any MainDataViewReloadable {
             alert.addAction(reloadAction(r))
         }
         return alert

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/ImageDataProviderCollectionViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/ImageDataProviderCollectionViewController.swift
@@ -68,7 +68,7 @@ struct UserNameLetterIconImageProvider: ImageDataProvider {
         color = backgroundColor
     }
     
-    func data(handler: @escaping (Result<Data, Error>) -> Void) {
+    func data(handler: @escaping (Result<Data, any Error>) -> Void) {
         let letter = self.letter as NSString
         let rect = CGRect(x: 0, y: 0, width: 250, height: 250)
         

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/ProcessorCollectionViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/ProcessorCollectionViewController.swift
@@ -37,7 +37,7 @@ class ProcessorCollectionViewController: UICollectionViewController {
         }
     }
     
-    var processors: [(ImageProcessor, String)] = [
+    var processors: [(any ImageProcessor, String)] = [
         (DefaultImageProcessor.default, "Default"),
         (ResizingImageProcessor(referenceSize: CGSize(width: 50, height: 50)), "Resizing"),
         (RoundCornerImageProcessor(radius: .point(20)), "Round Corner"),

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/ProcessorCollectionViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/ProcessorCollectionViewController.swift
@@ -31,7 +31,7 @@ private let reuseIdentifier = "ProcessorCell"
 
 class ProcessorCollectionViewController: UICollectionViewController {
 
-    var currentProcessor: ImageProcessor = DefaultImageProcessor.default {
+    var currentProcessor: any ImageProcessor = DefaultImageProcessor.default {
         didSet {
             collectionView.reloadData()
         }

--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -410,7 +410,7 @@ open class ImageCache: @unchecked Sendable {
         original: Data? = nil,
         forKey key: String,
         processorIdentifier identifier: String = "",
-        cacheSerializer serializer: CacheSerializer = DefaultCacheSerializer.default,
+        cacheSerializer serializer: any CacheSerializer = DefaultCacheSerializer.default,
         toDisk: Bool = true,
         callbackQueue: CallbackQueue = .untouch,
         completionHandler: (@Sendable (CacheStoreResult) -> Void)? = nil
@@ -522,7 +522,7 @@ open class ImageCache: @unchecked Sendable {
                           fromMemory: Bool = true,
                           fromDisk: Bool = true,
                           callbackQueue: CallbackQueue = .untouch,
-                          completionHandler: (@Sendable (Error?) -> Void)? = nil)
+                          completionHandler: (@Sendable ((any Error)?) -> Void)? = nil)
     {
         let computedKey = key.computedKey(with: identifier)
 
@@ -530,7 +530,7 @@ open class ImageCache: @unchecked Sendable {
             memoryStorage.remove(forKey: computedKey)
         }
         
-        @Sendable func callHandler(_ error: Error?) {
+        @Sendable func callHandler(_ error: (any Error)?) {
             if let completionHandler = completionHandler {
                 callbackQueue.execute { completionHandler(error) }
             }
@@ -1004,7 +1004,7 @@ open class ImageCache: @unchecked Sendable {
         original: Data? = nil,
         forKey key: String,
         processorIdentifier identifier: String = "",
-        cacheSerializer serializer: CacheSerializer = DefaultCacheSerializer.default,
+        cacheSerializer serializer: any CacheSerializer = DefaultCacheSerializer.default,
         toDisk: Bool = true
     ) async throws {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/Documentation.docc/Topics/Topic_ImageDataProvider.md
+++ b/Sources/Documentation.docc/Topics/Topic_ImageDataProvider.md
@@ -65,7 +65,7 @@ struct UserNameLetterIconImageProvider: ImageDataProvider {
         self.letter = userNameFirstLetter
     }
     
-    func data(handler: @escaping (Result<Data, Error>) -> Void) {
+    func data(handler: @escaping (Result<Data, any Error>) -> Void) {
         
         // You can ignore these detail below.
         // It generates some data for an image with `letter` being rendered in the center.

--- a/Sources/Extensions/CPListItem+Kingfisher.swift
+++ b/Sources/Extensions/CPListItem+Kingfisher.swift
@@ -88,7 +88,7 @@ extension KingfisherWrapper where Base: CPListItem {
     ///
     @discardableResult
     public func setImage(
-        with resource: Resource?,
+        with resource: (any Resource)?,
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,

--- a/Sources/Extensions/HasImageComponent+Kingfisher.swift
+++ b/Sources/Extensions/HasImageComponent+Kingfisher.swift
@@ -235,7 +235,7 @@ extension KingfisherWrapper where Base: KingfisherImageSettable {
     /// > Both `progressBlock` and `completionHandler` will also be executed in the main thread.
     @discardableResult
     public func setImage(
-        with resource: Resource?,
+        with resource: (any Resource)?,
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
@@ -275,7 +275,7 @@ extension KingfisherWrapper where Base: KingfisherImageSettable {
     /// > Both `progressBlock` and `completionHandler` will also be executed in the main thread.
     @discardableResult
     public func setImage(
-        with resource: Resource?,
+        with resource: (any Resource)?,
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
@@ -307,7 +307,7 @@ extension KingfisherWrapper where Base: KingfisherImageSettable {
     /// > Both `progressBlock` and `completionHandler` will also be executed in the main thread.
     @discardableResult
     public func setImage(
-        with provider: ImageDataProvider?,
+        with provider: (any ImageDataProvider)?,
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
@@ -338,7 +338,7 @@ extension KingfisherWrapper where Base: KingfisherImageSettable {
     /// > Both `progressBlock` and `completionHandler` will also be executed in the main thread.
     @discardableResult
     public func setImage(
-        with provider: ImageDataProvider?,
+        with provider: (any ImageDataProvider)?,
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil

--- a/Sources/Extensions/ImageView+Kingfisher.swift
+++ b/Sources/Extensions/ImageView+Kingfisher.swift
@@ -76,7 +76,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
     @discardableResult
     public func setImage(
         with source: Source?,
-        placeholder: Placeholder? = nil,
+        placeholder: (any Placeholder)? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
@@ -123,7 +123,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
     @discardableResult
     public func setImage(
         with source: Source?,
-        placeholder: Placeholder? = nil,
+        placeholder: (any Placeholder)? = nil,
         options: KingfisherOptionsInfo? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
     ) -> DownloadTask?
@@ -163,8 +163,8 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
     /// > Both `progressBlock` and `completionHandler` will also be executed in the main thread.
     @discardableResult
     public func setImage(
-        with resource: Resource?,
-        placeholder: Placeholder? = nil,
+        with resource: (any Resource)?,
+        placeholder: (any Placeholder)? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
@@ -202,8 +202,8 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
     /// > Both `progressBlock` and `completionHandler` will also be executed in the main thread.
     @discardableResult
     public func setImage(
-        with resource: Resource?,
-        placeholder: Placeholder? = nil,
+        with resource: (any Resource)?,
+        placeholder: (any Placeholder)? = nil,
         options: KingfisherOptionsInfo? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
     ) -> DownloadTask?
@@ -234,8 +234,8 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
     /// > Both `progressBlock` and `completionHandler` will also be executed in the main thread.
     @discardableResult
     public func setImage(
-        with provider: ImageDataProvider?,
-        placeholder: Placeholder? = nil,
+        with provider: (any ImageDataProvider)?,
+        placeholder: (any Placeholder)? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
@@ -264,8 +264,8 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
     /// > Both `progressBlock` and `completionHandler` will also be executed in the main thread.
     @discardableResult
     public func setImage(
-        with provider: ImageDataProvider?,
-        placeholder: Placeholder? = nil,
+        with provider: (any ImageDataProvider)?,
+        placeholder: (any Placeholder)? = nil,
         options: KingfisherOptionsInfo? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
     ) -> DownloadTask?
@@ -281,7 +281,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
 
     func setImage(
         with source: Source?,
-        placeholder: Placeholder? = nil,
+        placeholder: (any Placeholder)? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
@@ -471,9 +471,9 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
     ///
     /// The protocol `Indicator` has a `view` property that will be shown when loading an image.
     /// It will be `nil` if ``KingfisherWrapper/indicatorType`` is ``IndicatorType/none``.
-    public private(set) var indicator: Indicator? {
+    public private(set) var indicator: (any Indicator)? {
         get {
-            let box: Box<Indicator>? = getAssociatedObject(base, &indicatorKey)
+            let box: Box<any Indicator>? = getAssociatedObject(base, &indicatorKey)
             return box?.value
         }
         
@@ -524,7 +524,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
     /// Represents the ``Placeholder`` used for this image view.
     ///
     /// A ``Placeholder`` will be shown in the view while it is downloading an image.
-    public private(set) var placeholder: Placeholder? {
+    public private(set) var placeholder: (any Placeholder)? {
         get { return getAssociatedObject(base, &placeholderKey) }
         set {
             if let previousPlaceholder = placeholder {

--- a/Sources/Extensions/NSButton+Kingfisher.swift
+++ b/Sources/Extensions/NSButton+Kingfisher.swift
@@ -84,7 +84,7 @@ extension KingfisherWrapper where Base: NSButton {
     /// > Both `progressBlock` and `completionHandler` will also be executed in the main thread.
     @discardableResult
     public func setImage(
-        with resource: Resource?,
+        with resource: (any Resource)?,
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
@@ -173,7 +173,7 @@ extension KingfisherWrapper where Base: NSButton {
     /// > Both `progressBlock` and `completionHandler` will also be executed in the main thread.
     @discardableResult
     public func setAlternateImage(
-        with resource: Resource?,
+        with resource: (any Resource)?,
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,

--- a/Sources/Extensions/NSTextAttachment+Kingfisher.swift
+++ b/Sources/Extensions/NSTextAttachment+Kingfisher.swift
@@ -144,7 +144,7 @@ extension KingfisherWrapper where Base: NSTextAttachment {
     /// ```
     @discardableResult
     public func setImage(
-        with resource: Resource?,
+        with resource: (any Resource)?,
         attributedView: @autoclosure @escaping @Sendable () -> KFCrossPlatformView,
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,

--- a/Sources/Extensions/UIButton+Kingfisher.swift
+++ b/Sources/Extensions/UIButton+Kingfisher.swift
@@ -89,7 +89,7 @@ extension KingfisherWrapper where Base: UIButton {
     ///
     @discardableResult
     public func setImage(
-        with resource: Resource?,
+        with resource: (any Resource)?,
         for state: UIControl.State,
         placeholder: UIImage? = nil,
         options: KingfisherOptionsInfo? = nil,
@@ -199,7 +199,7 @@ extension KingfisherWrapper where Base: UIButton {
     ///
     @discardableResult
     public func setBackgroundImage(
-        with resource: Resource?,
+        with resource: (any Resource)?,
         for state: UIControl.State,
         placeholder: UIImage? = nil,
         options: KingfisherOptionsInfo? = nil,

--- a/Sources/General/ImageSource/AVAssetImageDataProvider.swift
+++ b/Sources/General/ImageSource/AVAssetImageDataProvider.swift
@@ -108,7 +108,7 @@ public struct AVAssetImageDataProvider: ImageDataProvider {
         self.init(assetURL: assetURL, time: time)
     }
 
-    public func data(handler: @Sendable @escaping (Result<Data, Error>) -> Void) {
+    public func data(handler: @Sendable @escaping (Result<Data, any Error>) -> Void) {
         assetImageGenerator.generateCGImagesAsynchronously(forTimes: [NSValue(time: time)]) {
             (requestedTime, image, imageTime, result, error) in
             if let error = error {

--- a/Sources/General/ImageSource/ImageDataProvider.swift
+++ b/Sources/General/ImageSource/ImageDataProvider.swift
@@ -46,7 +46,7 @@ public protocol ImageDataProvider: Sendable {
     /// - Note: If the `handler` is called with a `.failure` with error,
     /// a ``KingfisherError/ImageSettingErrorReason/dataProviderError(provider:error:)`` will be finally thrown out to
     /// you as the ``KingfisherError`` from the framework.
-    func data(handler: @escaping @Sendable (Result<Data, Error>) -> Void)
+    func data(handler: @escaping @Sendable (Result<Data, any Error>) -> Void)
 
     /// The content URL represents this provider, if exists.
     var contentURL: URL? { get }
@@ -96,7 +96,7 @@ public struct LocalFileImageDataProvider: ImageDataProvider {
     /// The key used in cache.
     public var cacheKey: String
 
-    public func data(handler: @escaping @Sendable (Result<Data, Error>) -> Void) {
+    public func data(handler: @escaping @Sendable (Result<Data, any Error>) -> Void) {
         loadingQueue.execute {
             handler(Result(catching: { try Data(contentsOf: fileURL) }))
         }
@@ -147,7 +147,7 @@ public struct Base64ImageDataProvider: ImageDataProvider {
     /// The key used in cache.
     public var cacheKey: String
 
-    public func data(handler: (Result<Data, Error>) -> Void) {
+    public func data(handler: (Result<Data, any Error>) -> Void) {
         let data = Data(base64Encoded: base64String)!
         handler(.success(data))
     }
@@ -178,7 +178,7 @@ public struct RawImageDataProvider: ImageDataProvider {
     /// The key used in cache.
     public var cacheKey: String
 
-    public func data(handler: @escaping (Result<Data, Error>) -> Void) {
+    public func data(handler: @escaping (Result<Data, any Error>) -> Void) {
         handler(.success(data))
     }
 }

--- a/Sources/General/ImageSource/PHPickerResultImageDataProvider.swift
+++ b/Sources/General/ImageSource/PHPickerResultImageDataProvider.swift
@@ -46,7 +46,7 @@ public struct PHPickerResultImageDataProvider: ImageDataProvider {
     /// - invalidImage: The retrieved image is invalid.
     public enum PHPickerResultImageDataProviderError: Error {
         /// An error happens during picking up image through the item provider of `PHPickerResult`.
-        case pickerProviderError(Error)
+        case pickerProviderError(any Error)
         /// The retrieved image is invalid.
         case invalidImage
     }
@@ -74,7 +74,7 @@ public struct PHPickerResultImageDataProvider: ImageDataProvider {
         self.contentType = contentType
     }
 
-    public func data(handler: @escaping @Sendable (Result<Data, Error>) -> Void) {
+    public func data(handler: @escaping @Sendable (Result<Data, any Error>) -> Void) {
         pickerResult.itemProvider.loadDataRepresentation(forTypeIdentifier: contentType.identifier) { data, error in
             if let error {
                 handler(.failure(PHPickerResultImageDataProviderError.pickerProviderError(error)))

--- a/Sources/General/ImageSource/Source.swift
+++ b/Sources/General/ImageSource/Source.swift
@@ -57,11 +57,11 @@ public enum Source: Sendable {
 
     /// The target image should be fetched from the network remotely. The associated `Resource`
     /// value defines detailed information such as the image URL and cache key.
-    case network(Resource)
-    
+    case network(any Resource)
+
     /// The target image should be provided in a data format, typically as an image
     /// from local storage or in any other encoding format, such as Base64.
-    case provider(ImageDataProvider)
+    case provider(any ImageDataProvider)
 
     // MARK: Getting Properties
 
@@ -112,7 +112,7 @@ extension Source: Hashable {
 }
 
 extension Source {
-    var asResource: Resource? {
+    var asResource: (any Resource)? {
         guard case .network(let resource) = self else {
             return nil
         }

--- a/Sources/General/KF.swift
+++ b/Sources/General/KF.swift
@@ -61,7 +61,7 @@ public enum KF {
     /// - Parameter resource: The ``Resource`` object defines data information like key or URL.
     /// - Returns: A ``Builder`` for future configuration. After configuring the builder, call its
     /// `Builder/set(to:)` to start the image loading.
-    public static func resource(_ resource: Resource?) -> KF.Builder {
+    public static func resource(_ resource: (any Resource)?) -> KF.Builder {
         source(resource?.convertToSource())
     }
 
@@ -80,7 +80,7 @@ public enum KF {
     /// - Parameter provider: The ``ImageDataProvider`` object contains information about the data.
     /// - Returns: A ``Builder`` for future configuration. After configuring the builder, call its
     /// `Builder/set(to:)` to start the image loading.
-    public static func dataProvider(_ provider: ImageDataProvider?) -> KF.Builder {
+    public static func dataProvider(_ provider: (any ImageDataProvider)?) -> KF.Builder {
         source(provider?.convertToSource())
     }
 
@@ -116,8 +116,8 @@ extension KF {
             set { propertyQueue.sync { _placeholder = newValue } }
         }
         #else
-        private var _placeholder: Placeholder?
-        private var placeholder: Placeholder? {
+        private var _placeholder: (any Placeholder)?
+        private var placeholder: (any Placeholder)? {
             get { propertyQueue.sync { _placeholder } }
             set { propertyQueue.sync { _placeholder = newValue } }
         }
@@ -337,7 +337,7 @@ extension KF.Builder {
     /// Sets a placeholder which is used while retrieving the image.
     /// - Parameter placeholder: A placeholder to show while retrieving the image from its source.
     /// - Returns: A ``KF/Builder`` with changes applied.
-    public func placeholder(_ placeholder: Placeholder?) -> Self {
+    public func placeholder(_ placeholder: (any Placeholder)?) -> Self {
         self.placeholder = placeholder
         return self
     }

--- a/Sources/General/KFOptionsSetter.swift
+++ b/Sources/General/KFOptionsSetter.swift
@@ -345,7 +345,7 @@ extension KFOptionSetter {
     /// - Parameter strategy: The provided strategy that defines how retry attempts should occur.
     /// - Returns: A `Self` value with the changes applied.
     ///
-    public func retry(_ strategy: RetryStrategy?) -> Self {
+    public func retry(_ strategy: (any RetryStrategy)?) -> Self {
         options.retryStrategy = strategy
         return self
     }
@@ -424,7 +424,7 @@ extension KFOptionSetter {
     /// This is your last opportunity to modify the image download request. You can use this for customization
     /// purposes, such as adding an authentication token to the header, implementing basic HTTP authentication,
     /// or URL mapping.
-    public func requestModifier(_ modifier: AsyncImageDownloadRequestModifier) -> Self {
+    public func requestModifier(_ modifier: any AsyncImageDownloadRequestModifier) -> Self {
         options.requestModifier = modifier
         return self
     }
@@ -460,7 +460,7 @@ extension KFOptionSetter {
     /// authentication, or URL mapping. By default, the original redirection request will be sent without any
     /// modification.
     ///
-    public func redirectHandler(_ handler: ImageDownloadRedirectHandler) -> Self {
+    public func redirectHandler(_ handler: any ImageDownloadRedirectHandler) -> Self {
         options.redirectHandler = handler
         return self
     }
@@ -497,7 +497,7 @@ extension KFOptionSetter {
     ///
     /// - Note: To append a processor to the current ones instead of replacing them all, use ``appendProcessor(_:)``.
     ///
-    public func setProcessor(_ processor: ImageProcessor) -> Self {
+    public func setProcessor(_ processor: any ImageProcessor) -> Self {
         options.processor = processor
         return self
     }
@@ -511,7 +511,7 @@ extension KFOptionSetter {
     /// - Note: To append processors to the current ones instead of replacing them all, concatenate them using the
     /// `|>` operator, and then use ``KFOptionSetter/appendProcessor(_:)``.
     ///
-    public func setProcessors(_ processors: [ImageProcessor]) -> Self {
+    public func setProcessors(_ processors: [any ImageProcessor]) -> Self {
         switch processors.count {
         case 0:
             options.processor = DefaultImageProcessor.default
@@ -528,7 +528,7 @@ extension KFOptionSetter {
     /// - Parameter processor: The processor to append to the current processor settings.
     /// - Returns: A `Self` value with the changes applied.
     ///
-    public func appendProcessor(_ processor: ImageProcessor) -> Self {
+    public func appendProcessor(_ processor: any ImageProcessor) -> Self {
         options.processor = options.processor |> processor
         return self
     }
@@ -669,7 +669,7 @@ extension KFOptionSetter {
     /// - Parameter cacheSerializer: The ``CacheSerializer`` to be used.
     /// - Returns: A `Self` value with the changes applied.
     ///
-    public func serialize(by cacheSerializer: CacheSerializer) -> Self {
+    public func serialize(by cacheSerializer: any CacheSerializer) -> Self {
         options.cacheSerializer = cacheSerializer
         return self
     }
@@ -712,7 +712,7 @@ extension KFOptionSetter {
     /// - Parameter modifier: The ``ImageModifier`` to be used for modifying the image object.
     /// - Returns: A `Self` value with the changes applied.
     ///
-    public func imageModifier(_ modifier: ImageModifier?) -> Self {
+    public func imageModifier(_ modifier: (any ImageModifier)?) -> Self {
         options.imageModifier = modifier
         return self
     }

--- a/Sources/General/KingfisherError.swift
+++ b/Sources/General/KingfisherError.swift
@@ -97,7 +97,7 @@ public enum KingfisherError: Error {
         ///   - error: The underlying URLSession error object.
         ///
         /// Error Code: 2003
-        case URLSessionError(error: Error)
+        case URLSessionError(error: any Error)
         
         /// Data modifying fails on returning a valid data.
         ///
@@ -152,7 +152,7 @@ public enum KingfisherError: Error {
         ///   - url: The disk URL where the target cached file exists.
         ///
         /// Error Code: 3003
-        case invalidURLResource(error: Error, key: String, url: URL)
+        case invalidURLResource(error: any Error, key: String, url: URL)
         
         /// The file at the target URL exists, but the data cannot be loaded from it.
         ///
@@ -161,7 +161,7 @@ public enum KingfisherError: Error {
         ///   - error: The underlying error that describes why this error occurs.
         ///
         /// Error Code: 3004
-        case cannotLoadDataFromDisk(url: URL, error: Error)
+        case cannotLoadDataFromDisk(url: URL, error: any Error)
         
         /// Cannot create a folder at a given path.
         ///
@@ -170,7 +170,7 @@ public enum KingfisherError: Error {
         ///   - error: The underlying error that describes why this error occurs.
         ///
         /// Error Code: 3005
-        case cannotCreateDirectory(path: String, error: Error)
+        case cannotCreateDirectory(path: String, error: any Error)
         
         /// The requested image does not exist in the cache.
         ///
@@ -186,7 +186,7 @@ public enum KingfisherError: Error {
         ///   - object: The object that needs to be converted to data.
         ///
         /// Error Code: 3007
-        case cannotConvertToData(object: Any, error: Error)
+        case cannotConvertToData(object: Any, error: any Error)
         
         /// Unable to serialize an image to data for storage.
         ///
@@ -196,7 +196,7 @@ public enum KingfisherError: Error {
         ///   - serializer: The ``CacheSerializer`` used for the image serialization.
         ///
         /// Error Code: 3008
-        case cannotSerializeImage(image: KFCrossPlatformImage?, original: Data?, serializer: CacheSerializer)
+        case cannotSerializeImage(image: KFCrossPlatformImage?, original: Data?, serializer: any CacheSerializer)
 
         /// Unable to create the cache file at a specified `fileURL` under a given `key`.
         ///
@@ -210,7 +210,7 @@ public enum KingfisherError: Error {
         ///            `fileURL`.
         ///
         /// Error Code: 3009
-        case cannotCreateCacheFile(fileURL: URL, key: String, data: Data, error: Error)
+        case cannotCreateCacheFile(fileURL: URL, key: String, data: Data, error: any Error)
 
         /// Unable to set file attributes for a cached file.
         ///
@@ -221,7 +221,7 @@ public enum KingfisherError: Error {
         ///            `attributes` for the disk file at `filePath`.
         ///
         /// Error Code: 3010
-        case cannotSetCacheFileAttribute(filePath: String, attributes: [FileAttributeKey : Any], error: Error)
+        case cannotSetCacheFileAttribute(filePath: String, attributes: [FileAttributeKey : Any], error: any Error)
 
         
         /// The disk storage for caching is not ready.
@@ -246,7 +246,7 @@ public enum KingfisherError: Error {
         ///   - item: The image or its data content.
         ///
         /// Error Code: 4001
-        case processingFailed(processor: ImageProcessor, item: ImageProcessItem)
+        case processingFailed(processor: any ImageProcessor, item: ImageProcessItem)
     }
 
     /// Represents the error reason during image setting in a view related class.
@@ -268,7 +268,7 @@ public enum KingfisherError: Error {
         ///   - source: The original source value of the task.
         ///
         /// Error Code: 5002
-        case notCurrentSourceTask(result: RetrieveImageResult?, error: Error?, source: Source)
+        case notCurrentSourceTask(result: RetrieveImageResult?, error: (any Error)?, source: Source)
 
         /// An error occurs while retrieving data from an `ImageDataProvider`.
         ///
@@ -277,7 +277,7 @@ public enum KingfisherError: Error {
         ///   - error: The underlying error that describes why this error occurred.
         ///
         /// Error Code: 5003
-        case dataProviderError(provider: ImageDataProvider, error: Error)
+        case dataProviderError(provider: any ImageDataProvider, error: any Error)
 
         /// No more alternative ``Source`` can be used in current loading process. It means that the
         /// ``KingfisherOptionsInfoItem/alternativeSources(_:)`` are set and Kingfisher tried to recovery from the original error, but still

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -194,7 +194,7 @@ public class KingfisherManager: @unchecked Sendable {
     ///
     @discardableResult
     public func retrieveImage(
-        with resource: Resource,
+        with resource: any Resource,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
         downloadTaskUpdated: DownloadTaskUpdatedBlock? = nil,
@@ -418,7 +418,7 @@ public class KingfisherManager: @unchecked Sendable {
     }
 
     func provideImage(
-        provider: ImageDataProvider,
+        provider: any ImageDataProvider,
         options: KingfisherParsedOptionsInfo,
         completionHandler: (@Sendable (Result<ImageLoadingResult, KingfisherError>) -> Void)?)
     {
@@ -764,7 +764,7 @@ extension KingfisherManager {
     /// the `resource`, stores it in the cache, and then calls the `completionHandler`.
     ///
     public func retrieveImage(
-        with resource: Resource,
+        with resource: any Resource,
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil
     ) async throws -> RetrieveImageResult

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -153,8 +153,8 @@ public enum KingfisherOptionsInfoItem: Sendable {
     /// mapping.
     ///
     /// By default, the original request is sent without any modifications.
-    case requestModifier(AsyncImageDownloadRequestModifier)
-    
+    case requestModifier(any AsyncImageDownloadRequestModifier)
+
     /// The contained ``ImageDownloadRedirectHandler`` will be used to alter the request during redirection.
     ///
     /// This provides an opportunity to customize the image download request during redirection. You can modify the 
@@ -162,8 +162,8 @@ public enum KingfisherOptionsInfoItem: Sendable {
     /// authentication, or URL mapping.
     ///
     /// By default, the original redirection request is sent without any modifications.
-    case redirectHandler(ImageDownloadRedirectHandler)
-    
+    case redirectHandler(any ImageDownloadRedirectHandler)
+
     /// The processor used in the image retrieval task.
     ///
     /// After downloading is complete, a processor will convert the downloaded data into an image and/or apply various 
@@ -172,13 +172,13 @@ public enum KingfisherOptionsInfoItem: Sendable {
     /// If a cache is linked to the downloader (which occurs when you use ``KingfisherManager`` or any of the view
     /// extension methods), the converted image will also be stored in the cache. If not set, the
     /// ``DefaultImageProcessor/default`` will be used.
-    case processor(ImageProcessor)
-    
+    case processor(any ImageProcessor)
+
     /// Offers a ``CacheSerializer`` to convert data into an image object for retrieval from disk cache, or vice versa
     /// for storage in the disk cache.
     ///
     /// If not set, the ``DefaultCacheSerializer/default`` will be used.
-    case cacheSerializer(CacheSerializer)
+    case cacheSerializer(any CacheSerializer)
 
     /// An ``ImageModifier`` for making adjustments to an image right before it is used.
     ///
@@ -188,8 +188,8 @@ public enum KingfisherOptionsInfoItem: Sendable {
     ///
     /// Use the ``ImageModifier`` when you need to set properties that do not persist when caching the image with a 
     /// specific image type. Examples include setting the `renderingMode` or `alignmentInsets` of a `UIImage`.
-    case imageModifier(ImageModifier)
-    
+    case imageModifier(any ImageModifier)
+
     /// Keep the existing image of image view while setting another image to it.
     /// By setting this option, the placeholder image parameter of image view extension method
     /// will be ignored and the current image will be kept while loading or downloading the new image.
@@ -330,7 +330,7 @@ public enum KingfisherOptionsInfoItem: Sendable {
     /// - Note: All extension methods of Kingfisher (the `kf` extensions on `UIImageView` or `UIButton`, for example)
     /// retrieve images through ``KingfisherManager``, so the retry strategy also applies when using them. However,
     /// this option does not apply when passed to an ``ImageDownloader`` or an ``ImageCache`` directly.
-    case retryStrategy(RetryStrategy)
+    case retryStrategy(any RetryStrategy)
 
     /// Specifies the `Source` to load when the user enables Low Data Mode and the original source fails due to the data
     /// constraint.
@@ -376,11 +376,11 @@ public struct KingfisherParsedOptionsInfo: Sendable {
     public var preloadAllAnimationData = false
     public var callbackQueue: CallbackQueue = .mainCurrentOrAsync
     public var scaleFactor: CGFloat = 1.0
-    public var requestModifier: AsyncImageDownloadRequestModifier? = nil
-    public var redirectHandler: ImageDownloadRedirectHandler? = nil
-    public var processor: ImageProcessor = DefaultImageProcessor.default
-    public var imageModifier: ImageModifier? = nil
-    public var cacheSerializer: CacheSerializer = DefaultCacheSerializer.default
+    public var requestModifier: (any AsyncImageDownloadRequestModifier)? = nil
+    public var redirectHandler: (any ImageDownloadRedirectHandler)? = nil
+    public var processor: any ImageProcessor = DefaultImageProcessor.default
+    public var imageModifier: (any ImageModifier)? = nil
+    public var cacheSerializer: any CacheSerializer = DefaultCacheSerializer.default
     public var keepCurrentImageWhileLoading = false
     public var onlyLoadFirstFrame = false
     public var cacheOriginalImage = false
@@ -395,10 +395,10 @@ public struct KingfisherParsedOptionsInfo: Sendable {
     public var processingQueue: CallbackQueue? = nil
     public var progressiveJPEG: ImageProgressive? = nil
     public var alternativeSources: [Source]? = nil
-    public var retryStrategy: RetryStrategy? = nil
+    public var retryStrategy: (any RetryStrategy)? = nil
     public var lowDataModeSource: Source? = nil
 
-    var onDataReceived: [DataReceivingSideEffect]? = nil
+    var onDataReceived: [any DataReceivingSideEffect]? = nil
     
     public init(_ info: KingfisherOptionsInfo?) {
         guard let info = info else { return }

--- a/Sources/Image/GIFAnimatedImage.swift
+++ b/Sources/Image/GIFAnimatedImage.swift
@@ -75,7 +75,7 @@ public class GIFAnimatedImage {
     let images: [KFCrossPlatformImage]
     let duration: TimeInterval
     
-    init?(from frameSource: ImageFrameSource, options: ImageCreatingOptions) {
+    init?(from frameSource: any ImageFrameSource, options: ImageCreatingOptions) {
         let frameCount = frameSource.frameCount
         var images = [KFCrossPlatformImage]()
         var gifDuration = 0.0

--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -104,7 +104,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     #endif
     
     /// The custom frame source for the current image.
-    public private(set) var frameSource: ImageFrameSource? {
+    public private(set) var frameSource: (any ImageFrameSource)? {
         get { return getAssociatedObject(base, imageSourceKey) }
         set { setRetainedAssociatedObject(base, imageSourceKey, newValue) }
     }
@@ -317,7 +317,7 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
     ///                frame of the `source` will be used.
     /// - Returns: An `Image` object representing the animated image. It consists of an array of image frames, each with a
     ///            specific duration. Returns `nil` if any issues arise during animated image creation.
-    public static func animatedImage(source: ImageFrameSource, options: ImageCreatingOptions, baseImage: KFCrossPlatformImage? = nil) -> KFCrossPlatformImage? {
+    public static func animatedImage(source: any ImageFrameSource, options: ImageCreatingOptions, baseImage: KFCrossPlatformImage? = nil) -> KFCrossPlatformImage? {
         #if os(macOS)
         guard let animatedImage = GIFAnimatedImage(from: source, options: options) else {
             return nil

--- a/Sources/Image/ImageProcessor.swift
+++ b/Sources/Image/ImageProcessor.swift
@@ -82,7 +82,7 @@ extension ImageProcessor {
     ///
     /// - Parameter another: An `ImageProcessor` to be appended to `self`.
     /// - Returns: The new `ImageProcessor` that will process the image in the order of the two processors concatenated.
-    public func append(another: ImageProcessor) -> ImageProcessor {
+    public func append(another: any ImageProcessor) -> any ImageProcessor {
         let newIdentifier = identifier.appending("|>\(another.identifier)")
         return GeneralProcessor(identifier: newIdentifier) {
             item, options in
@@ -95,11 +95,11 @@ extension ImageProcessor {
     }
 }
 
-func ==(left: ImageProcessor, right: ImageProcessor) -> Bool {
+func ==(left: any ImageProcessor, right: any ImageProcessor) -> Bool {
     return left.identifier == right.identifier
 }
 
-func !=(left: ImageProcessor, right: ImageProcessor) -> Bool {
+func !=(left: any ImageProcessor, right: any ImageProcessor) -> Bool {
     return !(left == right)
 }
 
@@ -827,7 +827,7 @@ infix operator |>: AdditionPrecedence
 ///     - left: The first processor.
 ///     - right: The second processor that follows the `left`.
 /// - Returns: The new processor that processes the image or the image data in left-to-right order.
-public func |>(left: ImageProcessor, right: ImageProcessor) -> ImageProcessor {
+public func |>(left: any ImageProcessor, right: any ImageProcessor) -> any ImageProcessor {
     return left.append(another: right)
 }
 

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -229,13 +229,13 @@ open class ImageDownloader: @unchecked Sendable {
     /// The delegate of this `ImageDownloader` object.
     ///
     /// See the ``ImageDownloaderDelegate`` protocol for more information.
-    open weak var delegate: ImageDownloaderDelegate?
-    
+    open weak var delegate: (any ImageDownloaderDelegate)?
+
     /// A responder for authentication challenges.
     ///
     /// The downloader forwards the received authentication challenge for the downloading session to this responder.
     /// See ``AuthenticationChallengeResponsible`` for more.
-    open weak var authenticationChallengeResponder: AuthenticationChallengeResponsible?
+    open weak var authenticationChallengeResponder: (any AuthenticationChallengeResponsible)?
 
     // The downloader name.
     private let name: String
@@ -348,7 +348,7 @@ open class ImageDownloader: @unchecked Sendable {
         // Modifies request before sending.
         // FIXME: A temporary solution for keep the sync `ImageDownloadRequestModifier` behavior as before.
         // We should be able to combine two cases once the full async support can be introduced to Kingfisher.
-        if let m = requestModifier as? ImageDownloadRequestModifier {
+        if let m = requestModifier as? any ImageDownloadRequestModifier {
             guard let result = m.modified(for: request) else {
                 done(.failure(KingfisherError.requestError(reason: .emptyRequest)))
                 return
@@ -388,7 +388,7 @@ open class ImageDownloader: @unchecked Sendable {
 
     private func reportDidDownloadImageData(result: Result<(Data, URLResponse?), KingfisherError>, url: URL) {
         var response: URLResponse?
-        var err: Error?
+        var err: (any Error)?
         do {
             response = try result.get().1
         } catch {

--- a/Sources/Networking/ImageDownloaderDelegate.swift
+++ b/Sources/Networking/ImageDownloaderDelegate.swift
@@ -56,7 +56,7 @@ public protocol ImageDownloaderDelegate: AnyObject {
         _ downloader: ImageDownloader,
         didFinishDownloadingImageForURL url: URL,
         with response: URLResponse?,
-        error: Error?)
+        error: (any Error)?)
 
     /// Called when the ``ImageDownloader`` object successfully downloads image data with a specified task.
     ///
@@ -166,7 +166,7 @@ extension ImageDownloaderDelegate {
         _ downloader: ImageDownloader,
         didFinishDownloadingImageForURL url: URL,
         with response: URLResponse?,
-        error: Error?) {}
+        error: (any Error)?) {}
 
     public func imageDownloader(
         _ downloader: ImageDownloader,

--- a/Sources/Networking/ImagePrefetcher.swift
+++ b/Sources/Networking/ImagePrefetcher.swift
@@ -38,7 +38,7 @@ import UIKit
 ///   - failedResources: An array of resources that fail to be downloaded. This could be because of being cancelled while downloading, encountering an error during downloading, or the download not being started at all.
 ///   - completedResources: An array of resources that are downloaded and cached successfully.
 public typealias PrefetcherProgressBlock =
-    ((_ skippedResources: [Resource], _ failedResources: [Resource], _ completedResources: [Resource]) -> Void)
+    ((_ skippedResources: [any Resource], _ failedResources: [any Resource], _ completedResources: [any Resource]) -> Void)
 
 /// Progress update block of prefetcher when initialized with a list of resources.
 ///
@@ -56,7 +56,7 @@ public typealias PrefetcherSourceProgressBlock =
 ///   - failedResources: An array of resources that fail to be downloaded. This could be because of being cancelled while downloading, encountering an error during downloading, or the download not being started at all.
 ///   - completedResources: An array of resources that are downloaded and cached successfully.
 public typealias PrefetcherCompletionHandler =
-    ((_ skippedResources: [Resource], _ failedResources: [Resource], _ completedResources: [Resource]) -> Void)
+    ((_ skippedResources: [any Resource], _ failedResources: [any Resource], _ completedResources: [any Resource]) -> Void)
 
 /// Completion block of prefetcher when initialized with a list of sources.
 ///
@@ -134,7 +134,7 @@ public class ImagePrefetcher: CustomStringConvertible, @unchecked Sendable {
         progressBlock: PrefetcherProgressBlock? = nil,
         completionHandler: PrefetcherCompletionHandler? = nil)
     {
-        let resources: [Resource] = urls.map { $0 }
+        let resources: [any Resource] = urls.map { $0 }
         self.init(
             resources: resources,
             options: options,
@@ -159,7 +159,7 @@ public class ImagePrefetcher: CustomStringConvertible, @unchecked Sendable {
     /// ``KingfisherOptionsInfo``. Both the progress and completion blocks will be invoked on the main thread. The
     /// ``KingfisherOptionsInfoItem/callbackQueue(_:)`` value in `optionsInfo` will be ignored in this method.
     public convenience init(
-        resources: [Resource],
+        resources: [any Resource],
         options: KingfisherOptionsInfo? = nil,
         progressBlock: PrefetcherProgressBlock? = nil,
         completionHandler: PrefetcherCompletionHandler? = nil)

--- a/Sources/Networking/SessionDelegate.swift
+++ b/Sources/Networking/SessionDelegate.swift
@@ -194,7 +194,7 @@ extension SessionDelegate: URLSessionDataDelegate {
         }
     }
 
-    open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+    open func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?) {
         guard let sessionTask = self.task(for: task) else { return }
 
         if let url = sessionTask.originalURL {

--- a/Sources/SwiftUI/KFImageOptions.swift
+++ b/Sources/SwiftUI/KFImageOptions.swift
@@ -50,7 +50,7 @@ extension KFImageProtocol {
     ///   - resource: The ``Resource`` object that defines data information such as a key or URL.
     /// - Returns: A Kingfisher-compatible image view for future configuration or embedding into another `SwiftUI.View`.
     public static func resource(
-        _ resource: Resource?
+        _ resource: (any Resource)?
     ) -> Self
     {
         source(resource?.convertToSource())
@@ -77,7 +77,7 @@ extension KFImageProtocol {
     /// - Returns: A Kingfisher-compatible image view for future configuration or embedding into another `SwiftUI.View`.
 
     public static func dataProvider(
-        _ provider: ImageDataProvider?
+        _ provider: (any ImageDataProvider)?
     ) -> Self
     {
         source(provider?.convertToSource())

--- a/Sources/Utility/DisplayLink.swift
+++ b/Sources/Utility/DisplayLink.swift
@@ -47,7 +47,7 @@ protocol DisplayLinkCompatible: AnyObject, Sendable {
 
 #if !os(macOS)
 extension UIView {
-    func compatibleDisplayLink(target: Any, selector: Selector) -> DisplayLinkCompatible {
+    func compatibleDisplayLink(target: Any, selector: Selector) -> any DisplayLinkCompatible {
         return CADisplayLink(target: target, selector: selector)
     }
 }
@@ -60,7 +60,7 @@ extension CADisplayLink: DisplayLinkCompatible, @unchecked Sendable {}
 
 #else
 extension NSView {
-    func compatibleDisplayLink(target: Any, selector: Selector) -> DisplayLinkCompatible {
+    func compatibleDisplayLink(target: Any, selector: Selector) -> any DisplayLinkCompatible {
 #if swift(>=5.9) // macOS 14 SDK is included in Xcode 15, which comes with swift 5.9. Add this check to make old compilers happy.
         if #available(macOS 14.0, *) {
             return displayLink(target: target, selector: selector)

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -177,7 +177,7 @@ open class AnimatedImageView: KFCrossPlatformImageView {
     /// The delegate of this `AnimatedImageView` object. 
     ///
     /// See the ``AnimatedImageViewDelegate`` protocol for more information.
-    public weak var delegate: AnimatedImageViewDelegate?
+    public weak var delegate: (any AnimatedImageViewDelegate)?
 
     /// The ``Animator`` instance that holds the frames of a specific image in memory.
     public private(set) var animator: Animator?
@@ -192,7 +192,7 @@ open class AnimatedImageView: KFCrossPlatformImageView {
     private var isDisplayLinkInitialized: Bool = false
     
     // A display link that keeps calling the `updateFrame` method on every screen refresh.
-    private lazy var displayLink: DisplayLinkCompatible = {
+    private lazy var displayLink: any DisplayLinkCompatible = {
         isDisplayLinkInitialized = true
         let displayLink = self.compatibleDisplayLink(target: TargetProxy(target: self), selector: #selector(TargetProxy.onScreenUpdate))
         displayLink.add(to: .main, forMode: runLoopMode)
@@ -550,7 +550,7 @@ extension AnimatedImageView {
         /// The maximum count of image frames that need to be preloaded.
         public let maxFrameCount: Int
 
-        private let frameSource: ImageFrameSource
+        private let frameSource: any ImageFrameSource
         private let maxRepeatCount: RepeatCount
 
         private let maxTimeStep: TimeInterval = 1.0
@@ -563,7 +563,7 @@ extension AnimatedImageView {
 
         var needsPrescaling = true
 
-        weak var delegate: AnimatorDelegate?
+        weak var delegate: (any AnimatorDelegate)?
 
         // Total duration of one animation loop
         var loopDuration: TimeInterval = 0
@@ -664,7 +664,7 @@ extension AnimatedImageView {
         ///   - count: Count of frames needed to be preloaded.
         ///   - repeatCount: The repeat count should this animator uses.
         ///   - preloadQueue: Dispatch queue used for preloading images.
-        init(frameSource source: ImageFrameSource,
+        init(frameSource source: any ImageFrameSource,
              contentMode mode: KFCrossPlatformContentMode,
              size: CGSize,
              imageSize: CGSize,

--- a/Sources/Views/Indicator.swift
+++ b/Sources/Views/Indicator.swift
@@ -49,7 +49,7 @@ public enum IndicatorType {
     /// Uses a custom indicator.
     ///
     /// The type of the associated value should conform to the ``Indicator`` protocol.
-    case custom(indicator: Indicator)
+    case custom(indicator: any Indicator)
 }
 
 /// An indicator type which can be used to show that the download task is in progress.
@@ -201,7 +201,7 @@ final class ImageIndicator: Indicator {
 
     init?(
         imageData data: Data,
-        processor: ImageProcessor = DefaultImageProcessor.default,
+        processor: any ImageProcessor = DefaultImageProcessor.default,
         options: KingfisherParsedOptionsInfo? = nil)
     {
         var options = options ?? KingfisherParsedOptionsInfo(nil)

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1402,9 +1402,9 @@ final class FailingProcessor: ImageProcessor, @unchecked Sendable {
 
 struct SimpleImageDataProvider: ImageDataProvider, @unchecked Sendable {
     let cacheKey: String
-    let provider: () -> (Result<Data, Error>)
+    let provider: () -> (Result<Data, any Error>)
     
-    func data(handler: @escaping (Result<Data, Error>) -> Void) {
+    func data(handler: @escaping (Result<Data, any Error>) -> Void) {
         handler(provider())
     }
     

--- a/Tests/KingfisherTests/Utils/StubHelpers.swift
+++ b/Tests/KingfisherTests/Utils/StubHelpers.swift
@@ -58,6 +58,6 @@ func stub(_ url: URL, errorCode: Int) {
     stub(url, error: error)
 }
 
-func stub(_ url: URL, error: Error) {
+func stub(_ url: URL, error: any Error) {
     return stubRequest("GET", url.absoluteString as NSString).andFailWithError(error)
 }


### PR DESCRIPTION
Apply existential any to protocol for Swift 6
- https://github.com/swiftlang/swift-evolution/blob/main/proposals/0335-existential-any.md

  > After any is introduced, warnings will be added to guide programmers toward the new syntax. Finally, these warnings can become errors, or [plain protocol names can be repurposed](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0335-existential-any.md#re-purposing-the-plain-protocol-name), in Swift 6.

- I refactored by apply `.enableUpcomingFeature("ExistentialAny")`
    ```swift
    let package = Package(
        name: "Kingfisher",
        platforms: [.iOS(.v13), .macOS(.v10_15), .tvOS(.v13), .watchOS(.v6)],
        products: [
            .library(name: "Kingfisher", targets: ["Kingfisher"])
        ],
        targets: [
            .target(
                name: "Kingfisher",
                path: "Sources",
                swiftSettings: [
                    .enableUpcomingFeature("ExistentialAny")
                ]
            )
        ]
    )
    ```