### PR TITLE
remove redundant code

### DIFF
--- a/Sources/Cache/MemoryStorage.swift
+++ b/Sources/Cache/MemoryStorage.swift
@@ -84,8 +84,6 @@ public enum MemoryStorage {
         /// default expiration settings, and more.
         public init(config: Config) {
             self.config = config
-            storage.totalCostLimit = config.totalCostLimit
-            storage.countLimit = config.countLimit
 
             cleanTimer = .scheduledTimer(withTimeInterval: config.cleanInterval, repeats: true) { [weak self] _ in
                 guard let self = self else { return }


### PR DESCRIPTION
Remove redundant assignments of `totalCostLimit` and `countLimit` to memory storage properties since the config setter already did it.