### PR TITLE
Refactor cacheFileName method

### DIFF
--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -372,22 +372,26 @@ public enum DiskStorage {
         }
         
         func cacheFileName(forKey key: String, forcedExtension: String? = nil) -> String {
-            // TODO: Bad code... Consider refactoring.
-            if config.usesHashedFileName {
-                let hashedKey = key.kf.sha256
-                if let ext = forcedExtension ?? config.pathExtension {
-                    return "\(hashedKey).\(ext)"
-                } else if config.autoExtAfterHashedFileName,
-                          let ext = forcedExtension ?? key.kf.ext {
-                    return "\(hashedKey).\(ext)"
-                }
-                return hashedKey
-            } else {
-                if let ext = forcedExtension ?? config.pathExtension {
-                    return "\(key).\(ext)"
-                }
-                return key
+            let baseName = config.usesHashedFileName ? key.kf.sha256 : key
+            let fileExtension = setFileExtension(key: key, forcedExtension: forcedExtension)
+            
+            if let fileExtension = fileExtension {
+                return "\(baseName).\(fileExtension)"
             }
+            
+            return baseName
+        }
+        
+        func setFileExtension(key: String, forcedExtension: String?) -> String? {
+            if let ext = forcedExtension ?? config.pathExtension {
+                return ext
+            }
+        
+            if config.usesHashedFileName && config.autoExtAfterHashedFileName {
+                return key.kf.ext
+            }
+        
+            return nil
         }
 
         func allFileURLs(for propertyKeys: [URLResourceKey]) throws -> [URL] {

--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -373,16 +373,15 @@ public enum DiskStorage {
         
         func cacheFileName(forKey key: String, forcedExtension: String? = nil) -> String {
             let baseName = config.usesHashedFileName ? key.kf.sha256 : key
-            let fileExtension = setFileExtension(key: key, forcedExtension: forcedExtension)
             
-            if let fileExtension = fileExtension {
-                return "\(baseName).\(fileExtension)"
+            if let ext = fileExtension(key: key, forcedExtension: forcedExtension) {
+                return "\(baseName).\(ext)"
             }
             
             return baseName
         }
         
-        func setFileExtension(key: String, forcedExtension: String?) -> String? {
+        func fileExtension(key: String, forcedExtension: String?) -> String? {
             if let ext = forcedExtension ?? config.pathExtension {
                 return ext
             }


### PR DESCRIPTION
I've refactored the cacheFileName method with the following improvements.
- Extracted the file extension setting logic into a separate method.
- Restructured the nested conditionals to clearly indicate the priority order of file extensions.
- Removed redundant forcedExtension check in the second condition from setFileExtension method since it's already been checked in the first condition. If we reach the second condition, forcedExtension is guaranteed to be nil.

I have verified that all test cases in DiskStorageTests pass after the refactoring. 
This is my first open source contribution, so please excuse any shortcomings. Thank you for your understanding.