### PR TITLE
Add support for Live Photo loading from network

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/Base.lproj/Main.storyboard
+++ b/Demo/Demo/Kingfisher-Demo/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="peg-r0-mlo">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="peg-r0-mlo">
     <device id="retina5_5" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -491,8 +491,32 @@
                                             <segue destination="wco-eY-gNu" kind="show" id="KCP-ab-diO"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="TIF-8x-GLM">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="8uq-CX-Fxl">
                                         <rect key="frame" x="0.0" y="710" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8uq-CX-Fxl" id="I9G-72-N8J">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Live Photo" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mXz-QJ-f80">
+                                                    <rect key="frame" x="20" y="11.666666666666664" width="80" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="mXz-QJ-f80" firstAttribute="leading" secondItem="I9G-72-N8J" secondAttribute="leading" constant="20" symbolic="YES" id="1BM-Eu-bcs"/>
+                                                <constraint firstItem="mXz-QJ-f80" firstAttribute="centerY" secondItem="I9G-72-N8J" secondAttribute="centerY" id="Fqb-ZQ-J3L"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mXz-QJ-f80" secondAttribute="trailing" constant="20" symbolic="YES" id="fAH-HG-EXN"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="nhf-ZY-JwU" kind="show" id="Srz-py-yg9"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="TIF-8x-GLM">
+                                        <rect key="frame" x="0.0" y="754" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TIF-8x-GLM" id="ykx-Ds-PkP">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -991,6 +1015,22 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="a3K-Ir-TOf" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2654" y="1061"/>
+        </scene>
+        <!--Live Photo View Controller-->
+        <scene sceneID="50O-N8-WQ3">
+            <objects>
+                <viewController id="nhf-ZY-JwU" customClass="LivePhotoViewController" customModule="Kingfisher_Demo" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="G81-wm-Fnw">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="12L-DC-epo"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="bYb-CA-CnJ"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="y5S-MW-IuF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1851" y="2398"/>
         </scene>
         <!--Asset Image Generator View Controller-->
         <scene sceneID="PCw-9j-oCu">

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/LivePhotoViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/LivePhotoViewController.swift
@@ -1,0 +1,59 @@
+//
+//  LivePhotoViewController.swift
+//  Kingfisher
+//
+//  Created by onevcat on 2024/10/05.
+//
+//  Copyright (c) 2024 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import UIKit
+import PhotosUI
+import Kingfisher
+
+class LivePhotoViewController: UIViewController {
+    
+    private var livePhotoView: PHLivePhotoView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Live Photo"
+        setupOperationNavigationBar()
+        
+        livePhotoView = PHLivePhotoView()
+        livePhotoView.translatesAutoresizingMaskIntoConstraints = false
+        
+        view.addSubview(livePhotoView)
+        NSLayoutConstraint.activate([
+            livePhotoView.heightAnchor.constraint(equalToConstant: 300),
+            livePhotoView.widthAnchor.constraint(equalToConstant: 300),
+            livePhotoView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            livePhotoView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -30)
+        ])
+        
+        let source = LivePhotoSource(urls: [
+            "https://github.com/onevcat/Kingfisher-TestImages/raw/refs/heads/master/LivePhotos/live_photo_sample.HEIC",
+            "https://github.com/onevcat/Kingfisher-TestImages/raw/refs/heads/master/LivePhotos/live_photo_sample.MOV"
+        ].compactMap(URL.init))
+        livePhotoView.kf.setImage(with: source, completionHandler: { result in
+            print(result)
+        })
+    }
+}

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/LivePhotoViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/LivePhotoViewController.swift
@@ -48,11 +48,11 @@ class LivePhotoViewController: UIViewController {
             livePhotoView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -30)
         ])
         
-        let source = LivePhotoSource(urls: [
+        let urls = [
             "https://github.com/onevcat/Kingfisher-TestImages/raw/refs/heads/master/LivePhotos/live_photo_sample.HEIC",
             "https://github.com/onevcat/Kingfisher-TestImages/raw/refs/heads/master/LivePhotos/live_photo_sample.MOV"
-        ].compactMap(URL.init))
-        livePhotoView.kf.setImage(with: source, completionHandler: { result in
+        ].compactMap(URL.init)
+        livePhotoView.kf.setImage(with: urls, completionHandler: { result in
             switch result {
             case .success(let r):
                 print("Live Photo done. \(r.loadingInfo.cacheType)")

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/LivePhotoViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/LivePhotoViewController.swift
@@ -53,7 +53,13 @@ class LivePhotoViewController: UIViewController {
             "https://github.com/onevcat/Kingfisher-TestImages/raw/refs/heads/master/LivePhotos/live_photo_sample.MOV"
         ].compactMap(URL.init))
         livePhotoView.kf.setImage(with: source, completionHandler: { result in
-            print(result)
+            switch result {
+            case .success(let r):
+                print("Live Photo done. \(r.loadingInfo.cacheType)")
+                print("Info: \(String(describing: r.info))")
+            case .failure(let error):
+                print("Live Photo error: \(error)")
+            }
         })
     }
 }

--- a/Demo/Kingfisher-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Kingfisher-Demo.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		D12E0CB61C47F9C100AC98AD /* NormalLoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12E0C941C47F91800AC98AD /* NormalLoadingViewController.swift */; };
 		D12EB83E24DD902300329EE1 /* TextAttachmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12EB83D24DD902300329EE1 /* TextAttachmentViewController.swift */; };
 		D12EB84024DDB9E100329EE1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D12EB83F24DDB9E000329EE1 /* LaunchScreen.storyboard */; };
+		D12F67682CB10AE000AB63AB /* LivePhotoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F67672CB10AD900AB63AB /* LivePhotoViewController.swift */; };
 		D1679A461C4E78B20020FD12 /* Kingfisher-watchOS-Demo Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = D1679A451C4E78B20020FD12 /* Kingfisher-watchOS-Demo Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D16CC3D824E03FEA00F1A515 /* AVAssetImageGeneratorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16CC3D724E03FEA00F1A515 /* AVAssetImageGeneratorViewController.swift */; };
 		D198F41E25EDC11500C53E0D /* LazyVStackDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D198F41D25EDC11500C53E0D /* LazyVStackDemo.swift */; };
@@ -204,6 +205,7 @@
 		D12E0CA11C47F92200AC98AD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D12EB83D24DD902300329EE1 /* TextAttachmentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextAttachmentViewController.swift; sourceTree = "<group>"; };
 		D12EB83F24DDB9E000329EE1 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D12F67672CB10AD900AB63AB /* LivePhotoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePhotoViewController.swift; sourceTree = "<group>"; };
 		D13F49C21BEDA53F00CE335D /* Kingfisher-tvOS-Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Kingfisher-tvOS-Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D16218A4238EAA67004A1C6C /* Kingfisher-Demo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Kingfisher-Demo.entitlements"; sourceTree = "<group>"; };
 		D1679A391C4E78B20020FD12 /* Kingfisher-watchOS-Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Kingfisher-watchOS-Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -386,6 +388,7 @@
 		D1A1CCA921A1936300263AD8 /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				D12F67672CB10AD900AB63AB /* LivePhotoViewController.swift */,
 				D10AC99721A300C9005F057C /* ProcessorCollectionViewController.swift */,
 				4B1C7A3C21A256E300CE9D31 /* InfinityCollectionViewController.swift */,
 				D1CE1BCF21A1AFA300419000 /* TransitionViewController.swift */,
@@ -731,6 +734,7 @@
 				078DCB512BCFEFB40008114E /* PHPickerResultViewController.swift in Sources */,
 				D1EDF7422C9F01270017FFA5 /* Issue2295View.swift in Sources */,
 				D1A1CCA321A1879600263AD8 /* MainViewController.swift in Sources */,
+				D12F67682CB10AE000AB63AB /* LivePhotoViewController.swift in Sources */,
 				4BC0ED4A29A6EE78003E9CD1 /* Issue2035View.swift in Sources */,
 				D1F06F3721AAEACF000B1C38 /* GIFViewController.swift in Sources */,
 				4B120CA726B91BB70060B092 /* TransitionViewDemo.swift in Sources */,

--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		D12E0C581C47F23500AC98AD /* UIButtonExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12E0C4E1C47F23500AC98AD /* UIButtonExtensionTests.swift */; };
 		D12EB83C24DD8EFC00329EE1 /* NSTextAttachment+Kingfisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12EB83B24DD8EFC00329EE1 /* NSTextAttachment+Kingfisher.swift */; };
 		D12F67602CAC2DBF00AB63AB /* ImageDownloader+LivePhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F675F2CAC2DB700AB63AB /* ImageDownloader+LivePhoto.swift */; };
+		D12F67622CAC32BF00AB63AB /* KingfisherManager+LivePhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F67612CAC32B800AB63AB /* KingfisherManager+LivePhoto.swift */; };
+		D12F67642CAC330A00AB63AB /* LivePhotoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F67632CAC330600AB63AB /* LivePhotoSource.swift */; };
 		D13646742165A1A100A33652 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13646732165A1A100A33652 /* Result.swift */; };
 		D16CC3D624E02E9500F1A515 /* AVAssetImageDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16CC3D524E02E9500F1A515 /* AVAssetImageDataProvider.swift */; };
 		D16FEA3A23078C63006E67D5 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = D16FE9F623078C63006E67D5 /* LICENSE */; };
@@ -215,6 +217,8 @@
 		D12E0C4E1C47F23500AC98AD /* UIButtonExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonExtensionTests.swift; sourceTree = "<group>"; };
 		D12EB83B24DD8EFC00329EE1 /* NSTextAttachment+Kingfisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSTextAttachment+Kingfisher.swift"; sourceTree = "<group>"; };
 		D12F675F2CAC2DB700AB63AB /* ImageDownloader+LivePhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageDownloader+LivePhoto.swift"; sourceTree = "<group>"; };
+		D12F67612CAC32B800AB63AB /* KingfisherManager+LivePhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KingfisherManager+LivePhoto.swift"; sourceTree = "<group>"; };
+		D12F67632CAC330600AB63AB /* LivePhotoSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePhotoSource.swift; sourceTree = "<group>"; };
 		D1356CEA2B273AEC009554C8 /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
 		D13646732165A1A100A33652 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		D16CC3D524E02E9500F1A515 /* AVAssetImageDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAssetImageDataProvider.swift; sourceTree = "<group>"; };
@@ -415,6 +419,7 @@
 				D1132C9625919F69003E528D /* KFOptionsSetter.swift */,
 				D12AB6B2215D2BB50013BA68 /* KingfisherError.swift */,
 				D12AB6B3215D2BB50013BA68 /* KingfisherManager.swift */,
+				D12F67612CAC32B800AB63AB /* KingfisherManager+LivePhoto.swift */,
 				D12AB6B4215D2BB50013BA68 /* KingfisherOptionsInfo.swift */,
 			);
 			path = General;
@@ -656,6 +661,7 @@
 			isa = PBXGroup;
 			children = (
 				D1A1CC99219FAB4B00263AD8 /* Source.swift */,
+				D12F67632CAC330600AB63AB /* LivePhotoSource.swift */,
 				D12AB69E215D2BB50013BA68 /* Resource.swift */,
 				D1E56444219B16330057AAE3 /* ImageDataProvider.swift */,
 				D16CC3D524E02E9500F1A515 /* AVAssetImageDataProvider.swift */,
@@ -829,11 +835,13 @@
 				D16CC3D624E02E9500F1A515 /* AVAssetImageDataProvider.swift in Sources */,
 				D1839845216E333E003927D3 /* Delegate.swift in Sources */,
 				D12AB6D8215D2BB50013BA68 /* ImageTransition.swift in Sources */,
+				D12F67642CAC330A00AB63AB /* LivePhotoSource.swift in Sources */,
 				D1A37BE8215D365A009B39B7 /* ExtensionHelpers.swift in Sources */,
 				C9286407228584EB00257182 /* ImageProgressive.swift in Sources */,
 				D12AB6DC215D2BB50013BA68 /* ImageProcessor.swift in Sources */,
 				D12AB6D4215D2BB50013BA68 /* Image.swift in Sources */,
 				D1AEB09425890DE7008556DF /* ImageBinder.swift in Sources */,
+				D12F67622CAC32BF00AB63AB /* KingfisherManager+LivePhoto.swift in Sources */,
 				4B8E2917216F3F7F0095FAD1 /* ImageDownloaderDelegate.swift in Sources */,
 				E9E3ED8B2B1F66B200734CFF /* HasImageComponent+Kingfisher.swift in Sources */,
 				D1132C9725919F69003E528D /* KFOptionsSetter.swift in Sources */,

--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		D12E0C571C47F23500AC98AD /* KingfisherTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12E0C4C1C47F23500AC98AD /* KingfisherTestHelper.swift */; };
 		D12E0C581C47F23500AC98AD /* UIButtonExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12E0C4E1C47F23500AC98AD /* UIButtonExtensionTests.swift */; };
 		D12EB83C24DD8EFC00329EE1 /* NSTextAttachment+Kingfisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12EB83B24DD8EFC00329EE1 /* NSTextAttachment+Kingfisher.swift */; };
+		D12F67602CAC2DBF00AB63AB /* ImageDownloader+LivePhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F675F2CAC2DB700AB63AB /* ImageDownloader+LivePhoto.swift */; };
 		D13646742165A1A100A33652 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13646732165A1A100A33652 /* Result.swift */; };
 		D16CC3D624E02E9500F1A515 /* AVAssetImageDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16CC3D524E02E9500F1A515 /* AVAssetImageDataProvider.swift */; };
 		D16FEA3A23078C63006E67D5 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = D16FE9F623078C63006E67D5 /* LICENSE */; };
@@ -213,6 +214,7 @@
 		D12E0C4D1C47F23500AC98AD /* KingfisherTests-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "KingfisherTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		D12E0C4E1C47F23500AC98AD /* UIButtonExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonExtensionTests.swift; sourceTree = "<group>"; };
 		D12EB83B24DD8EFC00329EE1 /* NSTextAttachment+Kingfisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSTextAttachment+Kingfisher.swift"; sourceTree = "<group>"; };
+		D12F675F2CAC2DB700AB63AB /* ImageDownloader+LivePhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageDownloader+LivePhoto.swift"; sourceTree = "<group>"; };
 		D1356CEA2B273AEC009554C8 /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
 		D13646732165A1A100A33652 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		D16CC3D524E02E9500F1A515 /* AVAssetImageDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAssetImageDataProvider.swift; sourceTree = "<group>"; };
@@ -361,6 +363,7 @@
 				D12AB69D215D2BB50013BA68 /* RequestModifier.swift */,
 				D8FCF6A721C5A0E500F9ABC0 /* RedirectHandler.swift */,
 				D12AB69F215D2BB50013BA68 /* ImageDownloader.swift */,
