### PR TITLE
Add Carthage support for both watchOS and iOS platforms

### DIFF
--- a/Kingfisher.json
+++ b/Kingfisher.json
@@ -1,0 +1,5 @@
+{
+  "8.3.2": "https://github.com/onevcat/Kingfisher/releases/download/8.3.2/Kingfisher-8.3.2.xcframework.zip",
+  "8.3.1": "https://github.com/onevcat/Kingfisher/releases/download/8.3.1/Kingfisher-8.3.1.xcframework.zip",
+  "8.3.0": "https://github.com/onevcat/Kingfisher/releases/download/8.3.0/Kingfisher-8.3.0.xcframework.zip"
+}


### PR DESCRIPTION
According to Cathage default behavior, Carthage would download iOS version zip to extract framework, which would cause that watchOS building may be failed. Because Kingfisher from `8.3.0` has `2 zip bundles` for resource. 
> #1992 

Add a Kingfisher.json as a workaround to let Carthage users to download the right zip by `binary "https://raw.githubusercontent.com/onevcat/Kingfisher/master/Kingfisher.json"`