### PR TITLE
feat: add BUILD_LIBRARY_FOR_DISTRIBUTION flag to podspec

### DIFF
--- a/Kingfisher.podspec
+++ b/Kingfisher.podspec
@@ -36,6 +36,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/onevcat/Kingfisher.git", :tag => s.version }
   s.source_files  = ["Sources/**/*.swift"]
   s.resource_bundles = {"Kingfisher" => ["Sources/PrivacyInfo.xcprivacy"]}
+  s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
 
   s.requires_arc = true
   s.frameworks = "CFNetwork", "Accelerate"


### PR DESCRIPTION
`BUILD_LIBRARY_FOR_DISTRIBUTION = YES` is essential for both source and binary distribution, but its primary benefits and the reasons it's crucial relate to how the Swift compiler handles modules and binary compatibility. 

When enabled, the Swift compiler generates a .swiftinterface file alongside your compiled .swiftmodule. This .swiftinterface acts as a stable, textual representation of your library's public API.  It's an Application Binary Interface (ABI) contract.
This should prevent from setting the flag manually in a host app that integrates the SDK.

- CocoaPods: The line `s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }` in your podspec explicitly tells CocoaPods to enable this build setting when it builds your library, whether it's building it from source or creating an XCFramework. Without this line, CocoaPods might use a default setting that doesn't include module stability.

- Swift Package Manager (SPM): SPM implicitly enables `BUILD_LIBRARY_FOR_DISTRIBUTION` (or its equivalent) when you define a .library product in your Package.swift. This is why you don't need to add any extra configuration to your Package.swift. SPM handles module stability by default.