### PR TITLE
Fix documentation for loadDiskFileSynchronously in SwiftUI components

### DIFF
--- a/Sources/General/KFOptionsSetter.swift
+++ b/Sources/General/KFOptionsSetter.swift
@@ -294,11 +294,15 @@ extension KFOptionSetter {
     ///
     /// By default, disk storage file loading operates in its own queue with asynchronous dispatch behavior. While this 
     /// provides better non-blocking disk loading performance, it can result in flickering when reloading an image
-    ///  from disk if the image view already has an image set.
+    /// from disk if the image view already has an image set.
     ///
     /// Enabling this option prevents flickering by performing all loading in the same queue (typically the UI queue if 
     /// you are using Kingfisher's extension methods to set an image). However, this may come at the cost of loading
     /// performance.
+    ///
+    /// - Note: When using SwiftUI components (e.g., `KFImage`), this option is enabled by default to prevent 
+    /// flickering during view updates. This is essential for maintaining visual consistency in SwiftUI's declarative
+    /// environment. For UIKit/AppKit usage, the default remains `false` for optimal performance.
     ///
     public func loadDiskFileSynchronously(_ enabled: Bool = true) -> Self {
         options.loadDiskFileSynchronously = enabled

--- a/Sources/SwiftUI/KFAnimatedImage.swift
+++ b/Sources/SwiftUI/KFAnimatedImage.swift
@@ -28,6 +28,15 @@
 import SwiftUI
 import Combine
 
+/// Represents an animated image view in SwiftUI that manages its content using Kingfisher.
+///
+/// Similar to ``KFImage``, this view provides support for animated image formats like GIF.
+///
+/// - Important: Like ``KFImage``, `KFAnimatedImage` loads disk cached images synchronously by default 
+/// (`.loadDiskFileSynchronously()` is enabled). This prevents image flickering during SwiftUI view updates 
+/// but may impact performance when loading large animated images from disk. You can disable this behavior 
+/// by calling `.loadDiskFileSynchronously(false)` if you prefer better loading performance over visual consistency.
+///
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, *)
 public struct KFAnimatedImage: KFImageProtocol {
     public typealias HoldingView = KFAnimatedImageViewRepresenter

--- a/Sources/SwiftUI/KFImage.swift
+++ b/Sources/SwiftUI/KFImage.swift
@@ -61,6 +61,11 @@ import Combine
 /// Here only very few are listed as demonstration. To check other available modifiers, see ``KFOptionSetter`` and its
 /// extension methods.
 ///
+/// - Important: `KFImage` loads disk cached images synchronously by default (`.loadDiskFileSynchronously()` is enabled).
+/// This prevents image flickering during SwiftUI view updates but may impact performance when loading large images from disk.
+/// You can disable this behavior by calling `.loadDiskFileSynchronously(false)` if you prefer better loading performance
+/// over visual consistency.
+///
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public struct KFImage: KFImageProtocol {
     


### PR DESCRIPTION
## Summary
- Updated documentation to accurately reflect that SwiftUI components enable `loadDiskFileSynchronously` by default
- Added clarifying notes about the different default behaviors between UIKit/AppKit and SwiftUI usage
- Explained the performance implications and how to disable this behavior if needed

## Details
This PR addresses issue #2403 which correctly pointed out that the documentation for `loadDiskFileSynchronously` was misleading. The documentation stated that disk loading happens asynchronously by default, but this is not the case for SwiftUI components (`KFImage` and `KFAnimatedImage`).

The synchronous loading default for SwiftUI is intentional and necessary to prevent image flickering during view updates in SwiftUI's declarative environment.

### Changes made:
1. **KFOptionsSetter.swift**: Added a Note to the `loadDiskFileSynchronously` method documentation clarifying the different defaults
2. **KFImage.swift**: Added an Important note explaining the default synchronous behavior
3. **KFAnimatedImage.swift**: Added similar documentation for animated images

## Test plan
This is a documentation-only change. No functional changes were made to the codebase.

Fixes #2403