### PR TITLE
Fix ThumbnailImageDataProvider image orientation issue

### DIFF
--- a/Sources/General/ImageSource/ImageDataProvider.swift
+++ b/Sources/General/ImageSource/ImageDataProvider.swift
@@ -245,7 +245,8 @@ public struct ThumbnailImageDataProvider: ImageDataProvider {
                 
                 let options = [
                     kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
-                    kCGImageSourceCreateThumbnailFromImageAlways: alwaysCreateThumbnail
+                    kCGImageSourceCreateThumbnailFromImageAlways: alwaysCreateThumbnail,
+                    kCGImageSourceCreateThumbnailWithTransform: true
                 ]
                 
                 guard let thumbnailRef = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options as CFDictionary) else {


### PR DESCRIPTION
## Summary

This PR fixes an issue where `ThumbnailImageDataProvider` does not handle image orientation correctly. The generated thumbnails may not match the orientation of the original image as seen by users due to missing EXIF orientation transformation.

## Changes

- Added `kCGImageSourceCreateThumbnailWithTransform: true` option to the thumbnail generation options in `ThumbnailImageDataProvider`
- This ensures that thumbnails respect the original image's EXIF orientation data

## Technical Details

When using `CGImageSourceCreateThumbnailAtIndex` to generate thumbnails, the `kCGImageSourceCreateThumbnailWithTransform` option is required to automatically apply any transformation specified in the image's metadata (such as EXIF orientation). Without this option, thumbnails could appear rotated compared to the original image.

## Testing

- All existing tests pass
- CocoaPods spec linting passes
- Swift Package Manager build succeeds

## Closes

Fixes #2395

## Test Plan

1. Create an image with EXIF orientation data (e.g., taken with a rotated camera)
2. Use `ThumbnailImageDataProvider` to generate a thumbnail
3. Verify that the thumbnail orientation matches the original image orientation as displayed by the Photos app or other image viewers