### PR TITLE
Update xcframework zip file name

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,8 +82,8 @@ platform :ios do
       tag_name: target_version,
       description: release_log[:text],
       upload_assets: [
-        "build/Kingfisher-#{target_version}.zip",
-        "build/Kingfisher-iOS-#{target_version}.zip"
+        "build/Kingfisher-#{target_version}.xcframework.zip",
+        "build/Kingfisher-iOS-#{target_version}.xcframework.zip"
       ]
     )
     
@@ -149,7 +149,7 @@ platform :ios do
 
       zip(
         path: "build/#{output_base_name}",
-        output_path: "build/#{output_base_name}.zip",
+        output_path: "build/#{output_base_name}.xcframework.zip",
         symlinks: true
       )
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -140,15 +140,17 @@ platform :ios do
         "Kingfisher-#{output_name}-#{version}"
       end
       
+      output_xcframework_path = "build/#{output_base_name}/Kingfisher.xcframework"
+
       create_xcframework(
         frameworks_with_dsyms: frameworks,
-        output: "build/#{output_base_name}/Kingfisher.xcframework"
+        output: output_xcframework_path
       )
 
       Actions.sh("codesign --timestamp -v --sign 'Apple Distribution: Wei Wang (A4YJ9MRZ66)' ../build/#{output_base_name}/Kingfisher.xcframework")
 
       zip(
-        path: "build/#{output_base_name}",
+        path: output_xcframework_path,
         output_path: "build/#{output_base_name}.xcframework.zip",
         symlinks: true
       )


### PR DESCRIPTION
For #2359 

Contain `.xcframework` to make clear and allow Carthage to find the binary.

Now the pre-built xcframeworks files includes the `xcframework` in the file name in the release page. 

- Before: `Kingfisher-${version}.zip`
- Now: `Kingfisher-${version}.xcframework.zip` 

The `xcframework` bundle is also now direct in the zip file as its root content, instead of being nested in a folder. 

- Before: `Kingfisher-${version}.zip` -> `Kingfisher-${version}/Kingfisher.xcframework`
- Now: `Kingfisher-${version}.zip` -> `Kingfisher.xcframework`

This change is for better discoverability for some package managers. However, it might break some scripts that rely on the old structure. Please update your scripts accordingly if you were relying on the old filename and zip structure.