### PR TITLE
Fix test timing issue in ImageCacheTests

### DIFF
--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -376,7 +376,7 @@ class ImageCacheTests: XCTestCase {
                 exp.fulfill()
             }
 
-            delay(1) {
+            delay(2) { // File writing in disk cache has an approximate (round) creating time. 1 second is not enough.
                 self.cache.cleanExpiredDiskCache()
             }
         }


### PR DESCRIPTION
## Summary
- Increased delay from 1 to 2 seconds in `testCleanDiskCacheWithUsedSpaceInsufficient` test
- Fixes CI test stability issues caused by disk cache file writing timing

## Test plan
- [x] Run test suite locally with `bundle exec fastlane tests`
- [x] Verify CI tests pass consistently
- [x] Confirm the test no longer fails intermittently