### PR TITLE
Fix progressive loading provider leak

### DIFF
--- a/Sources/General/KFOptionsSetter.swift
+++ b/Sources/General/KFOptionsSetter.swift
@@ -44,7 +44,7 @@ public protocol KFOptionSetter {
 
 extension KF.Builder: KFOptionSetter { }
 
-final class KFDelegateObserver: Sendable {
+final actor KFDelegateObserver {
     static let `default` = KFDelegateObserver()
 }
 

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -277,12 +277,13 @@ public class KingfisherManager: @unchecked Sendable {
     {
         var options = options
         let retryStrategy = options.retryStrategy
-        
+
+        let progressiveJPEG = options.progressiveJPEG
         if let provider = ImageProgressiveProvider(options: options, refresh: { image in
             guard let setter = progressiveImageSetter else {
                 return
             }
-            guard let strategy = options.progressiveJPEG?.onImageUpdated(image) else {
+            guard let strategy = progressiveJPEG?.onImageUpdated(image) else {
                 setter(image)
                 return
             }


### PR DESCRIPTION
The progressive provider and side effect should not leak now. :]

This fixes #2299 

<img width="1230" alt="截屏2025-03-04 22 33 07" src="https://github.com/user-attachments/assets/d0e4f02c-1782-4926-bb12-94ef328000d2" />
