### PR TITLE
SWIFT TASK CONTINUATION MISUSE fix

### DIFF
--- a/Sources/General/KingfisherError.swift
+++ b/Sources/General/KingfisherError.swift
@@ -363,6 +363,7 @@ public enum KingfisherError: Error {
     case processorError(reason: ProcessorErrorReason)
     /// Represents the error reason that can occur during image setting in a view related class.
     case imageSettingError(reason: ImageSettingErrorReason)
+    case swiftTaskCancelled
 
     // MARK: Helper Properties & Methods
 
@@ -452,6 +453,7 @@ extension KingfisherError: LocalizedError {
         case .cacheError(let reason): return reason.errorDescription
         case .processorError(let reason): return reason.errorDescription
         case .imageSettingError(let reason): return reason.errorDescription
+        case .swiftTaskCancelled: return "The task was cancelled."
         }
     }
 }
@@ -485,6 +487,7 @@ extension KingfisherError: CustomNSError {
         case .cacheError(let reason): return reason.errorCode
         case .processorError(let reason): return reason.errorCode
         case .imageSettingError(let reason): return reason.errorCode
+        case .swiftTaskCancelled: return 3333
         }
     }
 }

--- a/Sources/General/KingfisherError.swift
+++ b/Sources/General/KingfisherError.swift
@@ -363,7 +363,6 @@ public enum KingfisherError: Error {
     case processorError(reason: ProcessorErrorReason)
     /// Represents the error reason that can occur during image setting in a view related class.
     case imageSettingError(reason: ImageSettingErrorReason)
-    case swiftTaskCancelled
 
     // MARK: Helper Properties & Methods
 
@@ -453,7 +452,6 @@ extension KingfisherError: LocalizedError {
         case .cacheError(let reason): return reason.errorDescription
         case .processorError(let reason): return reason.errorDescription
         case .imageSettingError(let reason): return reason.errorDescription
-        case .swiftTaskCancelled: return "The task was cancelled."
         }
     }
 }
@@ -487,7 +485,6 @@ extension KingfisherError: CustomNSError {
         case .cacheError(let reason): return reason.errorCode
         case .processorError(let reason): return reason.errorCode
         case .imageSettingError(let reason): return reason.errorCode
-        case .swiftTaskCancelled: return 3333
         }
     }
 }

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -831,7 +831,7 @@ extension KingfisherManager {
     ) async throws -> RetrieveImageResult {
         // Check for cancellation before even starting
         if Task.isCancelled {
-            throw KingfisherError.swiftTaskCancelled
+            throw CancellationError()
         }
 
         // Create a task-local actor to safely manage the continuation state
@@ -891,7 +891,7 @@ extension KingfisherManager {
                 if Task.isCancelled {
                     downloadTask?.cancel()
                     Task {
-                        await continuationManager.resumeWithError(KingfisherError.swiftTaskCancelled)
+                        await continuationManager.resumeWithError(CancellationError())
                     }
                 } else {
                     Task {
@@ -903,7 +903,7 @@ extension KingfisherManager {
             Task {
                 await task.task?.cancel()
                 // Ensure continuation is resumed on cancellation
-                await continuationManager.resumeWithError(KingfisherError.swiftTaskCancelled)
+                await continuationManager.resumeWithError(CancellationError())
             }
         }
     }


### PR DESCRIPTION
We’re encountering an issue related to Swift concurrency when using Kingfisher. Specifically, we’re seeing the following runtime warning:

```
SWIFT TASK CONTINUATION MISUSE: retrieveImage(with:options:progressiveImageSetter:referenceTaskIdentifierChecker:) leaked its continuation without resuming it. 
```

This may cause tasks waiting on it to remain suspended forever.
Our concern is around proper handling of task cancellation. Shouldn't the continuation be resumed even when Task.isCancelled is true?

```
func retrieveImage(
        with source: Source,
        options: KingfisherParsedOptionsInfo,
        progressiveImageSetter: ((KFCrossPlatformImage?) -> Void)? = nil,
        referenceTaskIdentifierChecker: (() -> Bool)? = nil
    ) async throws -> RetrieveImageResult
    {
        let task = CancellationDownloadTask()
        return try await withTaskCancellationHandler {
            try await withCheckedThrowingContinuation { continuation in
                let downloadTask = retrieveImage(
                    with: source,
                    options: options,
                    downloadTaskUpdated: { newTask in
                        Task {
                            await task.setTask(newTask)
                        }
                    },
                    progressiveImageSetter: progressiveImageSetter,
                    referenceTaskIdentifierChecker: referenceTaskIdentifierChecker,
                    completionHandler: { result in
                        continuation.resume(with: result)
                    }
                )
                if Task.isCancelled {
                    downloadTask?.cancel()
                } else {
                    Task {
                        await task.setTask(downloadTask)
                    }
                }
            }
        } onCancel: {
            Task {
                await task.task?.cancel()
            }
        }
    }
```
    
    
This pull request refactors the `KingfisherManager` extension in `Sources/General/KingfisherManager.swift` to improve cancellation handling and ensure thread safety during asynchronous operations. The changes introduce a task-local actor for managing continuation state and enhance the cancellation logic.

### Improvements to cancellation handling:

* **Pre-check for cancellation:** Added a check for `Task.isCancelled` at the start of the method to avoid unnecessary processing if the task is already canceled.

* **Continuation management with actor:** Introduced a task-local actor (`ContinuationManager`) to safely manage the continuation state, ensuring thread-safe handling of asynchronous operations.

### Enhanced thread safety:

* **Safe continuation resumption:** Updated the completion handler to use the actor for resuming the continuation safely based on the result (`success` or `failure`).

* **Cancellation during setup:** Added logic to handle cancellation that might occur during the setup phase, ensuring proper cleanup and continuation resumption.

* **On-cancel logic:** Modified the `onCancel` block to use the actor for safely resuming the continuation with a `CancellationError`.