### PR TITLE
fix: add @MainActor attribute to animation closure of custom transition

### DIFF
--- a/Sources/Image/ImageTransition.swift
+++ b/Sources/Image/ImageTransition.swift
@@ -56,7 +56,7 @@ public enum ImageTransition: Sendable {
     ///    - completion: A block called when the transition animation finishes.
     case custom(duration: TimeInterval,
                  options: UIView.AnimationOptions,
-              animations: (@Sendable (UIImageView, UIImage) -> Void)?,
+              animations: (@Sendable @MainActor (UIImageView, UIImage) -> Void)?,
               completion: (@Sendable (Bool) -> Void)?)
     
     var duration: TimeInterval {


### PR DESCRIPTION
Warning occurs when set `imageView.image` in animation closure of custom transition.

```swift
let transition = .custom(duration: 0.2, options: .curveEaseIn, animations: { imageView, image in
    imageView.image = image
    //  Main actor-isolated property 'image' can not be mutated from a Sendable closure; this is an error in the Swift 6 language mode
}, completion: nil)
```

So I added `@MainActor` attribute to animations parameter because animations should be executed on main thread.