### PR TITLE
fix: The image doesn't render correctly when blur is applied

### DIFF
--- a/Sources/Image/ImageDrawing.swift
+++ b/Sources/Image/ImageDrawing.swift
@@ -344,7 +344,15 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
         guard let inputContext = CGContext.fresh(cgImage: cgImage) else {
             return base
         }
-        inputContext.draw(cgImage, in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+        inputContext.draw(
+            cgImage,
+            in: CGRect(
+                x: 0,
+                y: 0,
+                width: size.width * base.scale,
+                height: size.height * base.scale
+            )
+        )
         var inBuffer = createEffectBuffer(inputContext)
 
         guard let outContext = CGContext.fresh(cgImage: cgImage) else {


### PR DESCRIPTION
The regression has been likely caused by this PR:
- https://github.com/onevcat/Kingfisher/pull/2274

<table>
<tr>
<th align="center">
<img width="294" height="1">
<p> 
<small>
ORIGINAL
</small>
</p>
</th>
<th align="center">
<img width="294" height="1">
<p> 
<small>
BLURRED v8.0.0-8.0.1
</small>
</p>
</th>
<th align="center">
<img width="294" height="1">
<p> 
<small>
BLURRED FIX
</small>
</p>
</th>
</tr>
<tr>
<td align="center">
<img src="https://github.com/user-attachments/assets/70544212-cc28-43fc-a62a-345e486a2834"/>
</td>
<td align="center">
<img src="https://github.com/user-attachments/assets/c3387b45-102c-4bf5-95a3-df1b415b9035"/>
</td>
<td align="center">
<img src="https://github.com/user-attachments/assets/8e7797b2-4a6e-4f14-9a0e-3ad08bdd6398"/>
</td>
</tr>
</table>