### PR TITLE
Fix ineffective cleanInterval parameter in DiskStorage after initial configuration.

### DIFF
--- a/Sources/Cache/MemoryStorage.swift
+++ b/Sources/Cache/MemoryStorage.swift
@@ -75,6 +75,11 @@ public enum MemoryStorage {
             didSet {
                 storage.totalCostLimit = config.totalCostLimit
                 storage.countLimit = config.countLimit
+                cleanTimer?.invalidate()
+                cleanTimer = .scheduledTimer(withTimeInterval: config.cleanInterval, repeats: true) { [weak self] _ in
+                    guard let self = self else { return }
+                    self.removeExpired()
+                }
             }
         }
 


### PR DESCRIPTION
DiskStorage's "config" parameter does nothing about the cleanTimer if it is set via property. I couldn't find an instance where storage is configured as such, yet the option is there and there might be users using the configuration like that.

I would usually extract a factory method to create "complex" objects like the timer here,  and making use of new Swift language features such as "[Allow implicit self for weak self captures, after self is unwrapped](https://www.hackingwithswift.com/swift/5.8/implicit-self-weak-capture)" and "[if/guard let shorthand for unwrapping optionals](https://www.hackingwithswift.com/swift/5.7/if-let-shorthand)" would be nice, but I just followed the old style to keep the code consistent.