### PR TITLE
Fix a potential duplicated completion invoking when task cancel

### DIFF
--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -101,10 +101,13 @@ public class SessionDataTask: @unchecked Sendable {
         return nil
     }
     
-    func removeAllCallbacks() -> Void {
+    @discardableResult
+    func removeAllCallbacks() -> [TaskCallback] {
         lock.lock()
         defer { lock.unlock() }
+        let callbacks = callbacksStore.values
         callbacksStore.removeAll()
+        return Array(callbacks)
     }
 
     func resume() {

--- a/Sources/Networking/SessionDelegate.swift
+++ b/Sources/Networking/SessionDelegate.swift
@@ -263,7 +263,8 @@ extension SessionDelegate: URLSessionDataDelegate {
         guard let sessionTask = self.task(for: task) else {
             return
         }
-        sessionTask.onTaskDone.call((result, sessionTask.callbacks))
+        let callbacks = sessionTask.removeAllCallbacks()
+        sessionTask.onTaskDone.call((result, callbacks))
         remove(sessionTask)
     }
 }


### PR DESCRIPTION
Fix a crash reported here: https://github.com/onevcat/Kingfisher/issues/2297#issuecomment-2478622132

There appears to be a brief window during which the callback can be accessed from another thread before the next lock is applied. This violates the assumption that the completion handler is invoked only once, leading to issues, particularly when task cancellation is involved.