+				D12F675F2CAC2DB700AB63AB /* ImageDownloader+LivePhoto.swift */,
 				4BD821612189FC0C0084CC21 /* SessionDelegate.swift */,
 				4BD821662189FD330084CC21 /* SessionDataTask.swift */,
 				4B8E2916216F3F7F0095FAD1 /* ImageDownloaderDelegate.swift */,
@@ -857,6 +860,7 @@
 				388F37382B4D9CDB0089705C /* DisplayLink.swift in Sources */,
 				D12AB6F4215D2BB50013BA68 /* ImageView+Kingfisher.swift in Sources */,
 				D12AB6FC215D2BB50013BA68 /* UIButton+Kingfisher.swift in Sources */,
+				D12F67602CAC2DBF00AB63AB /* ImageDownloader+LivePhoto.swift in Sources */,
 				D12AB6E8215D2BB50013BA68 /* GIFAnimatedImage.swift in Sources */,
 				22FDCE0E2700078B0044D11E /* CPListItem+Kingfisher.swift in Sources */,
 				D13646742165A1A100A33652 /* Result.swift in Sources */,

--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		D12F67602CAC2DBF00AB63AB /* ImageDownloader+LivePhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F675F2CAC2DB700AB63AB /* ImageDownloader+LivePhoto.swift */; };
 		D12F67622CAC32BF00AB63AB /* KingfisherManager+LivePhoto.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F67612CAC32B800AB63AB /* KingfisherManager+LivePhoto.swift */; };
 		D12F67642CAC330A00AB63AB /* LivePhotoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F67632CAC330600AB63AB /* LivePhotoSource.swift */; };
+		D12F67662CB022FC00AB63AB /* PHLivePhotoView+Kingfisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12F67652CB022EB00AB63AB /* PHLivePhotoView+Kingfisher.swift */; };
 		D13646742165A1A100A33652 /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13646732165A1A100A33652 /* Result.swift */; };
 		D16CC3D624E02E9500F1A515 /* AVAssetImageDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16CC3D524E02E9500F1A515 /* AVAssetImageDataProvider.swift */; };
 		D16FEA3A23078C63006E67D5 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = D16FE9F623078C63006E67D5 /* LICENSE */; };
@@ -219,6 +220,7 @@
 		D12F675F2CAC2DB700AB63AB /* ImageDownloader+LivePhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageDownloader+LivePhoto.swift"; sourceTree = "<group>"; };
 		D12F67612CAC32B800AB63AB /* KingfisherManager+LivePhoto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KingfisherManager+LivePhoto.swift"; sourceTree = "<group>"; };
 		D12F67632CAC330600AB63AB /* LivePhotoSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePhotoSource.swift; sourceTree = "<group>"; };
+		D12F67652CB022EB00AB63AB /* PHLivePhotoView+Kingfisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PHLivePhotoView+Kingfisher.swift"; sourceTree = "<group>"; };
 		D1356CEA2B273AEC009554C8 /* Documentation.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Documentation.docc; sourceTree = "<group>"; };
 		D13646732165A1A100A33652 /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
 		D16CC3D524E02E9500F1A515 /* AVAssetImageDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AVAssetImageDataProvider.swift; sourceTree = "<group>"; };
@@ -400,6 +402,7 @@
 		D12AB6AB215D2BB50013BA68 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				D12F67652CB022EB00AB63AB /* PHLivePhotoView+Kingfisher.swift */,
 				D12EB83B24DD8EFC00329EE1 /* NSTextAttachment+Kingfisher.swift */,
 				D12AB6AC215D2BB50013BA68 /* ImageView+Kingfisher.swift */,
 				D12AB6AD215D2BB50013BA68 /* NSButton+Kingfisher.swift */,
@@ -886,6 +889,7 @@
 				D12AB724215D2BB50013BA68 /* Box.swift in Sources */,
 				4B8E291C216F40AA0095FAD1 /* AuthenticationChallengeResponsable.swift in Sources */,
 				3ADE9AF92A73CD69009A86CA /* String+SHA256.swift in Sources */,
+				D12F67662CB022FC00AB63AB /* PHLivePhotoView+Kingfisher.swift in Sources */,
 				D12AB710215D2BB50013BA68 /* KingfisherOptionsInfo.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		D1E56445219B16330057AAE3 /* ImageDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E56444219B16330057AAE3 /* ImageDataProvider.swift */; };
 		D1ED2D401AD2D09F00CFC3EB /* Kingfisher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D1ED2D351AD2D09F00CFC3EB /* Kingfisher.framework */; };
 		D1F1F6FF24625EC600910725 /* RetryStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F1F6FE24625EC600910725 /* RetryStrategyTests.swift */; };
+		D1F66CC12CB2CF2E004959F3 /* LivePhotoSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F66CC02CB2CF2D004959F3 /* LivePhotoSourceTests.swift */; };
 		D8FCF6A821C5A0E500F9ABC0 /* RedirectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FCF6A721C5A0E500F9ABC0 /* RedirectHandler.swift */; };
 		D9638BA61C7DC71F0046523D /* ImagePrefetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9638BA41C7DC71F0046523D /* ImagePrefetcherTests.swift */; };
 		E9E3ED8B2B1F66B200734CFF /* HasImageComponent+Kingfisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3ED8A2B1F66B200734CFF /* HasImageComponent+Kingfisher.swift */; };
@@ -301,6 +302,7 @@
 		D1ED2D351AD2D09F00CFC3EB /* Kingfisher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Kingfisher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D1ED2D3F1AD2D09F00CFC3EB /* KingfisherTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = KingfisherTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D1F1F6FE24625EC600910725 /* RetryStrategyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryStrategyTests.swift; sourceTree = "<group>"; };
+		D1F66CC02CB2CF2D004959F3 /* LivePhotoSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LivePhotoSourceTests.swift; sourceTree = "<group>"; };
 		D1F7607523097532000C5269 /* ImageBinder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageBinder.swift; sourceTree = "<group>"; };
 		D1F7607623097532000C5269 /* KFImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KFImage.swift; sourceTree = "<group>"; };
 		D8FCF6A721C5A0E500F9ABC0 /* RedirectHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedirectHandler.swift; sourceTree = "<group>"; };
@@ -491,6 +493,7 @@
 				4BCFF7A9219932390055AAC4 /* DiskStorageTests.swift */,
 				D1E564402199C21E0057AAE3 /* StorageExpirationTests.swift */,
 				D1A1CC9E21A0F98600263AD8 /* ImageDataProviderTests.swift */,
+				D1F66CC02CB2CF2D004959F3 /* LivePhotoSourceTests.swift */,
 				D1BFED94222ACC6B009330C8 /* ImageProcessorTests.swift */,
 				4BA3BF1D228BCDD100909201 /* DataReceivingSideEffectTests.swift */,
 				D1F1F6FE24625EC600910725 /* RetryStrategyTests.swift */,
@@ -921,6 +924,7 @@
 				D16FEA5023078C63006E67D5 /* NSString+Nocilla.m in Sources */,
 				D16FEA4E23078C63006E67D5 /* LSRegexMatcher.m in Sources */,
 				F72CE9CE1FCF17ED00CC522A /* ImageModifierTests.swift in Sources */,
+				D1F66CC12CB2CF2E004959F3 /* LivePhotoSourceTests.swift in Sources */,
 				D12E0C531C47F23500AC98AD /* ImageViewExtensionTests.swift in Sources */,
 				D16FEA4023078C63006E67D5 /* LSHTTPClientHook.m in Sources */,
 				D16FEA3F23078C63006E67D5 /* LSHTTPRequestDiff.m in Sources */,

