### PR TITLE
Resolves performance issue when presenting animated images

### DIFF
--- a/Sources/Image/GIFAnimatedImage.swift
+++ b/Sources/Image/GIFAnimatedImage.swift
@@ -148,6 +148,13 @@ public protocol ImageFrameSource {
     
     /// Retrieves the duration at a specific index. If the index is invalid, implementors should return `0.0`.
     func duration(at index: Int) -> TimeInterval
+    
+    /// Creates a copy of the current `ImageFrameSource` instance.
+    ///
+    /// - Returns: A new instance of the same type as `self` with identical properties.
+    ///            If not overridden by conforming types, this default implementation
+    ///            simply returns `self`, which may not create an actual copy if the type is a reference type.
+    func copy() -> Self
 }
 
 public extension ImageFrameSource {
@@ -155,6 +162,10 @@ public extension ImageFrameSource {
     /// Retrieves the frame at a specific index. If the index is invalid, implementors should return `nil`.
     func frame(at index: Int) -> CGImage? {
         return frame(at: index, maxSize: nil)
+    }
+    
+    func copy() -> Self {
+        return self
     }
 }
 
@@ -182,6 +193,13 @@ struct CGImageFrameSource: ImageFrameSource {
 
     func duration(at index: Int) -> TimeInterval {
         return GIFAnimatedImage.getFrameDuration(from: imageSource, at: index)
+    }
+    
+    func copy() -> Self {
+        guard let data = data, let source = CGImageSourceCreateWithData(data as CFData, options as CFDictionary?) else {
+            return self
+        }
+        return CGImageFrameSource(data: data, imageSource: source, options: options)
     }
 }
 

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -759,7 +759,7 @@ extension AnimatedImageView {
                     return KFCrossPlatformImage(cgImage: cgImage)
                 }
                 
-                return KFCrossPlatformImage(cgImage: unretainedImage)
+                return KFCrossPlatformImage(cgImage: unretainedImage).preparingForDisplay()
             } else {
                 return KFCrossPlatformImage(cgImage: cgImage)
             }

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -672,7 +672,7 @@ extension AnimatedImageView {
              framePreloadCount count: Int,
              repeatCount: RepeatCount,
              preloadQueue: DispatchQueue) {
-            self.frameSource = source
+            self.frameSource = source.copy()
             self.contentMode = mode
             self.size = size
             self.imageSize = imageSize


### PR DESCRIPTION
Fixes #2352 

The problem is that `AnimatedImageView` currently decodes GIF images on the main thread and doesn’t adhere to `kCGImageSourceShouldCacheImmediately`. This was already a performance concern, but after #2347 was merged, the issue worsened when multiple AnimatedImageView instances shared a single CGImageSource instance.

This PR tries to fix this problem with two changes:

1. When creating `AnimatedImageView`, we now make a copy of the `CGImageSource` instance to restore the performance to pre-#2347 levels.
2. We use `UIImage.preparingForDisplay` to decode animated image frames ahead of time, eliminating the need to decode them on the main thread.

Both changes independently solve the performance issue, but both are included here for discussion and further evaluation.