--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -146,7 +146,9 @@ public enum DiskStorage {
             value: T,
             forKey key: String,
             expiration: StorageExpiration? = nil,
-            writeOptions: Data.WritingOptions = []) throws
+            writeOptions: Data.WritingOptions = [],
+            forcedExtension: String? = nil
+        ) throws
         {
             guard storageReady else {
                 throw KingfisherError.cacheError(reason: .diskStorageIsNotReady(cacheURL: directoryURL))
@@ -163,7 +165,7 @@ public enum DiskStorage {
                 throw KingfisherError.cacheError(reason: .cannotConvertToData(object: value, error: error))
             }
 
-            let fileURL = cacheFileURL(forKey: key)
+            let fileURL = cacheFileURL(forKey: key, forcedExtension: forcedExtension)
             do {
                 try data.write(to: fileURL, options: writeOptions)
             } catch {
@@ -215,22 +217,34 @@ public enum DiskStorage {
         ///   - extendingExpiration: The expiration policy used by this retrieval action.
         /// - Throws: An error during converting the data to a value or during the operation of disk files.
         /// - Returns: The value under `key` if it is valid and found in the storage; otherwise, `nil`.
-        public func value(forKey key: String, extendingExpiration: ExpirationExtending = .cacheTime) throws -> T? {
-            try value(forKey: key, referenceDate: Date(), actuallyLoad: true, extendingExpiration: extendingExpiration)
+        public func value(
+            forKey key: String,
+            forcedExtension: String? = nil,
+            extendingExpiration: ExpirationExtending = .cacheTime
+        ) throws -> T? {
+            try value(
+                forKey: key,
+                referenceDate: Date(),
+                actuallyLoad: true,
+                extendingExpiration: extendingExpiration,
+                forcedExtension: forcedExtension
+            )
         }
 
         func value(
             forKey key: String,
             referenceDate: Date,
             actuallyLoad: Bool,
-            extendingExpiration: ExpirationExtending) throws -> T?
+            extendingExpiration: ExpirationExtending,
+            forcedExtension: String?
+        ) throws -> T?
         {
             guard storageReady else {
                 throw KingfisherError.cacheError(reason: .diskStorageIsNotReady(cacheURL: directoryURL))
             }
 
             let fileManager = config.fileManager
-            let fileURL = cacheFileURL(forKey: key)
+            let fileURL = cacheFileURL(forKey: key, forcedExtension: forcedExtension)
             let filePath = fileURL.path
 
             let fileMaybeCached = maybeCachedCheckingQueue.sync {
@@ -276,8 +290,8 @@ public enum DiskStorage {
         ///
         /// > This method does not actually load the data from disk, so it is faster than directly loading the cached
         /// value by checking the nullability of the ``DiskStorage/Backend/value(forKey:extendingExpiration:)`` method.
-        public func isCached(forKey key: String) -> Bool {
-            return isCached(forKey: key, referenceDate: Date())
+        public func isCached(forKey key: String, forcedExtension: String? = nil) -> Bool {
+            return isCached(forKey: key, referenceDate: Date(), forcedExtension: forcedExtension)
         }
 
         /// Determines whether there is valid cached data under a given key and a reference date.
@@ -291,13 +305,14 @@ public enum DiskStorage {
         /// If you pass `Date()` as the `referenceDate`, this method is identical to
         /// ``DiskStorage/Backend/isCached(forKey:)``. Use the `referenceDate` to determine whether the cache is still
         /// valid for a future date.
-        public func isCached(forKey key: String, referenceDate: Date) -> Bool {
+        public func isCached(forKey key: String, referenceDate: Date, forcedExtension: String? = nil) -> Bool {
             do {
                 let result = try value(
                     forKey: key,
                     referenceDate: referenceDate,
                     actuallyLoad: false,
-                    extendingExpiration: .none
+                    extendingExpiration: .none,
+                    forcedExtension: forcedExtension
                 )
                 return result != nil
             } catch {
@@ -308,8 +323,8 @@ public enum DiskStorage {
         /// Removes a value from a specified key.
         /// - Parameter key: The cache key of the value.
         /// - Throws: An error during the removal of the value.
-        public func remove(forKey key: String) throws {
-            let fileURL = cacheFileURL(forKey: key)
+        public func remove(forKey key: String, forcedExtension: String? = nil) throws {
+            let fileURL = cacheFileURL(forKey: key, forcedExtension: forcedExtension)
             try removeFile(at: fileURL)
         }
 
@@ -338,23 +353,24 @@ public enum DiskStorage {
         ///
         /// This method does not guarantee that an image is already cached at the returned URL. It just provides the URL 
         /// where the image should be if it exists in the disk storage, with the given key.
-        public func cacheFileURL(forKey key: String) -> URL {
-            let fileName = cacheFileName(forKey: key)
+        public func cacheFileURL(forKey key: String, forcedExtension: String? = nil) -> URL {
+            let fileName = cacheFileName(forKey: key, forcedExtension: forcedExtension)
             return directoryURL.appendingPathComponent(fileName, isDirectory: false)
         }
-
-        func cacheFileName(forKey key: String) -> String {
+        
+        func cacheFileName(forKey key: String, forcedExtension: String? = nil) -> String {
+            // TODO: Bad code... Consider refactoring.
             if config.usesHashedFileName {
                 let hashedKey = key.kf.sha256
-                if let ext = config.pathExtension {
+                if let ext = forcedExtension ?? config.pathExtension {
                     return "\(hashedKey).\(ext)"
                 } else if config.autoExtAfterHashedFileName,
-                          let ext = key.kf.ext {
+                          let ext = forcedExtension ?? key.kf.ext {
                     return "\(hashedKey).\(ext)"
                 }
                 return hashedKey
             } else {
-                if let ext = config.pathExtension {
+                if let ext = forcedExtension ?? config.pathExtension {
                     return "\(key).\(ext)"
                 }
                 return key

--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -954,6 +954,14 @@ open class ImageCache: @unchecked Sendable {
         return diskStorage.cacheFileURL(forKey: computedKey).path
     }
     
+    open func cacheFileURLIfOnDisk(
+        forKey key: String,
+        processorIdentifier identifier: String = DefaultImageProcessor.default.identifier) -> URL?
+    {
+        let computedKey = key.computedKey(with: identifier)
+        return diskStorage.isCached(forKey: computedKey) ? diskStorage.cacheFileURL(forKey: computedKey) : nil
+    }
+    
     // MARK: - Concurrency
     
     /// Stores an image to the cache.

--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -396,6 +396,8 @@ open class ImageCache: @unchecked Sendable {
     ///   - key: The key used for caching the image.
     ///   - identifier: The identifier of the processor being used for caching. If you are using a processor for the 
     ///   image, pass the identifier of the processor to this parameter.
+    ///   - forcedExtension: The expected extension of the file. If `nil`, the file extension will be determined by the
+    ///   disk storage configuration instead.
     ///   - serializer: The ``CacheSerializer`` used to convert the `image` and `original` to the data that will be
     ///   stored to disk. By default, the ``DefaultCacheSerializer/default`` will be used.
     ///   - toDisk: Whether this image should be cached to disk or not. If `false`, the image is only cached in memory.
@@ -441,6 +443,22 @@ open class ImageCache: @unchecked Sendable {
         )
     }
     
+    /// Store some data to the disk.
+    /// 
+    /// - Parameters:
+    ///   - data: The data to be stored.
+    ///   - key: The key used for caching the data.
+    ///   - identifier: The identifier of the processor being used for caching. If you are using a processor for the
+    ///   image, pass the identifier of the processor to this parameter.
+    ///   - forcedExtension: The expected extension of the file. If `nil`, the file extension will be determined by the
+    ///   disk storage configuration instead.
+    ///   - expiration: The expiration policy used by this storage action.
+    ///   - callbackQueue: The callback queue on which the `completionHandler` is invoked. The default is
+    ///   ``CallbackQueue/untouch``. Under this default ``CallbackQueue/untouch`` queue, if `toDisk` is `false`, it
+    ///   means the `completionHandler` will be invoked from the caller queue of this method; if `toDisk` is `true`,
+    ///   the `completionHandler` will be called from an internal file IO queue. To change this behavior, specify
+    ///   another ``CallbackQueue`` value.
+    ///   - completionHandler: A closure that is invoked when the cache operation finishes.
     open func storeToDisk(
         _ data: Data,
         forKey key: String,
@@ -510,6 +528,8 @@ open class ImageCache: @unchecked Sendable {
     ///   - key: The key used for caching the image.
     ///   - identifier: The identifier of the processor being used for caching. If you are using a processor for the 
     ///   image, pass the identifier of the processor to this parameter.
+    ///   - forcedExtension: The expected extension of the file. If `nil`, the file extension will be determined by the
+    ///   disk storage configuration instead.
     ///   - fromMemory: Whether this image should be removed from memory storage or not. If `false`, the image won't be 
     ///   removed from the memory storage. The default is `true`.
     ///   - fromDisk: Whether this image should be removed from the disk storage or not. If `false`, the image won't be
@@ -888,6 +908,9 @@ open class ImageCache: @unchecked Sendable {
     ///   - key: The key used for caching the image.
     ///   - identifier: The processor identifier used for this image. The default value is the
     ///    ``DefaultImageProcessor/identifier`` of the ``DefaultImageProcessor/default`` image processor.
+    ///   - forcedExtension: The expected extension of the file. If `nil`, the file extension will be determined by the
+    ///   disk storage configuration instead.
+    /// 
     /// - Returns: A ``CacheType`` instance that indicates the cache status. ``CacheType/none`` indicates that the
     /// image is not in the cache or that it has already expired.
     open func imageCachedType(
@@ -908,6 +931,9 @@ open class ImageCache: @unchecked Sendable {
     ///   - key: The key used for caching the image.
     ///   - identifier: The processor identifier used for this image. The default value is the
     ///    ``DefaultImageProcessor/identifier`` of the ``DefaultImageProcessor/default`` image processor.
+    ///   - forcedExtension: The expected extension of the file. If `nil`, the file extension will be determined by the
+    ///   disk storage configuration instead.
+    ///
     /// - Returns: A `Bool` value indicating whether a cache matches the given `key` and `identifier` combination.
     ///
     /// > The return value does not contain information about the kind of storage the cache matches from.
@@ -928,6 +954,9 @@ open class ImageCache: @unchecked Sendable {
     ///   - key: The key used for caching the image.
     ///   - identifier: The processor identifier used for this image. The default value is the
     ///    ``DefaultImageProcessor/identifier`` of the ``DefaultImageProcessor/default`` image processor.
+    ///   - forcedExtension: The expected extension of the file. If `nil`, the file extension will be determined by the
+    ///   disk storage configuration instead.
+    /// 
     /// - Returns: The hash used as the cache file name.
     ///
     /// > By default, for a given combination of `key` and `identifier`, the ``ImageCache`` instance uses the value
@@ -972,6 +1001,9 @@ open class ImageCache: @unchecked Sendable {
     ///   - key: The key used for caching the image.
     ///   - identifier: The processor identifier used for this image. The default value is the
     ///    ``DefaultImageProcessor/identifier`` of the ``DefaultImageProcessor/default`` image processor.
+    ///   - forcedExtension: The expected extension of the file. If `nil`, the file extension will be determined by the
+    ///   disk storage configuration instead.
+    /// 
     /// - Returns: The disk path of the cached image under the given `key` and `identifier`.
     ///
     /// > This method does not guarantee that there is an image already cached in the returned path. It simply provides
@@ -989,6 +1021,14 @@ open class ImageCache: @unchecked Sendable {
         return diskStorage.cacheFileURL(forKey: computedKey, forcedExtension: forcedExtension).path
     }
     
+    /// Returns the file URL if a disk cache file is existing for the target key, identifier and forcedExtension
+    /// combination. Otherwise, if the requested cache value is not on the disk as a file, `nil`.
+    ///
+    /// - Parameters:
+    ///   - key: The key used for caching the item.
+    ///   - identifier: The processor identifier used for this image. It involves into calculating the final cache key.
+    ///   - forcedExtension: The expected extension of the file.
+    /// - Returns: The file URL if a disk cache file is existing for the combination. Otherwise, `nil`.
     open func cacheFileURLIfOnDisk(
         forKey key: String,
         processorIdentifier identifier: String = DefaultImageProcessor.default.identifier,

--- a/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
+++ b/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
@@ -73,7 +73,7 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
         with source: LivePhotoSource?,
         placeholder: KFCrossPlatformImage? = nil,
         options: KingfisherOptionsInfo? = nil,
-        progressBlock: DownloadProgressBlock? = nil,
+        // progressBlock: DownloadProgressBlock? = nil, // Not supported yet
         completionHandler: (@MainActor @Sendable (Result<RetrieveLivePhotoResult, KingfisherError>) -> Void)? = nil
     ) -> Task<(), Never>? {
         var mutatingSelf = self
@@ -96,12 +96,16 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
         
         let taskIdentifierChecking = { issuedIdentifier == self.taskIdentifier }
 
+        // Copy these associated values in case of re-entry.
+        let targetSize = targetSize
+        let contentMode = contentMode
+        
         let task = Task { @MainActor in
             do {
                 let loadingInfo = try await KingfisherManager.shared.retrieveLivePhoto(
                     with: source,
                     options: options,
-                    progressBlock: progressBlock,
+                    progressBlock: nil, // progressBlock, // Not supported yet
                     referenceTaskIdentifierChecker: taskIdentifierChecking
                 )
                 if let notCurrentTaskError = self.checkNotCurrentTask(
@@ -119,9 +123,7 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
                     placeholderImage: placeholder,
                     targetSize: targetSize,
                     contentMode: contentMode,
-                    resultHandler: {
-                        livePhoto,
-                        info in
+                    resultHandler: { livePhoto, info in
                         let result = RetrieveLivePhotoResult(
                             loadingInfo: loadingInfo,
                             livePhoto: livePhoto,

--- a/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
+++ b/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
@@ -92,18 +92,83 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
         set { setRetainedAssociatedObject(base, &contentModeKey, newValue) }
     }
     
-    /// Sets a live photo to the view with a `LivePhotoSource`.
+    /// Sets a live photo to the view with an array of `URL`.
     ///
     /// - Parameters:
-    ///   - source: The `LivePhotoSource` object defining the live photo resource.
+    ///   - urls: The `URL`s defining the live photo resource. It should contains two URLs, one for the still image and
+    ///     one for the video.
+    ///   - options: An options set to define image setting behaviors. See ``KingfisherOptionsInfo`` for more.
+    ///   - completionHandler: Called when the image setting process finishes.
+    /// - Returns: A task represents the image downloading.
+    ///            The return value will be `nil` if the image is set with a empty source.
+    ///
+    /// - Note: Not all options in ``KingfisherOptionsInfo`` are supported in this method, for example, the live photo
+    /// does not support any custom processors. Different from the extension method for a normal image view on the
+    /// platform, the `placeholder` and `progressBlock` are not supported yet, and will be implemented in the future.
+    /// 
+    /// - Note: To get refined control of the resources, use the ``setImage(with:options:completionHandler:)-1n4p2``
+    /// method with a ``LivePhotoSource`` object.
+    ///
+    /// Sample:
+    /// ```swift
+    /// let urls = [
+    ///   URL(string: "https://example.com/image.heic")!, // imageURL
+    ///   URL(string: "https://example.com/video.mov")!   // videoURL
+    /// ]
+    /// let livePhotoView = PHLivePhotoView()
+    /// livePhotoView.kf.setImage(with: urls) { result in
+    ///   switch result {
+    ///   case .success(let retrieveResult):
+    ///     print("Live photo loaded: \(retrieveResult.livePhoto).")
+    ///     print("Cache type: \(retrieveResult.loadingInfo.cacheType).")
+    ///   case .failure(let error):
+    ///     print("Error: \(error)")
+    /// }
+    /// ```
+    @discardableResult
+    public func setImage(
+        with urls: [URL],
+        // placeholder: KFCrossPlatformImage? = nil, // Not supported yet
+        options: KingfisherOptionsInfo? = nil,
+        // progressBlock: DownloadProgressBlock? = nil, // Not supported yet
+        completionHandler: (@MainActor @Sendable (Result<RetrieveLivePhotoResult, KingfisherError>) -> Void)? = nil
+    ) -> Task<(), Never>? {
+        setImage(
+            with: LivePhotoSource(urls: urls),
+            options: options,
+            completionHandler: completionHandler
+        )
+    }
+    
+    /// Sets a live photo to the view with a ``LivePhotoSource``.
+    ///
+    /// - Parameters:
+    ///   - source: The ``LivePhotoSource`` object defining the live photo resource.
     ///   - options: An options set to define image setting behaviors. See `KingfisherOptionsInfo` for more.
     ///   - completionHandler: Called when the image setting process finishes.
     /// - Returns: A task represents the image downloading.
     ///            The return value will be `nil` if the image is set with a empty source.
     ///
-    /// - Note: Not all options in `KingfisherOptionsInfo` are supported in this method, for example, the live photo
-    /// does not support any custom processors. Different from the extension method for a normal image view on the 
+    /// - Note: Not all options in ``KingfisherOptionsInfo`` are supported in this method, for example, the live photo
+    /// does not support any custom processors. Different from the extension method for a normal image view on the
     /// platform, the `placeholder` and `progressBlock` are not supported yet, and will be implemented in the future.
+    /// 
+    /// Sample:
+    /// ```swift
+    /// let source = LivePhotoSource(urls: [
+    ///   URL(string: "https://example.com/image.heic")!, // imageURL
+    ///   URL(string: "https://example.com/video.mov")!   // videoURL
+    /// ])
+    /// let livePhotoView = PHLivePhotoView()
+    /// livePhotoView.kf.setImage(with: source) { result in 
+    ///   switch result {
+    ///   case .success(let retrieveResult):
+    ///     print("Live photo loaded: \(retrieveResult.livePhoto).")
+    ///     print("Cache type: \(retrieveResult.loadingInfo.cacheType).")
+    ///   case .failure(let error):
+    ///     print("Error: \(error)")
+    /// }
+    /// ```
     @discardableResult
     public func setImage(
         with source: LivePhotoSource?,

--- a/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
+++ b/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
@@ -109,7 +109,8 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
     /// - Note: To get refined control of the resources, use the ``setImage(with:options:completionHandler:)-1n4p2``
     /// method with a ``LivePhotoSource`` object.
     ///
-    /// Sample:
+    /// Example:
+    /// 
     /// ```swift
     /// let urls = [
     ///   URL(string: "https://example.com/image.heic")!, // imageURL

--- a/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
+++ b/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
@@ -1,0 +1,195 @@
+//
+//  PHLivePhotoView+Kingfisher.swift
+//  Kingfisher
+//
+//  Created by onevcat on 2024/10/04.
+//
+//  Copyright (c) 2024 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+@preconcurrency import PhotosUI
+
+public struct RetrieveLivePhotoResult: @unchecked Sendable {
+    public let loadingInfo: LivePhotoLoadingInfoResult
+    public let livePhoto: PHLivePhoto?
+    
+    // According to "Result Handler Info Dictionary Keys", we can trust the `info` in handler is sendable.
+    // https://developer.apple.com/documentation/photokit/phlivephoto/result_handler_info_dictionary_keys
+    public let info: [AnyHashable : Any]?
+}
+
+@MainActor private var taskIdentifierKey: Void?
+@MainActor private var targetSizeKey: Void?
+@MainActor private var contentModeKey: Void?
+
+@MainActor
+extension KingfisherWrapper where Base: PHLivePhotoView {
+    
+    public private(set) var taskIdentifier: Source.Identifier.Value? {
+        get {
+            let box: Box<Source.Identifier.Value>? = getAssociatedObject(base, &taskIdentifierKey)
+            return box?.value
+        }
+        set {
+            let box = newValue.map { Box($0) }
+            setRetainedAssociatedObject(base, &taskIdentifierKey, box)
+        }
+    }
+    
+    public var targetSize: CGSize {
+        get { getAssociatedObject(base, &targetSizeKey) ?? .zero }
+        set { setRetainedAssociatedObject(base, &targetSizeKey, newValue) }
+    }
+    
+    public var contentMode: PHImageContentMode {
+        get { getAssociatedObject(base, &contentModeKey) ?? .default }
+        set { setRetainedAssociatedObject(base, &contentModeKey, newValue) }
+    }
+    
+    @discardableResult
+    public func setImage(
+        with source: LivePhotoSource?,
+        placeholder: KFCrossPlatformImage? = nil,
+        options: KingfisherOptionsInfo? = nil,
+        progressBlock: DownloadProgressBlock? = nil,
+        completionHandler: (@MainActor @Sendable (Result<RetrieveLivePhotoResult, KingfisherError>) -> Void)? = nil
+    ) -> Task<(), Never>? {
+        var mutatingSelf = self
+        guard let source = source else {
+            PHLivePhoto.request(
+                withResourceFileURLs: [],
+                placeholderImage: placeholder,
+                targetSize: .zero,
+                contentMode: .default
+            ) { photo, _ in
+                base.livePhoto = photo
+            }
+            mutatingSelf.taskIdentifier = nil
+            completionHandler?(.failure(KingfisherError.imageSettingError(reason: .emptySource)))
+            return nil
+        }
+        
+        let issuedIdentifier = Source.Identifier.next()
+        mutatingSelf.taskIdentifier = issuedIdentifier
+        
+        let taskIdentifierChecking = { issuedIdentifier == self.taskIdentifier }
+
+        let task = Task { @MainActor in
+            do {
+                let loadingInfo = try await KingfisherManager.shared.retrieveLivePhoto(
+                    with: source,
+                    options: options,
+                    progressBlock: progressBlock,
+                    referenceTaskIdentifierChecker: taskIdentifierChecking
+                )
+                if let notCurrentTaskError = self.checkNotCurrentTask(
+                    issuedIdentifier: issuedIdentifier,
+                    result: .init(loadingInfo: loadingInfo, livePhoto: nil, info: nil),
+                    error: nil,
+                    source: source
+                ) {
+                    completionHandler?(.failure(notCurrentTaskError))
+                    return
+                }
+                
+                PHLivePhoto.request(
+                    withResourceFileURLs: loadingInfo.fileURLs,
+                    placeholderImage: placeholder,
+                    targetSize: targetSize,
+                    contentMode: contentMode,
+                    resultHandler: {
+                        livePhoto,
+                        info in
+                        let result = RetrieveLivePhotoResult(
+                            loadingInfo: loadingInfo,
+                            livePhoto: livePhoto,
+                            info: info
+                        )
+                        
+                        if let notCurrentTaskError = self.checkNotCurrentTask(
+                            issuedIdentifier: issuedIdentifier,
+                            result: result,
+                            error: nil,
+                            source: source
+                        ) {
+                            completionHandler?(.failure(notCurrentTaskError))
+                            return
+                        }
+                        
+                        base.livePhoto = livePhoto
+                        
+                        if let error = info[PHLivePhotoInfoErrorKey] as? NSError {
+                            let failingReason: KingfisherError.ImageSettingErrorReason =
+                                .livePhotoResultError(result: result, error: error, source: source)
+                            completionHandler?(.failure(.imageSettingError(reason: failingReason)))
+                            return
+                        }
+                        
+                        if info.keys.contains(PHLivePhotoInfoCancelledKey) {
+                            let cancelled = (info[PHLivePhotoInfoCancelledKey] as? NSNumber)?.boolValue ?? false
+                            if cancelled {
+                                completionHandler?(.failure(
+                                    .requestError(reason: .livePhotoTaskCancelled(source: source)))
+                                )
+                                return
+                            }
+                        }
+                            
+                        completionHandler?(.success(result))
+                    }
+                )
+            } catch {
+                if let notCurrentTaskError = self.checkNotCurrentTask(
+                    issuedIdentifier: issuedIdentifier,
+                    result: nil,
+                    error: error,
+                    source: source
+                ) {
+                    completionHandler?(.failure(notCurrentTaskError))
+                    return
+                }
+                
+                if let kfError = error as? KingfisherError {
+                    completionHandler?(.failure(kfError))
+                } else if error is CancellationError {
+                    completionHandler?(.failure(.requestError(reason: .livePhotoTaskCancelled(source: source))))
+                } else {
+                    completionHandler?(.failure(.imageSettingError(
+                        reason: .livePhotoResultError(result: nil, error: error, source: source)))
+                    )
+                }
+            }
+        }
+        
+        return task
+    }
+    
+    private func checkNotCurrentTask(
+        issuedIdentifier: Source.Identifier.Value,
+        result: RetrieveLivePhotoResult?,
+        error: (any Error)?,
+        source: LivePhotoSource
+    ) -> KingfisherError? {
+        if issuedIdentifier == self.taskIdentifier {
+            return nil
+        }
+        return .imageSettingError(reason: .notCurrentLivePhotoSourceTask(result: result, error: error, source: source))
+    }
+}

--- a/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
+++ b/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
@@ -24,6 +24,11 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if os(watchOS)
+// Only a placeholder.
+public struct RetrieveLivePhotoResult: @unchecked Sendable {
+}
+#else
 @preconcurrency import PhotosUI
 
 public struct RetrieveLivePhotoResult: @unchecked Sendable {
@@ -193,3 +198,4 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
         return .imageSettingError(reason: .notCurrentLivePhotoSourceTask(result: result, error: error, source: source))
     }
 }
+#endif

--- a/Sources/General/ImageSource/ImageDataProvider.swift
+++ b/Sources/General/ImageSource/ImageDataProvider.swift
@@ -52,6 +52,14 @@ public protocol ImageDataProvider: Sendable {
     var contentURL: URL? { get }
 }
 
+extension ImageDataProvider {
+    func data() async throws -> Data {
+        try await withCheckedThrowingContinuation { continuation in
+            data(handler: { continuation.resume(with: $0) })
+        }
+    }
+}
+
 public extension ImageDataProvider {
     var contentURL: URL? { return nil }
     func convertToSource() -> Source {

--- a/Sources/General/ImageSource/LivePhotoSource.swift
+++ b/Sources/General/ImageSource/LivePhotoSource.swift
@@ -28,7 +28,7 @@ import Foundation
 
 public struct LivePhotoResource: Sendable {
     
-    public enum FileType: Sendable {
+    public enum FileType: Sendable, Equatable {
         case heic
         case mov
         case other(String)
@@ -79,7 +79,7 @@ extension LivePhotoResource.FileType {
     
     static func guessedFileExtension(from data: Data) -> String? {
         
-        guard data.count > 12 else { return nil }
+        guard data.count >= 12 else { return nil }
         
         var buffer = [UInt8](repeating: 0, count: 12)
         data.copyBytes(to: &buffer, count: 12)

--- a/Sources/General/ImageSource/LivePhotoSource.swift
+++ b/Sources/General/ImageSource/LivePhotoSource.swift
@@ -1,0 +1,40 @@
+//
+//  LivePhotoSource.swift
+//  Kingfisher
+//
+//  Created by onevcat on 2024/10/01.
+//
+//  Copyright (c) 2024 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+public struct LivePhotoSource: Sendable {
+    
+    public let resources: [any Resource]
+    
+    public init(resources: [any Resource]) {
+        self.resources = resources
+    }
+    
+    public init(urls: [URL]) {
+        self.resources = urls.map { KF.ImageResource(downloadURL: $0) }
+    }
+}

--- a/Sources/General/ImageSource/LivePhotoSource.swift
+++ b/Sources/General/ImageSource/LivePhotoSource.swift
@@ -26,11 +26,26 @@
 
 import Foundation
 
+/// A resource type representing a component of a Live Photo, which consists of a still image and a video.
+///
+/// ``LivePhotoResource`` encapsulates the necessary information to download and cache a single components of a Live
+/// Photo: it is either a still image (typically in HEIC format) or a video (typically in MOV format). Multiple
+/// ``LivePhotoResource`` values (typically two, one for the image and one for the video) can form a ``LivePhotoSource``,
+/// which is expected by Kingfisher in its live photo loading high level APIs.
+///
+/// The Live Photo data can be retrieved by `PHAssetResourceManager.requestData` method and uploaded to your server.
+/// You should not modify the metadata or other information of the data, otherwise, it is possible that the
+/// `PHLivePhoto` class cannot read and recognize it anymore. For more information, please refer to Apple's
+/// documentation of Photos framework.
 public struct LivePhotoResource: Sendable {
     
+    /// The file type of a ``LivePhotoResource``.
     public enum FileType: Sendable, Equatable {
+        /// File type HEIC. Usually it represents the still image in a Live Photo.
         case heic
+        /// File type MOV. Usually it represents the video in a Live Photo.
         case mov
+        /// Other file types with the file extension.
         case other(String)
         
         var fileExtension: String {
@@ -40,7 +55,6 @@ public struct LivePhotoResource: Sendable {
             case .other(let ext): return ext
             }
         }
-        
     }
     
     public let resource: any Resource

--- a/Sources/General/ImageSource/LivePhotoSource.swift
+++ b/Sources/General/ImageSource/LivePhotoSource.swift
@@ -31,6 +31,7 @@ public struct LivePhotoResource: Sendable {
     public enum FileType: Sendable {
         case heic
         case mov
+        case other(String)
     }
     
     public let resource: any Resource
@@ -53,12 +54,10 @@ public struct LivePhotoResource: Sendable {
 extension Resource {
     var guessedFileType: LivePhotoResource.FileType {
         let pathExtension = downloadURL.pathExtension.lowercased()
-        switch pathExtension {
-        case "mov": return .mov
-        case "heic": return .heic
-        default:
-            assertionFailure("Explicit file type is necessary in the download URL as its extension. Otherwise, set the file type of the LivePhoto resource manually with `LivePhotoSource.init(resources:)`.")
-            return .heic
+        return switch pathExtension {
+        case "mov": .mov
+        case "heic": .heic
+        default: .other(pathExtension)
         }
     }
 }

--- a/Sources/General/ImageSource/LivePhotoSource.swift
+++ b/Sources/General/ImageSource/LivePhotoSource.swift
@@ -57,19 +57,20 @@ public struct LivePhotoResource: Sendable {
         }
     }
     
-    public let resource: any Resource
+    public let dataSource: Source
     public let referenceFileType: FileType
     
-    var cacheKey: String { resource.cacheKey }
-    var downloadURL: URL { resource.downloadURL }
+    var cacheKey: String { dataSource.cacheKey }
+    var downloadURL: URL? { dataSource.url }
     
     public init(downloadURL: URL, cacheKey: String? = nil, fileType: FileType? = nil) {
-        resource = KF.ImageResource(downloadURL: downloadURL, cacheKey: cacheKey)
+        let resource = KF.ImageResource(downloadURL: downloadURL, cacheKey: cacheKey)
+        dataSource = .network(resource)
         referenceFileType = fileType ?? resource.guessedFileType
     }
     
     public init(resource: any Resource, fileType: FileType? = nil) {
-        self.resource = resource
+        self.dataSource = .network(resource)
         referenceFileType = fileType ?? resource.guessedFileType
     }
 }

--- a/Sources/General/ImageSource/LivePhotoSource.swift
+++ b/Sources/General/ImageSource/LivePhotoSource.swift
@@ -32,6 +32,15 @@ public struct LivePhotoResource: Sendable {
         case heic
         case mov
         case other(String)
+        
+        var fileExtension: String {
+            switch self {
+            case .heic: return "heic"
+            case .mov: return "mov"
+            case .other(let ext): return ext
+            }
+        }
+        
     }
     
     public let resource: any Resource

--- a/Sources/General/Kingfisher.swift
+++ b/Sources/General/Kingfisher.swift
@@ -114,6 +114,12 @@ extension NSTextAttachment          : KingfisherCompatible { }
 extension WKInterfaceImage          : KingfisherCompatible { }
 #endif
 
+#if canImport(PhotosUI)
+import PhotosUI
+extension PHLivePhotoView           : KingfisherCompatible { }
+#endif
+
+
 #if os(tvOS) && canImport(TVUIKit)
 @available(tvOS 12.0, *)
 extension TVMonogramView            : KingfisherCompatible { }

--- a/Sources/General/Kingfisher.swift
+++ b/Sources/General/Kingfisher.swift
@@ -114,7 +114,7 @@ extension NSTextAttachment          : KingfisherCompatible { }
 extension WKInterfaceImage          : KingfisherCompatible { }
 #endif
 
-#if canImport(PhotosUI)
+#if canImport(PhotosUI) && !os(watchOS)
 import PhotosUI
 extension PHLivePhotoView           : KingfisherCompatible { }
 #endif

--- a/Sources/General/KingfisherError.swift
+++ b/Sources/General/KingfisherError.swift
@@ -578,7 +578,7 @@ extension KingfisherError.CacheErrorReason {
             return "The disk storage is not ready to use yet at URL: '\(cacheURL)'. " +
                 "This is usually caused by extremely lack of disk space. Ask users to free up some space and restart the app."
         case .missingLivePhotoResourceOnDisk(let resource):
-            return "The live photo resource '\(resource.downloadURL)' is missing in the cache. Usually a re-download" +
+            return "The live photo resource '\(resource)' is missing in the cache. Usually a re-download" +
             " can fix this issue."
         }
     }

--- a/Sources/General/KingfisherError.swift
+++ b/Sources/General/KingfisherError.swift
@@ -66,6 +66,14 @@ public enum KingfisherError: Error {
         ///
         /// Error Code: 1003
         case taskCancelled(task: SessionDataTask, token: SessionDataTask.CancelToken)
+
+        /// The live photo downloading task is canceled by the user.
+        ///
+        /// - Parameters:
+        ///   - source: The live phot source.
+        ///
+        /// Error Code: 1004
+        case livePhotoTaskCancelled(source: LivePhotoSource)
     }
     
     /// Represents the error reason during networking response phase.
@@ -296,6 +304,44 @@ public enum KingfisherError: Error {
         ///
         /// Error Code: 5004
         case alternativeSourcesExhausted([PropagationError])
+        
+        /// The resource task is completed, but it is not the one that was expected. This typically occurs when you set
+        /// another resource on the view without canceling the current ongoing task. The previous task will fail with the
+        /// `.notCurrentLivePhotoSourceTask` error when a result is obtained, regardless of whether it was successful or
+        /// not for that task.
+        ///
+        /// This error is the live photo version of the `.notCurrentSourceTask` error (error 5002).
+        ///
+        /// - Parameters:
+        ///   - result: The `RetrieveImageResult` if the source task is completed without any issues. `nil` if an error occurred.
+        ///   - error: The `Error` if there was a problem during the image setting task. `nil` if the task completed successfully.
+        ///   - source: The original source value of the task.
+        ///
+        /// Error Code: 5005
+        case notCurrentLivePhotoSourceTask(
+            result: RetrieveLivePhotoResult?, error: (any Error)?, source: LivePhotoSource
+        )
+        
+        /// The error happens during processing the live photo.
+        ///
+        /// When creating the final `PHLivePhoto` object from the downloaded image files, the internal Photos framework
+        /// method `PHLivePhoto.request(withResourceFileURLs:placeholderImage:targetSize:contentMode:resultHandler:)`
+        /// invokes its `resultHandler`. If the `info` dictionary in `resultHandler` contains `PHLivePhotoInfoErrorKey`,
+        /// Kingfisher raises this error reason to pass the information to outside.
+        ///
+        /// If the processing fails due to any error that is not a `KingfisherError` case, Kingfisher also reports it
+        /// with this reason.
+        ///
+        /// - Parameters:
+        ///   - result: The `RetrieveLivePhotoResult` if the source task is completed and a result is already existing.
+        ///   - error: The `NSError` if `PHLivePhotoInfoErrorKey` is contained in the `resultHandler` info dictionary.
+        ///   - source: The original source value of the task.
+        ///
+        /// - Note: It is possible that both `result` and `error` are non-nil value. Check the
+        /// ``RetrieveLivePhotoResult/info`` property for the raw values that are from the Photos framework.
+        ///
+        /// Error Code: 5006
+        case livePhotoResultError(result: RetrieveLivePhotoResult?, error: (any Error)?, source: LivePhotoSource)
     }
 
     // MARK: Member Cases
@@ -445,6 +491,8 @@ extension KingfisherError.RequestErrorReason {
             return "The request contains an invalid or empty URL. Request: \(request)."
         case .taskCancelled(let task, let token):
             return "The session task was cancelled. Task: \(task), cancel token: \(token)."
+        case .livePhotoTaskCancelled(let source):
+            return "The live photo download task was cancelled. Source: \(source)"
         }
     }
     
@@ -453,6 +501,7 @@ extension KingfisherError.RequestErrorReason {
         case .emptyRequest: return 1001
         case .invalidURL: return 1002
         case .taskCancelled: return 1003
+        case .livePhotoTaskCancelled: return 1004
         }
     }
 }
@@ -575,6 +624,19 @@ extension KingfisherError.ImageSettingErrorReason {
             return "Image data provider fails to provide data. Provider: \(provider), error: \(error)"
         case .alternativeSourcesExhausted(let errors):
             return "Image setting from alternative sources failed: \(errors)"
+        case .notCurrentLivePhotoSourceTask(let result, let error, let source):
+            if let result = result {
+                return "Retrieving live photo resource succeeded, but this source is " +
+                "not the one currently expected. Result: \(result). Resource: \(source)."
+            } else if let error = error {
+                return "Retrieving live photo resource failed, and this resource is " +
+                "not the one currently expected. Error: \(error). Resource: \(source)."
+            } else {
+                return nil
+            }
+        case .livePhotoResultError(let result, let error, let source):
+            return "An error occurred while processing live photo. Source: \(source). " +
+                   "Result: \(String(describing: result)). Error: \(String(describing: error))"
         }
     }
     
@@ -584,6 +646,8 @@ extension KingfisherError.ImageSettingErrorReason {
         case .notCurrentSourceTask: return 5002
         case .dataProviderError: return 5003
         case .alternativeSourcesExhausted: return 5004
+        case .notCurrentLivePhotoSourceTask: return 5005
+        case .livePhotoResultError: return 5006
         }
     }
 }

--- a/Sources/General/KingfisherError.swift
+++ b/Sources/General/KingfisherError.swift
@@ -243,6 +243,13 @@ public enum KingfisherError: Error {
         ///
         /// Error Code: 3011
         case diskStorageIsNotReady(cacheURL: URL)
+        
+        /// The resource is expected on the disk, but now missing for some reason.
+        ///
+        /// This happens when the expected resource is not on the disk for some reason during loading a live photo.
+        ///
+        /// Error Code: 3012
+        case missingLivePhotoResourceOnDisk(_ resource: LivePhotoResource)
     }
     
     /// Represents the error reason during image processing phase.
@@ -570,6 +577,9 @@ extension KingfisherError.CacheErrorReason {
         case .diskStorageIsNotReady(let cacheURL):
             return "The disk storage is not ready to use yet at URL: '\(cacheURL)'. " +
                 "This is usually caused by extremely lack of disk space. Ask users to free up some space and restart the app."
+        case .missingLivePhotoResourceOnDisk(let resource):
+            return "The live photo resource '\(resource.downloadURL)' is missing in the cache. Usually a re-download" +
+            " can fix this issue."
         }
     }
     
@@ -586,6 +596,7 @@ extension KingfisherError.CacheErrorReason {
         case .cannotCreateCacheFile: return 3009
         case .cannotSetCacheFileAttribute: return 3010
         case .diskStorageIsNotReady: return 3011
+        case .missingLivePhotoResourceOnDisk: return 3012
         }
     }
 }

--- a/Sources/General/KingfisherManager+LivePhoto.swift
+++ b/Sources/General/KingfisherManager+LivePhoto.swift
@@ -90,11 +90,7 @@ extension KingfisherManager {
         
         let targetCache = checkedOptions.targetCache ?? cache
         let fileURLs = source.resources.map {
-            targetCache.possibleCacheFileURLIfOnDisk(
-                forKey: $0.cacheKey,
-                processorIdentifier: checkedOptions.processor.identifier,
-                referenceFileType: $0.referenceFileType
-            )
+            targetCache.possibleCacheFileURLIfOnDisk(resource: $0, options: checkedOptions)
         }
         if fileURLs.contains(nil) {
             // not all file done. throw error
@@ -116,13 +112,8 @@ extension KingfisherManager {
         } else {
             let targetCache = options.targetCache ?? cache
             missingResources = source.resources.reduce([], { r, resource in
-                let cacheKey = resource.cacheKey
-                let existingCachedFileURL = targetCache.possibleCacheFileURLIfOnDisk(
-                    forKey: cacheKey,
-                    processorIdentifier: options.processor.identifier,
-                    referenceFileType: resource.referenceFileType
-                )
-                if existingCachedFileURL == nil {
+                let cachedFileURL = targetCache.possibleCacheFileURLIfOnDisk(resource: resource, options: options)
+                if cachedFileURL == nil {
                     return r + [resource]
                 } else {
                     return r
@@ -171,6 +162,18 @@ extension KingfisherManager {
 }
 
 extension ImageCache {
+    
+    func possibleCacheFileURLIfOnDisk(
+        resource: LivePhotoResource,
+        options: KingfisherParsedOptionsInfo
+    ) -> URL? {
+        possibleCacheFileURLIfOnDisk(
+            forKey: resource.cacheKey,
+            processorIdentifier: options.processor.identifier,
+            referenceFileType: resource.referenceFileType
+        )
+    }
+    
     func possibleCacheFileURLIfOnDisk(
         forKey key: String,
         processorIdentifier identifier: String,

--- a/Sources/General/KingfisherManager+LivePhoto.swift
+++ b/Sources/General/KingfisherManager+LivePhoto.swift
@@ -173,11 +173,22 @@ extension KingfisherManager {
             
             for resource in resources {
                 group.addTask {
-                    let downloadedResource = try await downloader.downloadLivePhotoResource(
-                        with: resource.downloadURL,
-                        options: options
-                    )
-
+                    
+                    let downloadedResource: LivePhotoResourceDownloadingResult
+                    
+                    switch resource.dataSource {
+                    case .network(let urlResource):
+                        downloadedResource = try await downloader.downloadLivePhotoResource(
+                            with: urlResource.downloadURL,
+                            options: options
+                        )
+                    case .provider(let provider):
+                        downloadedResource = try await LivePhotoResourceDownloadingResult(
+                            originalData: provider.data(),
+                            url: provider.contentURL
+                        )
+                    }
+                     
                     // We need to specify the extension so the file is saved correctly. Live photo loading requires
                     // the file extension to be correct. Otherwise, a 3302 error will be thrown.
                     // https://developer.apple.com/documentation/photokit/phphotoserror/code/invalidresource

--- a/Sources/General/KingfisherManager+LivePhoto.swift
+++ b/Sources/General/KingfisherManager+LivePhoto.swift
@@ -91,7 +91,8 @@ extension KingfisherManager {
         let fileURLs = source.resources.map {
             targetCache.cacheFileURLIfOnDisk(
                 forKey: $0.cacheKey,
-                processorIdentifier: checkedOptions.processor.identifier
+                processorIdentifier: checkedOptions.processor.identifier,
+                forcedExtension: $0.referenceFileType.determinedFileExtension(.init())
             )
         }
         if fileURLs.contains(nil) {
@@ -117,7 +118,8 @@ extension KingfisherManager {
                 let cacheKey = resource.cacheKey
                 let existingCachedFileURL = targetCache.cacheFileURLIfOnDisk(
                     forKey: cacheKey,
-                    processorIdentifier: options.processor.identifier
+                    processorIdentifier: options.processor.identifier,
+                    forcedExtension: resource.referenceFileType.determinedFileExtension(.init())
                 )
                 if existingCachedFileURL == nil {
                     return r + [resource]

--- a/Sources/General/KingfisherManager+LivePhoto.swift
+++ b/Sources/General/KingfisherManager+LivePhoto.swift
@@ -26,7 +26,7 @@
 
 @preconcurrency import Photos
 
-public struct RetrieveLivePhotoResult: Sendable {
+public struct LivePhotoLoadingInfoResult: Sendable {
     
     /// Retrieves the live photo disk URLs from this result.
     public let fileURLs: [URL]
@@ -64,7 +64,7 @@ extension KingfisherManager {
         options: KingfisherOptionsInfo? = nil,
         progressBlock: DownloadProgressBlock? = nil,
         referenceTaskIdentifierChecker: (() -> Bool)? = nil
-    ) async throws -> RetrieveLivePhotoResult {
+    ) async throws -> LivePhotoLoadingInfoResult {
         let fullOptions = currentDefaultOptions + (options ?? .empty)
         var checkedOptions = KingfisherParsedOptionsInfo(fullOptions)
         
@@ -97,7 +97,7 @@ extension KingfisherManager {
         if fileURLs.contains(nil) {
             // not all file done. throw error
         }
-        return RetrieveLivePhotoResult(
+        return LivePhotoLoadingInfoResult(
             fileURLs: fileURLs.compactMap { $0 },
             cacheType: missingResources.isEmpty ? .disk : .none,
             source: source,
@@ -132,13 +132,13 @@ extension KingfisherManager {
     func downloadAndCache(
         resources: [any Resource],
         options: KingfisherParsedOptionsInfo
-    ) async throws -> [LivePhotoResourceLoadingResult] {
+    ) async throws -> [LivePhotoResourceDownloadingResult] {
         if resources.isEmpty {
             return []
         }
         let downloader = options.downloader ?? downloader
         let cache = options.targetCache ?? cache
-        return try await withThrowingTaskGroup(of: LivePhotoResourceLoadingResult.self) { group in
+        return try await withThrowingTaskGroup(of: LivePhotoResourceDownloadingResult.self) { group in
             for resource in resources {
                 group.addTask {
                     let downloadedResource = try await downloader.downloadLivePhotoResource(
@@ -155,7 +155,7 @@ extension KingfisherManager {
                 }
             }
             
-            var result: [LivePhotoResourceLoadingResult] = []
+            var result: [LivePhotoResourceDownloadingResult] = []
             for try await resource in group {
                 result.append(resource)
             }

--- a/Sources/General/KingfisherManager+LivePhoto.swift
+++ b/Sources/General/KingfisherManager+LivePhoto.swift
@@ -24,6 +24,7 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#if !os(watchOS)
 @preconcurrency import Photos
 
 public struct LivePhotoLoadingInfoResult: Sendable {
@@ -201,3 +202,4 @@ extension ImageCache {
         }
     }
 }
+#endif

--- a/Sources/General/KingfisherManager+LivePhoto.swift
+++ b/Sources/General/KingfisherManager+LivePhoto.swift
@@ -107,8 +107,8 @@ extension KingfisherManager {
             })
     }
     
-    func missingResources(_ source: LivePhotoSource, options: KingfisherParsedOptionsInfo) -> [any Resource] {
-        let missingResources: [any Resource]
+    func missingResources(_ source: LivePhotoSource, options: KingfisherParsedOptionsInfo) -> [LivePhotoResource] {
+        let missingResources: [LivePhotoResource]
         if options.forceRefresh {
             missingResources = source.resources
         } else {
@@ -130,7 +130,7 @@ extension KingfisherManager {
     }
     
     func downloadAndCache(
-        resources: [any Resource],
+        resources: [LivePhotoResource],
         options: KingfisherParsedOptionsInfo
     ) async throws -> [LivePhotoResourceDownloadingResult] {
         if resources.isEmpty {

--- a/Sources/General/KingfisherManager+LivePhoto.swift
+++ b/Sources/General/KingfisherManager+LivePhoto.swift
@@ -145,10 +145,13 @@ extension KingfisherManager {
                         with: resource.downloadURL,
                         options: options
                     )
+                    let fileExtension = resource.referenceFileType
+                        .determinedFileExtension(downloadedResource.originalData)
                     try await cache.storeToDisk(
                         downloadedResource.originalData,
                         forKey: resource.cacheKey,
                         processorIdentifier: options.processor.identifier,
+                        forcedExtension: fileExtension,
                         expiration: options.diskCacheExpiration
                     )
                     return downloadedResource
@@ -163,3 +166,4 @@ extension KingfisherManager {
         }
     }
 }
+

--- a/Sources/General/KingfisherManager+LivePhoto.swift
+++ b/Sources/General/KingfisherManager+LivePhoto.swift
@@ -83,7 +83,7 @@ extension KingfisherManager {
             }
         }
         
-        // TODO. We ignore the retry of live photo now to suppress the complexity.
+        // TODO. We ignore the retry of live photo and the progress now to suppress the complexity.
         
         let missingResources = missingResources(source, options: checkedOptions)
         let resourcesResult = try await downloadAndCache(resources: missingResources, options: checkedOptions)

--- a/Sources/General/KingfisherManager+LivePhoto.swift
+++ b/Sources/General/KingfisherManager+LivePhoto.swift
@@ -129,7 +129,7 @@ extension KingfisherManager {
         return missingResources
     }
     
-    private func downloadAndCache(
+    func downloadAndCache(
         resources: [any Resource],
         options: KingfisherParsedOptionsInfo
     ) async throws -> [LivePhotoResourceLoadingResult] {

--- a/Sources/General/KingfisherManager+LivePhoto.swift
+++ b/Sources/General/KingfisherManager+LivePhoto.swift
@@ -1,0 +1,165 @@
+//
+//  KingfisherManager+LivePhoto.swift
+//  Kingfisher
+//
+//  Created by onevcat on 2024/10/01.
+//
+//  Copyright (c) 2024 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+@preconcurrency import Photos
+
+public struct RetrieveLivePhotoResult: Sendable {
+    
+    /// Retrieves the live photo disk URLs from this result.
+    public let fileURLs: [URL]
+
+    /// Retrieves the cache source of the image, indicating from which cache layer it was retrieved.
+    ///
+    /// If the image was freshly downloaded from the network and not retrieved from any cache, `.none` will be returned.
+    /// Otherwise, ``CacheType/disk`` will be returned for the live photo. ``CacheType/memory`` is not available for
+    /// live photos since it may take too much memory. All cached live photos are loaded from disk only.
+    public let cacheType: CacheType
+
+    /// The ``LivePhotoSource`` to which this result is related. This indicates where the `livePhoto` referenced by
+    /// `self` is located.
+    public let source: LivePhotoSource
+
+    /// The original ``LivePhotoSource`` from which the retrieval task begins. It may differ from the ``source`` property.
+    /// When an alternative source loading occurs, the ``source`` will represent the replacement loading target, while the
+    /// ``originalSource`` will retain the initial ``source`` that initiated the image loading process.
+    public let originalSource: LivePhotoSource
+    
+    /// Retrieves the data associated with this result.
+    ///
+    /// When this result is obtained from a network download (when `cacheType == .none`), calling this method returns
+    /// the downloaded data. If the result is from the cache, it serializes the image using the specified cache
+    /// serializer from the loading options and returns the result.
+    ///
+    /// - Note: Retrieving this data can be a time-consuming operation, so it is advisable to store it if you need to
+    /// use it multiple times and avoid frequent calls to this method.
+    public let data: @Sendable () -> [Data]
+}
+
+extension KingfisherManager {
+    public func retrieveLivePhoto(
+        with source: LivePhotoSource,
+        options: KingfisherOptionsInfo? = nil,
+        progressBlock: DownloadProgressBlock? = nil,
+        referenceTaskIdentifierChecker: (() -> Bool)? = nil
+    ) async throws -> RetrieveLivePhotoResult {
+        let fullOptions = currentDefaultOptions + (options ?? .empty)
+        var checkedOptions = KingfisherParsedOptionsInfo(fullOptions)
+        
+        if checkedOptions.processor == DefaultImageProcessor.default {
+            // The default processor is a default behavior so we replace it silently.
+            checkedOptions.processor = LivePhotoImageProcessor.default
+        } else if checkedOptions.processor != LivePhotoImageProcessor.default {
+            assertionFailure("[Kingfisher] Using of custom processors during loading of live photo resource is not supported.")
+            checkedOptions.processor = LivePhotoImageProcessor.default
+        }
+        
+        if let checker = referenceTaskIdentifierChecker {
+            checkedOptions.onDataReceived?.forEach {
+                $0.onShouldApply = checker
+            }
+        }
+        
+        // TODO. We ignore the retry of live photo now to suppress the complexity.
+        
+        let missingResources = missingResources(source, options: checkedOptions)
+        let resourcesResult = try await downloadAndCache(resources: missingResources, options: checkedOptions)
+        
+        let targetCache = checkedOptions.targetCache ?? cache
+        let fileURLs = source.resources.map {
+            targetCache.cacheFileURLIfOnDisk(
+                forKey: $0.cacheKey,
+                processorIdentifier: checkedOptions.processor.identifier
+            )
+        }
+        if fileURLs.contains(nil) {
+            // not all file done. throw error
+        }
+        return RetrieveLivePhotoResult(
+            fileURLs: fileURLs.compactMap { $0 },
+            cacheType: missingResources.isEmpty ? .disk : .none,
+            source: source,
+            originalSource: source,
+            data: {
+                resourcesResult.map { $0.originalData }
+            })
+    }
+    
+    func missingResources(_ source: LivePhotoSource, options: KingfisherParsedOptionsInfo) -> [any Resource] {
+        let missingResources: [any Resource]
+        if options.forceRefresh {
+            missingResources = source.resources
+        } else {
+            let targetCache = options.targetCache ?? cache
+            missingResources = source.resources.reduce([], { r, resource in
+                let cacheKey = resource.cacheKey
+                let existingCachedFileURL = targetCache.cacheFileURLIfOnDisk(
+                    forKey: cacheKey,
+                    processorIdentifier: options.processor.identifier
+                )
+                if existingCachedFileURL == nil {
+                    return r + [resource]
+                } else {
+                    return r
+                }
+            })
+        }
+        return missingResources
+    }
+    
+    private func downloadAndCache(
+        resources: [any Resource],
+        options: KingfisherParsedOptionsInfo
+    ) async throws -> [LivePhotoResourceLoadingResult] {
+        if resources.isEmpty {
+            return []
+        }
+        let downloader = options.downloader ?? downloader
+        let cache = options.targetCache ?? cache
+        return try await withThrowingTaskGroup(of: LivePhotoResourceLoadingResult.self) { group in
+            for resource in resources {
+                group.addTask {
+                    let downloadedResource = try await downloader.downloadLivePhotoResource(
+                        with: resource.downloadURL,
+                        options: options
+                    )
+                    try await cache.storeToDisk(
+                        downloadedResource.originalData,
+                        forKey: resource.cacheKey,
+                        processorIdentifier: options.processor.identifier,
+                        expiration: options.diskCacheExpiration
+                    )
+                    return downloadedResource
+                }
+            }
+            
+            var result: [LivePhotoResourceLoadingResult] = []
+            for try await resource in group {
+                result.append(resource)
+            }
+            return result
+        }
+    }
+}

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -146,7 +146,7 @@ public class KingfisherManager: @unchecked Sendable {
     public var defaultOptions = KingfisherOptionsInfo.empty
     
     // Use `defaultOptions` to overwrite the `downloader` and `cache`.
-    private var currentDefaultOptions: KingfisherOptionsInfo {
+    var currentDefaultOptions: KingfisherOptionsInfo {
         return [.downloader(downloader), .targetCache(cache)] + defaultOptions
     }
 
@@ -384,7 +384,7 @@ public class KingfisherManager: @unchecked Sendable {
     
     private func retrieveImage(
         with source: Source,
-        context: RetrievingContext,
+        context: RetrievingContext<Source>,
         completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask?
     {
         let options = context.options
@@ -457,7 +457,7 @@ public class KingfisherManager: @unchecked Sendable {
     private func cacheImage(
         source: Source,
         options: KingfisherParsedOptionsInfo,
-        context: RetrievingContext,
+        context: RetrievingContext<Source>,
         result: Result<ImageLoadingResult, KingfisherError>,
         completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?
     )
@@ -519,7 +519,7 @@ public class KingfisherManager: @unchecked Sendable {
     @discardableResult
     func loadAndCacheImage(
         source: Source,
-        context: RetrievingContext,
+        context: RetrievingContext<Source>,
         completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask.WrappedTask?
     {
         let options = context.options
@@ -582,7 +582,7 @@ public class KingfisherManager: @unchecked Sendable {
     ///
     func retrieveImageFromCache(
         source: Source,
-        context: RetrievingContext,
+        context: RetrievingContext<Source>,
         completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> Bool
     {
         let options = context.options
@@ -863,7 +863,7 @@ extension KingfisherManager {
     }
 }
 
-class RetrievingContext: @unchecked Sendable {
+class RetrievingContext<SourceType>: @unchecked Sendable {
 
     private let propertyQueue = DispatchQueue(label: "com.onevcat.Kingfisher.RetrievingContextPropertyQueue")
     
@@ -873,10 +873,10 @@ class RetrievingContext: @unchecked Sendable {
         set { propertyQueue.sync { _options = newValue } }
     }
 
-    let originalSource: Source
+    let originalSource: SourceType
     var propagationErrors: [PropagationError] = []
 
-    init(options: KingfisherParsedOptionsInfo, originalSource: Source) {
+    init(options: KingfisherParsedOptionsInfo, originalSource: SourceType) {
         self.originalSource = originalSource
         _options = options
     }

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -347,6 +347,8 @@ public enum KingfisherOptionsInfoItem: Sendable {
     /// If not set or if the associated optional ``Source`` value is `nil`, the device's Low Data Mode will be ignored,
     /// and the original source will be loaded following the system default behavior.
     case lowDataMode(Source?)
+    
+    case forcedCacheFileExtension(String?)
 }
 
 // MARK: - KingfisherParsedOptionsInfo
@@ -397,6 +399,7 @@ public struct KingfisherParsedOptionsInfo: Sendable {
     public var alternativeSources: [Source]? = nil
     public var retryStrategy: (any RetryStrategy)? = nil
     public var lowDataModeSource: Source? = nil
+    public var forcedExtension: String? = nil
 
     var onDataReceived: [any DataReceivingSideEffect]? = nil
     
@@ -440,6 +443,7 @@ public struct KingfisherParsedOptionsInfo: Sendable {
             case .alternativeSources(let sources): alternativeSources = sources
             case .retryStrategy(let strategy): retryStrategy = strategy
             case .lowDataMode(let source): lowDataModeSource = source
+            case .forcedCacheFileExtension(let ext): forcedExtension = ext
             }
         }
 

--- a/Sources/Image/ImageProcessor.swift
+++ b/Sources/Image/ImageProcessor.swift
@@ -818,6 +818,25 @@ public struct DownsamplingImageProcessor: ImageProcessor {
     }
 }
 
+// This is an internal processor to provide the same interface for Live Photos.
+// It is not intended to be open and used from external.
+struct LivePhotoImageProcessor: ImageProcessor {
+    
+    public static let `default` = LivePhotoImageProcessor()
+    private init() { }
+    
+    public let identifier = "com.onevcat.Kingfisher.LivePhotoImageProcessor"
+    
+    public func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
+        switch item {
+        case .image(let image):
+            return image
+        case .data:
+            return KFCrossPlatformImage()
+        }
+    }
+}
+
 infix operator |>: AdditionPrecedence
 
 /// Concatenates two `ImageProcessor`s to create a new one, in which the `left` and `right` are combined in order to 

--- a/Sources/Networking/ImageDownloader+LivePhoto.swift
+++ b/Sources/Networking/ImageDownloader+LivePhoto.swift
@@ -1,0 +1,99 @@
+//
+//  ImageDownloader+LivePhoto.swift
+//  Kingfisher
+//
+//  Created by onevcat on 2024/10/01.
+//
+//  Copyright (c) 2024 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+public struct LivePhotoResourceLoadingResult: Sendable {
+    
+    /// The original URL of the image request.
+    public let url: URL?
+
+    /// The raw data received from the downloader.
+    public let originalData: Data
+
+    /// Creates an `ImageDownloadResult` object.
+    ///
+    /// - Parameters:
+    ///   - image: The image of the download result.
+    ///   - url: The URL from which the image was downloaded.
+    ///   - originalData: The binary data of the image.
+    public init(originalData: Data, url: URL? = nil) {
+        self.url = url
+        self.originalData = originalData
+    }
+}
+
+extension ImageDownloader {
+    
+    public func downloadLivePhotoResource(
+        with url: URL,
+        options: KingfisherParsedOptionsInfo
+    ) async throws -> LivePhotoResourceLoadingResult {
+        let task = CancellationDownloadTask()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let downloadTask = downloadLivePhotoResource(with: url, options: options) { result in
+                    continuation.resume(with: result)
+                }
+                if Task.isCancelled {
+                    downloadTask.cancel()
+                } else {
+                    Task {
+                        await task.setTask(downloadTask)
+                    }
+                }
+            }
+        } onCancel: {
+            Task {
+                await task.task?.cancel()
+            }
+        }
+    }
+    
+    @discardableResult
+    public func downloadLivePhotoResource(
+        with url: URL,
+        options: KingfisherParsedOptionsInfo,
+        completionHandler: (@Sendable (Result<LivePhotoResourceLoadingResult, KingfisherError>) -> Void)? = nil
+    ) -> DownloadTask {
+        var checkedOptions = options
+        if options.processor != LivePhotoImageProcessor.default {
+            assertionFailure("[Kingfisher] Using of custom processors during loading of live photo resource is not supported.")
+            checkedOptions.processor = LivePhotoImageProcessor.default
+        }
+        return downloadImage(with: url, options: checkedOptions) { result in
+            guard let completionHandler else {
+                return
+            }
+            let newResult = result.map { LivePhotoResourceLoadingResult(originalData: $0.originalData, url: $0.url) }
+            completionHandler(newResult)
+        }
+    }
+}

--- a/Sources/Networking/ImageDownloader+LivePhoto.swift
+++ b/Sources/Networking/ImageDownloader+LivePhoto.swift
@@ -30,7 +30,7 @@ import AppKit
 import UIKit
 #endif
 
-public struct LivePhotoResourceLoadingResult: Sendable {
+public struct LivePhotoResourceDownloadingResult: Sendable {
     
     /// The original URL of the image request.
     public let url: URL?
@@ -55,7 +55,7 @@ extension ImageDownloader {
     public func downloadLivePhotoResource(
         with url: URL,
         options: KingfisherParsedOptionsInfo
-    ) async throws -> LivePhotoResourceLoadingResult {
+    ) async throws -> LivePhotoResourceDownloadingResult {
         let task = CancellationDownloadTask()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
@@ -81,7 +81,7 @@ extension ImageDownloader {
     public func downloadLivePhotoResource(
         with url: URL,
         options: KingfisherParsedOptionsInfo,
-        completionHandler: (@Sendable (Result<LivePhotoResourceLoadingResult, KingfisherError>) -> Void)? = nil
+        completionHandler: (@Sendable (Result<LivePhotoResourceDownloadingResult, KingfisherError>) -> Void)? = nil
     ) -> DownloadTask {
         var checkedOptions = options
         if options.processor == DefaultImageProcessor.default {
@@ -95,7 +95,7 @@ extension ImageDownloader {
             guard let completionHandler else {
                 return
             }
-            let newResult = result.map { LivePhotoResourceLoadingResult(originalData: $0.originalData, url: $0.url) }
+            let newResult = result.map { LivePhotoResourceDownloadingResult(originalData: $0.originalData, url: $0.url) }
             completionHandler(newResult)
         }
     }

--- a/Sources/Networking/ImageDownloader+LivePhoto.swift
+++ b/Sources/Networking/ImageDownloader+LivePhoto.swift
@@ -84,7 +84,10 @@ extension ImageDownloader {
         completionHandler: (@Sendable (Result<LivePhotoResourceLoadingResult, KingfisherError>) -> Void)? = nil
     ) -> DownloadTask {
         var checkedOptions = options
-        if options.processor != LivePhotoImageProcessor.default {
+        if options.processor == DefaultImageProcessor.default {
+            // The default processor is a default behavior so we replace it silently.
+            checkedOptions.processor = LivePhotoImageProcessor.default
+        } else if options.processor != LivePhotoImageProcessor.default {
             assertionFailure("[Kingfisher] Using of custom processors during loading of live photo resource is not supported.")
             checkedOptions.processor = LivePhotoImageProcessor.default
         }

--- a/Sources/Networking/ImagePrefetcher.swift
+++ b/Sources/Networking/ImagePrefetcher.swift
@@ -309,7 +309,8 @@ public class ImagePrefetcher: CustomStringConvertible, @unchecked Sendable {
         
         let cacheType = manager.cache.imageCachedType(
             forKey: source.cacheKey,
-            processorIdentifier: optionsInfo.processor.identifier)
+            processorIdentifier: optionsInfo.processor.identifier
+        )
         switch cacheType {
         case .memory:
             append(cached: source)

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -310,18 +310,15 @@ class ImageCacheTests: XCTestCase {
         XCTAssertTrue(cachePath.hasSuffix(".jpg"))
     }
   
-    func testCachedImageIsFetchedSynchronouslyFromTheMemoryCache() {
+    @MainActor func testCachedImageIsFetchedSynchronouslyFromTheMemoryCache() {
         cache.store(testImage, forKey: testKeys[0], toDisk: false)
-        let foundImage = ActorBox<KFCrossPlatformImage?>(nil)
+        var image: KFCrossPlatformImage? = nil
         cache.retrieveImage(forKey: testKeys[0]) { result in
-            Task {
-                await foundImage.setValue(result.value?.image)
+            MainActor.assumeIsolated {
+                image = try? result.get().image
             }
         }
-        Task {
-            let value = await foundImage.value
-            XCTAssertEqual(testImage, value)
-        }
+        XCTAssertEqual(testImage, image)
     }
     
     func testCachedImageIsFetchedSynchronouslyFromTheMemoryCacheAsync() async throws {

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -762,6 +762,24 @@ class ImageCacheTests: XCTestCase {
         XCTAssertEqual(newSize, UInt(testImagePNGData.count * testKeys.count))
     }
     
+    func testStoreFileWithForcedExtension() async throws {
+        let key = testKeys[0]
+        try await cache.store(testImage, forKey: key, forcedExtension: "jpg", toDisk: true)
+    
+        let pathWithoutExtension = cache.cachePath(forKey: key)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: pathWithoutExtension))
+        
+        let pathWithExtension = cache.cachePath(forKey: key, forcedExtension: "jpg")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: pathWithExtension))
+        
+        XCTAssertEqual(cache.imageCachedType(forKey: key), .memory)
+        XCTAssertEqual(cache.imageCachedType(forKey: key, forcedExtension: "jpg"), .memory)
+        
+        cache.clearMemoryCache()
+        XCTAssertEqual(cache.imageCachedType(forKey: key), .none)
+        XCTAssertEqual(cache.imageCachedType(forKey: key, forcedExtension: "jpg"), .disk)
+    }
+    
     // MARK: - Helper
     private func storeMultipleImages(_ completionHandler: @escaping () -> Void) {
         let group = DispatchGroup()

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -676,6 +676,14 @@ class ImageDownloaderTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
+    
+    func testDownloadingLivePhotoResources() async throws {
+        let url = testURLs[0]
+        stub(url, data: testImageData)
+        let result = try await downloader.downloadLivePhotoResource(with: url, options: .init(.empty))
+        XCTAssertEqual(result.originalData, testImageData)
+        XCTAssertEqual(result.url, url)
+    }
 }
 
 class URLNilDataModifier: ImageDownloaderDelegate {

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -363,6 +363,7 @@ class ImageViewExtensionTests: XCTestCase {
                 reason: .notCurrentSourceTask(let result, _, let source)) = result.error!
             {
                 XCTAssertEqual(source.url, testURLs[0])
+                XCTAssertEqual(result?.originalSource.url, testURLs[0])
                 XCTAssertNotEqual(result!.image, self.imageView.image)
             } else {
                 XCTFail()

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1363,7 +1363,11 @@ class KingfisherManagerTests: XCTestCase {
     func testMissingResourceOfLivePhotoNotFound() async throws {
         let resource = KF.ImageResource(downloadURL: LivePhotoURL.mov)
         
-        try await manager.cache.storeToDisk(testImageData, forKey: resource.cacheKey)
+        try await manager.cache.storeToDisk(
+            testImageData,
+            forKey: resource.cacheKey,
+            forcedExtension: resource.downloadURL.pathExtension
+        )
         
         let source = LivePhotoSource(resources: [resource])
         let missing = manager.missingResources(source, options: .init(.empty))
@@ -1374,7 +1378,11 @@ class KingfisherManagerTests: XCTestCase {
         let resource1 = KF.ImageResource(downloadURL: LivePhotoURL.heic)
         let resource2 = KF.ImageResource(downloadURL: LivePhotoURL.mov)
         
-        try await manager.cache.storeToDisk(testImageData, forKey: resource1.cacheKey)
+        try await manager.cache.storeToDisk(
+            testImageData,
+            forKey: resource1.cacheKey,
+            forcedExtension: resource1.downloadURL.pathExtension
+        )
         
         let source = LivePhotoSource(resources: [resource1, resource2])
         let missing = manager.missingResources(source, options: .init(.empty))
@@ -1399,8 +1407,14 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertTrue(urls.contains(LivePhotoURL.mov))
         XCTAssertTrue(urls.contains(LivePhotoURL.heic))
         
-        let resourceCached1 = manager.cache.imageCachedType(forKey: resource1.cacheKey)
-        let resourceCached2 = manager.cache.imageCachedType(forKey: resource1.cacheKey)
+        let resourceCached1 = manager.cache.imageCachedType(
+            forKey: resource1.cacheKey,
+            forcedExtension: resource1.downloadURL.pathExtension
+        )
+        let resourceCached2 = manager.cache.imageCachedType(
+            forKey: resource2.cacheKey,
+            forcedExtension: resource2.downloadURL.pathExtension
+        )
         XCTAssertEqual(resourceCached1, .disk)
         XCTAssertEqual(resourceCached2, .disk)
     }
@@ -1443,21 +1457,25 @@ class KingfisherManagerTests: XCTestCase {
         try await manager.cache.storeToDisk(
             testImageData,
             forKey: resource1.cacheKey,
-            processorIdentifier: LivePhotoImageProcessor.default.identifier
+            processorIdentifier: LivePhotoImageProcessor.default.identifier,
+            forcedExtension: resource1.downloadURL.pathExtension
         )
         try await manager.cache.storeToDisk(
             testImageData,
             forKey: resource2.cacheKey,
-            processorIdentifier: LivePhotoImageProcessor.default.identifier
+            processorIdentifier: LivePhotoImageProcessor.default.identifier,
+            forcedExtension: resource2.downloadURL.pathExtension
         )
         
         let resource1Cached = manager.cache.isCached(
             forKey: resource1.cacheKey,
-            processorIdentifier: LivePhotoImageProcessor.default.identifier
+            processorIdentifier: LivePhotoImageProcessor.default.identifier,
+            forcedExtension: resource1.downloadURL.pathExtension
         )
         let resource2Cached = manager.cache.isCached(
             forKey: resource2.cacheKey,
-            processorIdentifier: LivePhotoImageProcessor.default.identifier
+            processorIdentifier: LivePhotoImageProcessor.default.identifier,
+            forcedExtension: resource2.downloadURL.pathExtension
         )
         XCTAssertTrue(resource1Cached)
         XCTAssertTrue(resource2Cached)
@@ -1482,17 +1500,20 @@ class KingfisherManagerTests: XCTestCase {
         try await manager.cache.storeToDisk(
             testImageData,
             forKey: resource1.cacheKey,
-            processorIdentifier: LivePhotoImageProcessor.default.identifier
+            processorIdentifier: LivePhotoImageProcessor.default.identifier,
+            forcedExtension: resource1.downloadURL.pathExtension
         )
         stub(resource2.downloadURL, data: testImageData)
         
         let resource1Cached = manager.cache.isCached(
             forKey: resource1.cacheKey,
-            processorIdentifier: LivePhotoImageProcessor.default.identifier
+            processorIdentifier: LivePhotoImageProcessor.default.identifier,
+            forcedExtension: resource1.downloadURL.pathExtension
         )
         let resource2Cached = manager.cache.isCached(
             forKey: resource2.cacheKey,
-            processorIdentifier: LivePhotoImageProcessor.default.identifier
+            processorIdentifier: LivePhotoImageProcessor.default.identifier,
+            forcedExtension: resource2.downloadURL.pathExtension
         )
         XCTAssertTrue(resource1Cached)
         XCTAssertFalse(resource2Cached)

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1592,7 +1592,7 @@ class KingfisherManagerTests: XCTestCase {
     
     func testDownloadAndCacheLivePhotoWithSingleResource() async throws {
         let resource = LivePhotoResource(downloadURL: LivePhotoURL.heic)
-        stub(resource.downloadURL, data: testImageData)
+        stub(resource.downloadURL!, data: testImageData)
         
         let result = try await manager.downloadAndCache(resources: [resource], options: .init([]))
         XCTAssertEqual(result.count, 1)
@@ -1603,7 +1603,7 @@ class KingfisherManagerTests: XCTestCase {
     
     func testDownloadAndCacheLivePhotoWithSingleResourceGuessingUnsupportedExtension() async throws {
         let resource = LivePhotoResource(downloadURL: URL(string: "https://example.com")!)
-        stub(resource.downloadURL, data: testImageData)
+        stub(resource.downloadURL!, data: testImageData)
         
         XCTAssertEqual(resource.referenceFileType, .other(""))
         
@@ -1619,7 +1619,7 @@ class KingfisherManagerTests: XCTestCase {
     
     func testDownloadAndCacheLivePhotoWithSingleResourceExplicitSetExtension() async throws {
         let resource = LivePhotoResource(downloadURL: URL(string: "https://example.com")!, fileType: .heic)
-        stub(resource.downloadURL, data: testImageData)
+        stub(resource.downloadURL!, data: testImageData)
         
         XCTAssertEqual(resource.referenceFileType, .heic)
         
@@ -1635,7 +1635,7 @@ class KingfisherManagerTests: XCTestCase {
     
     func testDownloadAndCacheLivePhotoWithSingleResourceGuessingHEICExtension() async throws {
         let resource = LivePhotoResource(downloadURL: URL(string: "https://example.com")!)
-        stub(resource.downloadURL, data: partitalHEICData)
+        stub(resource.downloadURL!, data: partitalHEICData)
         
         XCTAssertEqual(resource.referenceFileType, .other(""))
         
@@ -1651,7 +1651,7 @@ class KingfisherManagerTests: XCTestCase {
     
     func testDownloadAndCacheLivePhotoWithSingleResourceGuessingMOVExtension() async throws {
         let resource = LivePhotoResource(downloadURL: URL(string: "https://example.com")!)
-        stub(resource.downloadURL, data: partitalMOVData)
+        stub(resource.downloadURL!, data: partitalMOVData)
         
         XCTAssertEqual(resource.referenceFileType, .other(""))
         

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1353,7 +1353,7 @@ class KingfisherManagerTests: XCTestCase {
     }
     
     func testMissingResourceOfLivePhotoFound() {
-        let resource = KF.ImageResource(downloadURL: testURLs[0])
+        let resource = KF.ImageResource(downloadURL: LivePhotoURL.mov)
         let source = LivePhotoSource(resources: [resource])
         
         let missing = manager.missingResources(source, options: .init(.empty))
@@ -1361,7 +1361,7 @@ class KingfisherManagerTests: XCTestCase {
     }
     
     func testMissingResourceOfLivePhotoNotFound() async throws {
-        let resource = KF.ImageResource(downloadURL: testURLs[0])
+        let resource = KF.ImageResource(downloadURL: LivePhotoURL.mov)
         
         try await manager.cache.storeToDisk(testImageData, forKey: resource.cacheKey)
         
@@ -1371,8 +1371,8 @@ class KingfisherManagerTests: XCTestCase {
     }
     
     func testMissingResourceOfLivePhotoFoundOne() async throws {
-        let resource1 = KF.ImageResource(downloadURL: testURLs[0])
-        let resource2 = KF.ImageResource(downloadURL: testURLs[1])
+        let resource1 = KF.ImageResource(downloadURL: LivePhotoURL.heic)
+        let resource2 = KF.ImageResource(downloadURL: LivePhotoURL.mov)
         
         try await manager.cache.storeToDisk(testImageData, forKey: resource1.cacheKey)
         
@@ -1383,18 +1383,21 @@ class KingfisherManagerTests: XCTestCase {
     }
     
     func testDownloadAndCacheLivePhotoResourcesAll() async throws {
-        let resource1 = KF.ImageResource(downloadURL: testURLs[0])
-        let resource2 = KF.ImageResource(downloadURL: testURLs[1])
+        let resource1 = KF.ImageResource(downloadURL: LivePhotoURL.mov)
+        let resource2 = KF.ImageResource(downloadURL: LivePhotoURL.heic)
         
         stub(resource1.downloadURL, data: testImageData)
         stub(resource2.downloadURL, data: testImageData)
         
-        let result = try await manager.downloadAndCache(resources: [resource1, resource2], options: .init(.empty))
+        let result = try await manager.downloadAndCache(
+            resources: [resource1, resource2].map { LivePhotoResource.init(resource: $0)
+            },
+            options: .init(.empty))
         XCTAssertEqual(result.count, 2)
         
         let urls = result.compactMap(\.url)
-        XCTAssertTrue(urls.contains(testURLs[0]))
-        XCTAssertTrue(urls.contains(testURLs[1]))
+        XCTAssertTrue(urls.contains(LivePhotoURL.mov))
+        XCTAssertTrue(urls.contains(LivePhotoURL.heic))
         
         let resourceCached1 = manager.cache.imageCachedType(forKey: resource1.cacheKey)
         let resourceCached2 = manager.cache.imageCachedType(forKey: resource1.cacheKey)
@@ -1403,8 +1406,8 @@ class KingfisherManagerTests: XCTestCase {
     }
     
     func testRetrieveLivePhotoFromNetwork() async throws {
-        let resource1 = KF.ImageResource(downloadURL: testURLs[0])
-        let resource2 = KF.ImageResource(downloadURL: testURLs[1])
+        let resource1 = KF.ImageResource(downloadURL: LivePhotoURL.mov)
+        let resource2 = KF.ImageResource(downloadURL: LivePhotoURL.heic)
         
         stub(resource1.downloadURL, data: testImageData)
         stub(resource2.downloadURL, data: testImageData)
@@ -1429,13 +1432,13 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertEqual(result.cacheType, .none)
         XCTAssertEqual(result.data(), [testImageData, testImageData])
         let urlsInSource = result.source.resources.map(\.downloadURL)
-        XCTAssertTrue(urlsInSource.contains(testURLs[0]))
-        XCTAssertTrue(urlsInSource.contains(testURLs[1]))
+        XCTAssertTrue(urlsInSource.contains(LivePhotoURL.mov))
+        XCTAssertTrue(urlsInSource.contains(LivePhotoURL.heic))
     }
     
     func testRetrieveLivePhotoFromLocal() async throws {
-        let resource1 = KF.ImageResource(downloadURL: testURLs[0])
-        let resource2 = KF.ImageResource(downloadURL: testURLs[1])
+        let resource1 = KF.ImageResource(downloadURL: LivePhotoURL.mov)
+        let resource2 = KF.ImageResource(downloadURL: LivePhotoURL.heic)
         
         try await manager.cache.storeToDisk(
             testImageData,
@@ -1468,13 +1471,13 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertEqual(result.cacheType, .disk)
         XCTAssertEqual(result.data(), [])
         let urlsInSource = result.source.resources.map(\.downloadURL)
-        XCTAssertTrue(urlsInSource.contains(testURLs[0]))
-        XCTAssertTrue(urlsInSource.contains(testURLs[1]))
+        XCTAssertTrue(urlsInSource.contains(LivePhotoURL.mov))
+        XCTAssertTrue(urlsInSource.contains(LivePhotoURL.heic))
     }
     
     func testRetrieveLivePhotoMixed() async throws {
-        let resource1 = KF.ImageResource(downloadURL: testURLs[0])
-        let resource2 = KF.ImageResource(downloadURL: testURLs[1])
+        let resource1 = KF.ImageResource(downloadURL: LivePhotoURL.mov)
+        let resource2 = KF.ImageResource(downloadURL: LivePhotoURL.heic)
         
         try await manager.cache.storeToDisk(
             testImageData,
@@ -1503,13 +1506,13 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertEqual(result.cacheType, .none)
         XCTAssertEqual(result.data(), [testImageData])
         let urlsInSource = result.source.resources.map(\.downloadURL)
-        XCTAssertTrue(urlsInSource.contains(testURLs[0]))
-        XCTAssertTrue(urlsInSource.contains(testURLs[1]))
+        XCTAssertTrue(urlsInSource.contains(LivePhotoURL.mov))
+        XCTAssertTrue(urlsInSource.contains(LivePhotoURL.heic))
     }
     
     func testRetrieveLivePhotoNetworkThenCache() async throws {
-        let resource1 = KF.ImageResource(downloadURL: testURLs[0])
-        let resource2 = KF.ImageResource(downloadURL: testURLs[1])
+        let resource1 = KF.ImageResource(downloadURL: LivePhotoURL.mov)
+        let resource2 = KF.ImageResource(downloadURL: LivePhotoURL.heic)
         
         stub(resource1.downloadURL, data: testImageData)
         stub(resource2.downloadURL, data: testImageData)
@@ -1534,8 +1537,8 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertEqual(result.cacheType, .none)
         XCTAssertEqual(result.data(), [testImageData, testImageData])
         let urlsInSource = result.source.resources.map(\.downloadURL)
-        XCTAssertTrue(urlsInSource.contains(testURLs[0]))
-        XCTAssertTrue(urlsInSource.contains(testURLs[1]))
+        XCTAssertTrue(urlsInSource.contains(LivePhotoURL.mov))
+        XCTAssertTrue(urlsInSource.contains(LivePhotoURL.heic))
         
         let localResult = try await manager.retrieveLivePhoto(with: source)
         XCTAssertEqual(localResult.fileURLs.count, 2)

--- a/Tests/KingfisherTests/KingfisherTestHelper.swift
+++ b/Tests/KingfisherTests/KingfisherTestHelper.swift
@@ -84,6 +84,11 @@ let testKeys = [
     "http://onevcat.com/content/images/2014/May/200.jpg?fads#kj1asf"
 ]
 
+enum LivePhotoURL {
+    static let mov = URL(string: "https://example.com/sample.mov")!
+    static let heic = URL(string: "https://example.com/sample.heic")!
+}
+
 let testURLs = testKeys.map { URL(string: $0)! }
 
 func cleanDefaultCache() {

--- a/Tests/KingfisherTests/KingfisherTestHelper.swift
+++ b/Tests/KingfisherTests/KingfisherTestHelper.swift
@@ -72,6 +72,9 @@ let testImageString =
 var testImage = KFCrossPlatformImage(data: testImageData)!
 let testImageData = Data(base64Encoded: testImageString)!
 
+let partitalHEICData = Data(base64Encoded: "AAAALGZ0eXBoZWljAAAAAG1pZjFNaUhCTWlIRU1pUHI=")!
+let partitalMOVData = Data(base64Encoded: "AAAAFGZ0eXBxdCAgAAAAAHF0ICAAAAAId2lkZQAgJto=")!
+
 let testImagePNGData = testImage.kf.pngRepresentation()!
 let testImageJEPGData = testImage.kf.jpegRepresentation(compressionQuality: 1.0)!
 let testImageGIFData = Data(fileName: "dancing-banana.gif")

--- a/Tests/KingfisherTests/LivePhotoSourceTests.swift
+++ b/Tests/KingfisherTests/LivePhotoSourceTests.swift
@@ -1,0 +1,183 @@
+//
+//  LivePhotoSourceTests.swift
+//  Kingfisher
+//
+//  Created by onevcat on 2024/10/01.
+//
+//  Copyright (c) 2024 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import XCTest
+@testable import Kingfisher
+
+class LivePhotoSourceTests: XCTestCase {
+    
+    func testLivePhotoResourceInitialization() {
+        let url = URL(string: "https://example.com/photo.heic")!
+        let resource = LivePhotoResource(downloadURL: url)
+        
+        XCTAssertEqual(resource.downloadURL, url)
+        XCTAssertEqual(resource.referenceFileType, .heic)
+    }
+    
+    func testLivePhotoResourceInitializationWithResource() {
+        let url = URL(string: "https://example.com/photo.mov")!
+        let imageResource = KF.ImageResource(downloadURL: url)
+        let resource = LivePhotoResource(resource: imageResource)
+        
+        XCTAssertEqual(resource.downloadURL, url)
+        XCTAssertEqual(resource.referenceFileType, .mov)
+    }
+    
+    func testLivePhotoResourceFileExtensionByType() {
+        let mov = LivePhotoResource.FileType.mov
+        XCTAssertEqual(mov.determinedFileExtension(Data()), "mov")
+        XCTAssertEqual(mov.fileExtension, "mov")
+        
+        let heic = LivePhotoResource.FileType.heic
+        XCTAssertEqual(heic.determinedFileExtension(Data()), "heic")
+        XCTAssertEqual(heic.fileExtension, "heic")
+        
+        let other = LivePhotoResource.FileType.other("exe")
+        XCTAssertEqual(other.fileExtension, "exe")
+    }
+    
+    func testLivePhotoResourceFileTypeDeterminationForHEIC() {
+        let data = Data([0x00, 0x00, 0x00, 0x00, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63])
+        let fileType = LivePhotoResource.FileType.other("")
+        let determinedExtension = fileType.determinedFileExtension(data)
+        
+        XCTAssertEqual(determinedExtension, "heic")
+    }
+
+    func testLivePhotoResourceFileTypeDeterminationForQT() {
+        let data = Data([0x00, 0x00, 0x00, 0x00, 0x66, 0x74, 0x79, 0x70, 0x71, 0x74, 0x20, 0x20])
+        let fileType = LivePhotoResource.FileType.other("")
+        let determinedExtension = fileType.determinedFileExtension(data)
+        
+        XCTAssertEqual(determinedExtension, "mov")
+    }
+
+    func testLivePhotoResourceFileTypeDeterminationForExplicitFileType() {
+        let data = Data([0x00, 0x00, 0x00, 0x00, 0x66, 0x74, 0x79, 0x70, 0x71, 0x74, 0x20, 0x20])
+        let fileType = LivePhotoResource.FileType.other("ext")
+        let determinedExtension = fileType.determinedFileExtension(data)
+        
+        XCTAssertEqual(determinedExtension, "ext")
+    }
+
+    func testLivePhotoResourceFileTypeDeterminationForUnknown() {
+        let data = Data([0x00, 0x00, 0x00, 0x00, 0x66, 0x74, 0x79, 0x70, 0x71, 0x74, 0x20, 0x22])
+        let fileType = LivePhotoResource.FileType.other("")
+        let determinedExtension = fileType.determinedFileExtension(data)
+        
+        XCTAssertEqual(determinedExtension, nil)
+    }
+    
+    func testLivePhotoResourceFileTypeDeterminationForNonFYTP() {
+        let data = Data([0x00, 0x00, 0x00, 0x00, 0x12, 0x34, 0x56, 0x78, 0x71, 0x74, 0x20, 0x20])
+        let fileType = LivePhotoResource.FileType.other("")
+        let determinedExtension = fileType.determinedFileExtension(data)
+        
+        XCTAssertEqual(determinedExtension, nil)
+    }
+    
+    func testLivePhotoResourceFileTypeDeterminationForNotEnoughData() {
+        let data = Data([0x00, 0x00, 0x00, 0x00])
+        let fileType = LivePhotoResource.FileType.other("")
+        let determinedExtension = fileType.determinedFileExtension(data)
+        
+        XCTAssertEqual(determinedExtension, nil)
+    }
+    
+    func testLivePhotoSourceInitializationWithResources() {
+        let url1 = URL(string: "https://example.com/photo1.heic")!
+        let url2 = URL(string: "https://example.com/photo2.mov")!
+        let resources = [KF.ImageResource(downloadURL: url1), KF.ImageResource(downloadURL: url2)]
+        let livePhotoSource = LivePhotoSource(resources: resources)
+        
+        XCTAssertEqual(livePhotoSource.resources.count, 2)
+        XCTAssertEqual(livePhotoSource.resources[0].downloadURL, url1)
+        XCTAssertEqual(livePhotoSource.resources[1].downloadURL, url2)
+    }
+    
+    func testLivePhotoSourceInitializationWithURLs() {
+        let url1 = URL(string: "https://example.com/photo1.heic")!
+        let url2 = URL(string: "https://example.com/photo2.mov")!
+        let livePhotoSource = LivePhotoSource(urls: [url1, url2])
+        
+        XCTAssertEqual(livePhotoSource.resources.count, 2)
+        XCTAssertEqual(livePhotoSource.resources[0].downloadURL, url1)
+        XCTAssertEqual(livePhotoSource.resources[1].downloadURL, url2)
+    }
+    
+    func testLivePhotoResourceInitializationWithCacheKey() {
+        let url = URL(string: "https://example.com/photo.heic")!
+        let cacheKey = "customCacheKey"
+        let resource = LivePhotoResource(downloadURL: url, cacheKey: cacheKey)
+        
+        XCTAssertEqual(resource.downloadURL, url)
+        XCTAssertEqual(resource.cacheKey, cacheKey)
+        XCTAssertEqual(resource.referenceFileType, .heic)
+    }
+
+    func testLivePhotoResourceInitializationWithFileType() {
+        let url = URL(string: "https://example.com/photo.unknown")!
+        let resource = LivePhotoResource(downloadURL: url, fileType: .other("unknown"))
+        
+        XCTAssertEqual(resource.downloadURL, url)
+        XCTAssertEqual(resource.referenceFileType, .other("unknown"))
+    }
+
+    func testLivePhotoResourceGuessedFileType() {
+        let url1 = URL(string: "https://example.com/photo.heic")!
+        let url2 = URL(string: "https://example.com/photo.mov")!
+        let url3 = URL(string: "https://example.com/photo.unknown")!
+        
+        let resource1 = KF.ImageResource(downloadURL: url1)
+        let resource2 = KF.ImageResource(downloadURL: url2)
+        let resource3 = KF.ImageResource(downloadURL: url3)
+        
+        XCTAssertEqual(resource1.guessedFileType, .heic)
+        XCTAssertEqual(resource2.guessedFileType, .mov)
+        XCTAssertEqual(resource3.guessedFileType, .other("unknown"))
+    }
+
+    func testLivePhotoSourceInitializationWithMixedResources() {
+        let url1 = URL(string: "https://example.com/photo1.heic")!
+        let url2 = URL(string: "https://example.com/photo2.mov")!
+        let url3 = URL(string: "https://example.com/photo3.unknown")!
+        let resources = [
+            KF.ImageResource(downloadURL: url1),
+            KF.ImageResource(downloadURL: url2),
+            KF.ImageResource(downloadURL: url3)
+        ]
+        let livePhotoSource = LivePhotoSource(resources: resources)
+        
+        XCTAssertEqual(livePhotoSource.resources.count, 3)
+        XCTAssertEqual(livePhotoSource.resources[0].downloadURL, url1)
+        XCTAssertEqual(livePhotoSource.resources[1].downloadURL, url2)
+        XCTAssertEqual(livePhotoSource.resources[2].downloadURL, url3)
+        XCTAssertEqual(livePhotoSource.resources[0].referenceFileType, .heic)
+        XCTAssertEqual(livePhotoSource.resources[1].referenceFileType, .mov)
+        XCTAssertEqual(livePhotoSource.resources[2].referenceFileType, .other("unknown"))
+    }
+
+}


### PR DESCRIPTION
This PR implements the requirement of #2297 

It mainly adds a high level extension method to `PHLivePhoto` to load a live photo (with two URLs, one for still image, one for video). That means, you can now use this code to load a live photo easily:

```swift
let urls = [
  URL(string: "https://example.com/image.heic")!, // imageURL
  URL(string: "https://example.com/video.mov")!   // videoURL
]
let livePhotoView = PHLivePhotoView()
livePhotoView.kf.setImage(with: urls)
```

The still image and video data can be retrieved by `PHAssetResourceManager.requestData` and uploaded to the server by a user. Then in another client, these files can be loaded and it finally generates a `PHLivePhoto` object.

It is supported on all platforms where `PHLivePhotoView` is available (iOS, macOS, tvOS, etc).

For more detail, a following PR of documentation will be added soon.