### PR TITLE
Add network metrics collection

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/Base.lproj/Main.storyboard
+++ b/Demo/Demo/Kingfisher-Demo/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="peg-r0-mlo">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="peg-r0-mlo">
     <device id="retina5_5" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -515,8 +515,32 @@
                                             <segue destination="nhf-ZY-JwU" kind="show" id="Srz-py-yg9"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="TIF-8x-GLM">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="wqA-9Z-1Al">
                                         <rect key="frame" x="0.0" y="754" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wqA-9Z-1Al" id="zF8-ez-i13">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Network Metrics" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zRy-GJ-Gal">
+                                                    <rect key="frame" x="19.999999999999993" y="11.666666666666664" width="125.33333333333331" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="zRy-GJ-Gal" secondAttribute="trailing" constant="20" symbolic="YES" id="Z4X-JI-dgy"/>
+                                                <constraint firstItem="zRy-GJ-Gal" firstAttribute="centerY" secondItem="zF8-ez-i13" secondAttribute="centerY" id="Zaf-1G-5CY"/>
+                                                <constraint firstItem="zRy-GJ-Gal" firstAttribute="leading" secondItem="zF8-ez-i13" secondAttribute="leading" constant="20" symbolic="YES" id="ncb-FX-kMj"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="Pg3-sc-Em9" kind="show" id="aWn-Nh-tPk"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="TIF-8x-GLM">
+                                        <rect key="frame" x="0.0" y="798" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="TIF-8x-GLM" id="ykx-Ds-PkP">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -1063,6 +1087,22 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Idc-Kb-7jc" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1850.7246376811595" y="1735.5978260869567"/>
+        </scene>
+        <!--Network Metrics View Controller-->
+        <scene sceneID="zOx-Gp-KL6">
+            <objects>
+                <viewController id="Pg3-sc-Em9" customClass="NetworkMetricsViewController" customModule="Kingfisher_Demo" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="PY3-v0-EIu">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="5i9-7s-TjX"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="aD3-6d-iIp"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="K6C-pd-2au" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2654" y="-1114"/>
         </scene>
         <!--SwiftUI View Controller-->
         <scene sceneID="rw7-vi-6Ep">

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/MainView.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/MainView.swift
@@ -55,6 +55,7 @@ struct MainView: View {
                 NavigationLink(destination: LoadTransitionDemo()) { Text("Load Transition") }
                 NavigationLink(destination: ProgressiveJPEGDemo()) { Text("Progressive JPEG") }
                 NavigationLink(destination: LoadingFailureDemo()) { Text("Loading Failure") }
+                NavigationLink(destination: NetworkMetricsDemo()) { Text("Network Metrics") }
             }
             
             Section(header: Text("Regression Cases")) {

--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/NetworkMetricsDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/NetworkMetricsDemo.swift
@@ -1,0 +1,303 @@
+//
+//  NetworkMetricsDemo.swift
+//  Demo
+//
+//  Created by FunnyValentine on 2025/07/25.
+//
+
+import SwiftUI
+import Kingfisher
+
+@available(iOS 14.0, *)
+struct NetworkMetricsDemo: View {
+    @State private var imageURL = URL(string: "https://picsum.photos/200/150?random=\(Int.random(in: 1...1000))")!
+    @State private var metricsInfo = "Tap a button to load image..."
+    @State private var isLoading = false
+    @State private var showImage = true
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                imageSection
+                metricsInfoSection
+                buttonsSection
+                
+                Spacer(minLength: 20)
+            }
+            .padding()
+        }
+        .navigationTitle("Network Metrics")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    // MARK: - UI Components
+    
+    private var imageSection: some View {
+        VStack {
+            if showImage {
+                KFImage(imageURL)
+                    .onProgress { _, _ in
+                        isLoading = true
+                    }
+                    .onSuccess { result in
+                        isLoading = false
+                        displayMetrics(result: result)
+                    }
+                    .onFailure { error in
+                        isLoading = false
+                        metricsInfo = "Failed to load image: \(error.localizedDescription)"
+                        print("error: \(error)")
+                    }
+                    .placeholder {
+                        placeholderView(text: isLoading ? "Loading..." : "Tap button to load")
+                    }
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxHeight: 150)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            } else {
+                placeholderView(text: "Reloading...")
+            }
+        }
+        .frame(width: 200, height: 150)
+        .padding(.bottom, 10)
+    }
+    
+    private var metricsInfoSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Metrics Information")
+                .font(.headline)
+            
+            VStack {
+                Text(metricsInfo)
+                    .font(.system(.caption, design: .monospaced))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+                Spacer()
+            }
+            .frame(height: 400)
+            .background(Color.gray.opacity(0.1))
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+    }
+    
+    private var buttonsSection: some View {
+        VStack(spacing: 12) {
+            actionButton(
+                title: "From Network",
+                icon: "wifi",
+                color: .red,
+                action: loadFromNetwork
+            )
+            
+            HStack(spacing: 12) {
+                actionButton(
+                    title: "From Memory",
+                    icon: "memorychip",
+                    color: .orange,
+                    action: loadFromMemory
+                )
+                
+                actionButton(
+                    title: "From Disk",
+                    icon: "internaldrive",
+                    color: .purple,
+                    action: loadFromDisk
+                )
+            }
+        }
+    }
+    
+    // MARK: - Helper Views
+    
+    private func placeholderView(text: String) -> some View {
+        RoundedRectangle(cornerRadius: 8)
+            .fill(Color.gray.opacity(0.3))
+            .frame(width: 200, height: 150)
+            .overlay(
+                Text(text)
+                    .foregroundColor(.gray)
+            )
+    }
+    
+    private func actionButton(title: String, icon: String, color: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack {
+                Image(systemName: icon)
+                Text(title)
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(color)
+            .foregroundColor(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+    }
+    
+    private func loadFromNetwork() {
+        // Refresh image
+        showImage = false
+        // Clear all cache to force network download
+        KingfisherManager.shared.cache.clearCache()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            showImage = true
+        }
+    }
+    
+    private func loadFromMemory() {
+        // Refresh image
+        showImage = false
+        // Clear disk cache only, keep memory cache
+        KingfisherManager.shared.cache.clearDiskCache()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            showImage = true
+        }
+    }
+    
+    private func loadFromDisk() {
+        // Refresh image
+        showImage = false
+        // Clear memory cache only, keep disk cache
+        KingfisherManager.shared.cache.clearMemoryCache()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            showImage = true
+        }
+    }
+    
+    private func displayMetrics(result: RetrieveImageResult) {
+        var info = "=== Image Load Results ===\n\n"
+        
+        // Basic info
+        info += "Cache Type: \(cacheTypeDescription(result.cacheType))\n\n"
+        
+        // Network Metrics
+        if let metrics = result.metrics {
+            info += "=== Network Metrics ===\n"
+            info += "✅ Downloaded from network\n\n"
+            
+            // Timing metrics
+            info += "📊 Timing Breakdown:\n"
+            info += "Total Request: \(String(format: "%.3f", metrics.totalRequestDuration))s\n"
+
+            if let dnsTime = metrics.domainLookupDuration {
+                info += "DNS Lookup: \(String(format: "%.3f", dnsTime))s\n"
+            } else {
+                info += "DNS Lookup: N/A (cached or skipped)\n"
+            }
+            
+            if let connectTime = metrics.connectDuration {
+                info += "TCP Connect: \(String(format: "%.3f", connectTime))s\n"
+            } else {
+                info += "TCP Connect: N/A (reused connection)\n"
+            }
+            
+            if let tlsTime = metrics.secureConnectionDuration {
+                info += "TLS Handshake: \(String(format: "%.3f", tlsTime))s\n"
+            } else {
+                info += "TLS Handshake: N/A (HTTP or reused)\n"
+            }
+            
+            // Data transfer
+            info += "\n📈 Data Transfer:\n"
+            info += "Request Body: \(formatBytes(metrics.requestBodyBytesSent))\n"
+            info += "Response Body: \(formatBytes(metrics.responseBodyBytesReceived))\n"
+            
+            if metrics.responseBodyBytesReceived > 0 {
+                let speed = Double(metrics.responseBodyBytesReceived) / metrics.totalRequestDuration
+                info += "Download Speed: \(formatBytes(Int64(speed)))/s\n"
+            }
+            
+            // HTTP details
+            info += "\n🌐 HTTP Details:\n"
+            if let statusCode = metrics.httpStatusCode {
+                info += "Status Code: \(statusCode) \(httpStatusDescription(statusCode))\n"
+            }
+            info += "Redirects: \(metrics.redirectCount)\n"
+            
+            
+        } else {
+            info += "=== Network Metrics ===\n"
+            info += "💾 Loaded from cache\n"
+            info += "No network request was made\n\n"
+            
+            info += "This image was served from:\n"
+            switch result.cacheType {
+            case .memory:
+                info += "• Memory cache (fastest)\n"
+            case .disk:
+                info += "• Disk cache (fast)\n"
+            case .none:
+                info += "• Network (but no metrics available)\n"
+            @unknown default:
+                info += "• Unknown cache type\n"
+            }
+        }
+        
+        metricsInfo = info
+    }
+    
+    private func cacheTypeDescription(_ cacheType: CacheType) -> String {
+        switch cacheType {
+        case .memory:
+            return "Memory Cache 🚀"
+        case .disk:
+            return "Disk Cache 💽"
+        case .none:
+            return "Network Download 🌐"
+        @unknown default:
+            return "Unknown"
+        }
+    }
+    
+    private func httpStatusDescription(_ statusCode: Int) -> String {
+        switch statusCode {
+        case 200:
+            return "OK"
+        case 201:
+            return "Created"
+        case 204:
+            return "No Content"
+        case 301:
+            return "Moved Permanently"
+        case 302:
+            return "Found"
+        case 304:
+            return "Not Modified"
+        case 400:
+            return "Bad Request"
+        case 401:
+            return "Unauthorized"
+        case 403:
+            return "Forbidden"
+        case 404:
+            return "Not Found"
+        case 500:
+            return "Internal Server Error"
+        default:
+            return ""
+        }
+    }
+    
+    private func formatBytes(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useBytes, .useKB, .useMB]
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: bytes)
+    }
+    
+    private func formatTime(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .medium
+        formatter.dateStyle = .none
+        return formatter.string(from: date)
+    }
+}
+
+@available(iOS 14.0, *)
+struct NetworkMetricsDemo_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            NetworkMetricsDemo()
+        }
+    }
+}

--- a/Demo/Demo/Kingfisher-Demo/ViewControllers/NetworkMetricsViewController.swift
+++ b/Demo/Demo/Kingfisher-Demo/ViewControllers/NetworkMetricsViewController.swift
@@ -1,0 +1,381 @@
+//
+//  NetworkMetricsViewController.swift
+//  Demo
+//
+//  Created by FunnyValentine on 2025/07/25.
+//
+
+import UIKit
+import Kingfisher
+
+class NetworkMetricsViewController: UIViewController {
+    
+    // MARK: - UI Components
+    
+    private let imageView = UIImageView()
+    private let metricsTextView = UITextView()
+    private let fromNetworkButton = UIButton(type: .system)
+    private let fromMemoryButton = UIButton(type: .system) 
+    private let fromDiskButton = UIButton(type: .system)
+    private let stackView = UIStackView()
+    private let buttonStackView = UIStackView()
+    private let metricsContainer = UIView()
+    
+    // MARK: - Properties
+    
+    private var currentImageURL = URL(string: "https://picsum.photos/200/150?random=\(Int.random(in: 1...1000))")!
+    private var showImage = true
+    
+    // MARK: - Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupConstraints()
+        setupInitialContent()
+    }
+    
+    // MARK: - UI Setup
+    
+    private func setupUI() {
+        title = "Network Metrics"
+        view.backgroundColor = .systemBackground
+        
+        setupImageView()
+        setupMetricsTextView()
+        setupButtons()
+        setupStackViews()
+    }
+    
+    private func setupImageView() {
+        imageView.contentMode = .scaleAspectFit
+        imageView.layer.cornerRadius = 8
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .clear  // Clear background
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    private func setupMetricsTextView() {
+        metricsTextView.isEditable = false
+        metricsTextView.backgroundColor = UIColor.systemGray6
+        metricsTextView.layer.cornerRadius = 8
+        metricsTextView.font = UIFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+        metricsTextView.text = "Tap a button to load image..."
+        metricsTextView.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    private func setupButtons() {
+        setupButton(fromNetworkButton, title: "From Network", icon: "wifi", color: .systemRed, action: #selector(fromNetworkButtonTapped))
+        setupButton(fromMemoryButton, title: "From Memory", icon: "memorychip", color: .systemOrange, action: #selector(fromMemoryButtonTapped))
+        setupButton(fromDiskButton, title: "From Disk", icon: "internaldrive", color: .systemPurple, action: #selector(fromDiskButtonTapped))
+    }
+    
+    private func setupButton(_ button: UIButton, title: String, icon: String, color: UIColor, action: Selector) {
+        button.setTitle(title, for: .normal)
+        button.setImage(UIImage(systemName: icon), for: .normal)
+        button.backgroundColor = color
+        button.setTitleColor(.white, for: .normal)
+        button.tintColor = .white
+        button.layer.cornerRadius = 8
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .medium)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: action, for: .touchUpInside)
+        
+        // Configure image and title positioning
+        button.imageEdgeInsets = UIEdgeInsets(top: 0, left: -8, bottom: 0, right: 0)
+        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 0)
+    }
+    
+    private func setupStackViews() {
+        // Button stack view
+        buttonStackView.axis = .vertical
+        buttonStackView.distribution = .fillEqually
+        buttonStackView.spacing = 12
+        buttonStackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        // Network button takes full width
+        buttonStackView.addArrangedSubview(fromNetworkButton)
+        
+        // Memory and Disk buttons in horizontal stack
+        let horizontalButtonStack = UIStackView()
+        horizontalButtonStack.axis = .horizontal
+        horizontalButtonStack.distribution = .fillEqually
+        horizontalButtonStack.spacing = 12
+        horizontalButtonStack.addArrangedSubview(fromMemoryButton)
+        horizontalButtonStack.addArrangedSubview(fromDiskButton)
+        
+        buttonStackView.addArrangedSubview(horizontalButtonStack)
+        
+        // Main stack view
+        stackView.axis = .vertical
+        stackView.spacing = 20
+        stackView.alignment = .center  // Center align all items
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        setupMetricsSection()
+        
+        stackView.addArrangedSubview(imageView)
+        stackView.addArrangedSubview(metricsContainer)
+        stackView.addArrangedSubview(buttonStackView)
+        
+        view.addSubview(stackView)
+    }
+    
+    private func setupMetricsSection() {
+        metricsContainer.translatesAutoresizingMaskIntoConstraints = false
+        
+        let titleLabel = UILabel()
+        titleLabel.text = "Metrics Information"
+        titleLabel.font = UIFont.systemFont(ofSize: 18, weight: .semibold)
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        metricsContainer.addSubview(titleLabel)
+        metricsContainer.addSubview(metricsTextView)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: metricsContainer.topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: metricsContainer.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: metricsContainer.trailingAnchor),
+            titleLabel.heightAnchor.constraint(equalToConstant: 22),
+            
+            metricsTextView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            metricsTextView.leadingAnchor.constraint(equalTo: metricsContainer.leadingAnchor),
+            metricsTextView.trailingAnchor.constraint(equalTo: metricsContainer.trailingAnchor),
+            metricsTextView.bottomAnchor.constraint(equalTo: metricsContainer.bottomAnchor),
+            metricsTextView.heightAnchor.constraint(equalToConstant: 400)
+        ])
+    }
+    
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+            
+            imageView.heightAnchor.constraint(equalToConstant: 150),
+            imageView.widthAnchor.constraint(equalToConstant: 200),
+
+            fromNetworkButton.heightAnchor.constraint(equalToConstant: 44),
+            fromMemoryButton.heightAnchor.constraint(equalToConstant: 44),
+            fromDiskButton.heightAnchor.constraint(equalToConstant: 44),
+            
+            // Make button stack view and metrics container full width
+            buttonStackView.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            buttonStackView.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+            
+            metricsContainer.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            metricsContainer.trailingAnchor.constraint(equalTo: stackView.trailingAnchor)
+        ])
+    }
+    
+    private func setupInitialContent() {
+        // Set initial placeholder
+        imageView.image = createPlaceholderImage(text: "Tap button to load")
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func fromNetworkButtonTapped() {
+        // Set placeholder and hide image
+        showImage = false
+        imageView.image = createPlaceholderImage(text: "Reloading...")
+        // Clear all cache to force network download
+        KingfisherManager.shared.cache.clearCache()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.showImage = true
+            self.loadImage()
+        }
+    }
+    
+    @objc private func fromMemoryButtonTapped() {
+        // Set placeholder and hide image
+        showImage = false
+        imageView.image = createPlaceholderImage(text: "Reloading...")
+        // Clear disk cache only, keep memory cache
+        KingfisherManager.shared.cache.clearDiskCache()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.showImage = true
+            self.loadImage()
+        }
+    }
+    
+    @objc private func fromDiskButtonTapped() {
+        // Set placeholder and hide image  
+        showImage = false
+        imageView.image = createPlaceholderImage(text: "Reloading...")
+        // Clear memory cache only, keep disk cache
+        KingfisherManager.shared.cache.clearMemoryCache()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.showImage = true
+            self.loadImage()
+        }
+    }
+    
+    // MARK: - Image Loading
+    
+    private func loadImage() {
+        guard showImage else { return }
+        
+        let placeholder = createPlaceholderImage(text: "Loading...")
+        
+        imageView.kf.setImage(
+            with: currentImageURL,
+            placeholder: placeholder,
+            options: nil,
+            completionHandler: { [weak self] result in
+                DispatchQueue.main.async {
+                    switch result {
+                    case .success(let retrieveImageResult):
+                        self?.displayMetrics(result: retrieveImageResult)
+                    case .failure(let error):
+                        self?.metricsTextView.text = "Failed to load image: \(error.localizedDescription)"
+                        print("Error: \(error)")
+                    }
+                }
+            }
+        )
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func createPlaceholderImage(text: String) -> UIImage {
+        let size = CGSize(width: 200, height: 150)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        
+        return renderer.image { context in
+            let rect = CGRect(origin: .zero, size: size)
+            
+            // Draw background with rounded corners
+            let path = UIBezierPath(roundedRect: rect, cornerRadius: 8)
+            UIColor.systemGray5.setFill()
+            path.fill()
+            
+            // Draw text
+            let attributes: [NSAttributedString.Key: Any] = [
+                .foregroundColor: UIColor.systemGray,
+                .font: UIFont.systemFont(ofSize: 16)
+            ]
+            
+            let attributedText = NSAttributedString(string: text, attributes: attributes)
+            let textSize = attributedText.size()
+            let textRect = CGRect(
+                x: (size.width - textSize.width) / 2,
+                y: (size.height - textSize.height) / 2,
+                width: textSize.width,
+                height: textSize.height
+            )
+            
+            attributedText.draw(in: textRect)
+        }
+    }
+    
+    private func displayMetrics(result: RetrieveImageResult) {
+        var info = "=== Image Load Results ===\n\n"
+        
+        // Basic info
+        info += "Cache Type: \(cacheTypeDescription(result.cacheType))\n\n"
+        
+        // Network Metrics
+        if let metrics = result.metrics {
+            info += "=== Network Metrics ===\n"
+            info += "✅ Downloaded from network\n\n"
+            
+            // Timing breakdown
+            info += "📊 Timing Breakdown:\n"
+            info += "Total Request: \(String(format: "%.3f", metrics.totalRequestDuration))s\n"
+            
+            if let dnsTime = metrics.domainLookupDuration {
+                info += "DNS Lookup: \(String(format: "%.3f", dnsTime))s\n"
+            } else {
+                info += "DNS Lookup: N/A (cached or skipped)\n"
+            }
+            
+            if let connectTime = metrics.connectDuration {
+                info += "TCP Connect: \(String(format: "%.3f", connectTime))s\n"
+            } else {
+                info += "TCP Connect: N/A (reused connection)\n"
+            }
+            
+            if let tlsTime = metrics.secureConnectionDuration {
+                info += "TLS Handshake: \(String(format: "%.3f", tlsTime))s\n"
+            } else {
+                info += "TLS Handshake: N/A (HTTP or reused)\n"
+            }
+            
+            // Data transfer
+            info += "\n📈 Data Transfer:\n"
+            info += "Request Body: \(formatBytes(metrics.requestBodyBytesSent))\n"
+            info += "Response Body: \(formatBytes(metrics.responseBodyBytesReceived))\n"
+            
+            if metrics.responseBodyBytesReceived > 0 {
+                let speed = Double(metrics.responseBodyBytesReceived) / metrics.totalRequestDuration
+                info += "Download Speed: \(formatBytes(Int64(speed)))/s\n"
+            }
+            
+            // HTTP details
+            info += "\n🌐 HTTP Details:\n"
+            if let statusCode = metrics.httpStatusCode {
+                info += "Status Code: \(statusCode) \(httpStatusDescription(statusCode))\n"
+            }
+            info += "Redirects: \(metrics.redirectCount)\n"
+            
+        } else {
+            info += "=== Network Metrics ===\n"
+            info += "💾 Loaded from cache\n"
+            info += "No network request was made\n\n"
+            
+            info += "This image was served from:\n"
+            switch result.cacheType {
+            case .memory:
+                info += "• Memory cache (fastest)\n"
+            case .disk:
+                info += "• Disk cache (fast)\n"
+            case .none:
+                info += "• Network (but no metrics available)\n"
+            @unknown default:
+                info += "• Unknown cache type\n"
+            }
+        }
+        
+        metricsTextView.text = info
+    }
+    
+    private func cacheTypeDescription(_ cacheType: CacheType) -> String {
+        switch cacheType {
+        case .memory:
+            return "Memory Cache 🚀"
+        case .disk:
+            return "Disk Cache 💽"
+        case .none:
+            return "Network Download 🌐"
+        @unknown default:
+            return "Unknown"
+        }
+    }
+    
+    private func httpStatusDescription(_ statusCode: Int) -> String {
+        switch statusCode {
+        case 200: return "OK"
+        case 201: return "Created"
+        case 204: return "No Content"
+        case 301: return "Moved Permanently"
+        case 302: return "Found"
+        case 304: return "Not Modified"
+        case 400: return "Bad Request"
+        case 401: return "Unauthorized"
+        case 403: return "Forbidden"
+        case 404: return "Not Found"
+        case 500: return "Internal Server Error"
+        default: return ""
+        }
+    }
+    
+    private func formatBytes(_ bytes: Int64) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useBytes, .useKB, .useMB]
+        formatter.countStyle = .file
+        return formatter.string(fromByteCount: bytes)
+    }
+}

--- a/Demo/Demo/Kingfisher-macOS-Demo/Base.lproj/Main.storyboard
+++ b/Demo/Demo/Kingfisher-macOS-Demo/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>

--- a/Demo/Kingfisher-Demo.xcodeproj/project.pbxproj
+++ b/Demo/Kingfisher-Demo.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		D1F78A662589F17200930759 /* SingleViewDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F78A632589F17200930759 /* SingleViewDemo.swift */; };
 		D1FAB06F21A853E600908910 /* HighResolutionCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FAB06E21A853E600908910 /* HighResolutionCollectionViewController.swift */; };
 		F344AEF22E1AD74F00BFE702 /* LoadTransitionDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F344AEF12E1AD74F00BFE702 /* LoadTransitionDemo.swift */; };
+		F39B68D22E33D36500404B02 /* NetworkMetricsDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39B68D12E33D36500404B02 /* NetworkMetricsDemo.swift */; };
+		F39B68D42E33E0D600404B02 /* NetworkMetricsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39B68D32E33E0D600404B02 /* NetworkMetricsViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -237,6 +239,8 @@
 		D1F78A632589F17200930759 /* SingleViewDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SingleViewDemo.swift; sourceTree = "<group>"; };
 		D1FAB06E21A853E600908910 /* HighResolutionCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighResolutionCollectionViewController.swift; sourceTree = "<group>"; };
 		F344AEF12E1AD74F00BFE702 /* LoadTransitionDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadTransitionDemo.swift; sourceTree = "<group>"; };
+		F39B68D12E33D36500404B02 /* NetworkMetricsDemo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMetricsDemo.swift; sourceTree = "<group>"; };
+		F39B68D32E33E0D600404B02 /* NetworkMetricsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMetricsViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -417,6 +421,7 @@
 				D16CC3D724E03FEA00F1A515 /* AVAssetImageGeneratorViewController.swift */,
 				078DCB502BCFEFB40008114E /* PHPickerResultViewController.swift */,
 				D1F78A5E2589F0AA00930759 /* SwiftUIViewController.swift */,
+				F39B68D32E33E0D600404B02 /* NetworkMetricsViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -468,6 +473,7 @@
 				D198F41F25EDC34000C53E0D /* SizingAnimationDemo.swift */,
 				072922422638639D0089E810 /* AnimatedImageDemo.swift */,
 				F344AEF12E1AD74F00BFE702 /* LoadTransitionDemo.swift */,
+				F39B68D12E33D36500404B02 /* NetworkMetricsDemo.swift */,
 			);
 			path = SwiftUIViews;
 			sourceTree = "<group>";
@@ -716,6 +722,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D16CC3D824E03FEA00F1A515 /* AVAssetImageGeneratorViewController.swift in Sources */,
+				F39B68D22E33D36500404B02 /* NetworkMetricsDemo.swift in Sources */,
 				C959EEE622874DC600467A10 /* ProgressiveJPEGViewController.swift in Sources */,
 				D1CE1BD321A1B45A00419000 /* ImageLoader.swift in Sources */,
 				D12EB83E24DD902300329EE1 /* TextAttachmentViewController.swift in Sources */,
@@ -725,6 +732,7 @@
 				D10AC99821A300C9005F057C /* ProcessorCollectionViewController.swift in Sources */,
 				D1F06F3921AAF1EE000B1C38 /* IndicatorCollectionViewController.swift in Sources */,
 				D1F78A662589F17200930759 /* SingleViewDemo.swift in Sources */,
+				F39B68D42E33E0D600404B02 /* NetworkMetricsViewController.swift in Sources */,
 				D12E0C981C47F91800AC98AD /* ImageCollectionViewCell.swift in Sources */,
 				D198F42025EDC34000C53E0D /* SizingAnimationDemo.swift in Sources */,
 				072922432638639D0089E810 /* AnimatedImageDemo.swift in Sources */,

--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		D8FCF6A821C5A0E500F9ABC0 /* RedirectHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FCF6A721C5A0E500F9ABC0 /* RedirectHandler.swift */; };
 		D9638BA61C7DC71F0046523D /* ImagePrefetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9638BA41C7DC71F0046523D /* ImagePrefetcherTests.swift */; };
 		E9E3ED8B2B1F66B200734CFF /* HasImageComponent+Kingfisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E3ED8A2B1F66B200734CFF /* HasImageComponent+Kingfisher.swift */; };
+		F39B68C82E33AC2A00404B02 /* NetworkMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39B68C72E33AC2A00404B02 /* NetworkMetrics.swift */; };
 		F72CE9CE1FCF17ED00CC522A /* ImageModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F72CE9CD1FCF17ED00CC522A /* ImageModifierTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -308,6 +309,7 @@
 		D8FCF6A721C5A0E500F9ABC0 /* RedirectHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RedirectHandler.swift; sourceTree = "<group>"; };
 		D9638BA41C7DC71F0046523D /* ImagePrefetcherTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImagePrefetcherTests.swift; sourceTree = "<group>"; };
 		E9E3ED8A2B1F66B200734CFF /* HasImageComponent+Kingfisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HasImageComponent+Kingfisher.swift"; sourceTree = "<group>"; };
+		F39B68C72E33AC2A00404B02 /* NetworkMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMetrics.swift; sourceTree = "<group>"; };
 		F72CE9CD1FCF17ED00CC522A /* ImageModifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageModifierTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -375,6 +377,7 @@
 				4BD821612189FC0C0084CC21 /* SessionDelegate.swift */,
 				4BD821662189FD330084CC21 /* SessionDataTask.swift */,
 				4B8E2916216F3F7F0095FAD1 /* ImageDownloaderDelegate.swift */,
+				F39B68C72E33AC2A00404B02 /* NetworkMetrics.swift */,
 				4B8E291B216F40AA0095FAD1 /* AuthenticationChallengeResponsable.swift */,
 				4B10480C216F157000300C61 /* ImageDataProcessor.swift */,
 				D12AB6A0215D2BB50013BA68 /* ImageModifier.swift */,
@@ -854,6 +857,7 @@
 				D18B3222251852E100662F63 /* KF.swift in Sources */,
 				D12AB704215D2BB50013BA68 /* Kingfisher.swift in Sources */,
 				D1AEB09725890DEA008556DF /* KFImage.swift in Sources */,
+				F39B68C82E33AC2A00404B02 /* NetworkMetrics.swift in Sources */,
 				D1BA781D2174D07800C69D7B /* CallbackQueue.swift in Sources */,
 				D12AB71C215D2BB50013BA68 /* FormatIndicatedCacheSerializer.swift in Sources */,
 				D1A37BF2215D3850009B39B7 /* SizeExtensions.swift in Sources */,

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -80,6 +80,37 @@ public struct RetrieveImageResult: Sendable {
     /// - Note: Retrieving this data can be a time-consuming operation, so it is advisable to store it if you need to 
     /// use it multiple times and avoid frequent calls to this method.
     public let data: @Sendable () -> Data?
+    
+    /// The network metrics collected during the download process.
+    ///
+    /// This property contains network performance metrics when the image was downloaded from the network
+    /// (`cacheType == .none`). For cached images (`cacheType == .memory` or `.disk`), this will be `nil`.
+    public let metrics: NetworkMetrics?
+    
+    /// Creates a RetrieveImageResult.
+    ///
+    /// - Parameters:
+    ///   - image: The retrieved image.
+    ///   - cacheType: The cache source type.
+    ///   - source: The source of the image.
+    ///   - originalSource: The original source that initiated the retrieval.
+    ///   - data: A closure that provides the image data.
+    ///   - metrics: The network metrics collected during download. Defaults to nil for cached images.
+    public init(
+        image: KFCrossPlatformImage,
+        cacheType: CacheType,
+        source: Source,
+        originalSource: Source,
+        data: @escaping @Sendable () -> Data?,
+        metrics: NetworkMetrics? = nil
+    ) {
+        self.image = image
+        self.cacheType = cacheType
+        self.source = source
+        self.originalSource = originalSource
+        self.data = data
+        self.metrics = metrics
+    }
 }
 
 /// A structure that stores related information about a ``KingfisherError``. It provides contextual information
@@ -475,7 +506,8 @@ public class KingfisherManager: @unchecked Sendable {
                 cacheType: .none,
                 source: source,
                 originalSource: context.originalSource,
-                data: {  value.originalData }
+                data: { value.originalData },
+                metrics: value.metrics
             )
             // Add image to cache.
             let targetCache = options.targetCache ?? self.cache

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -43,6 +43,9 @@ public struct ImageLoadingResult: Sendable {
 
     /// The raw data received from the downloader.
     public let originalData: Data
+    
+    /// The network metrics collected during the download process.
+    public let metrics: NetworkMetrics?
 
     /// Creates an `ImageDownloadResult` object.
     ///
@@ -50,10 +53,12 @@ public struct ImageLoadingResult: Sendable {
     ///   - image: The image of the download result.
     ///   - url: The URL from which the image was downloaded.
     ///   - originalData: The binary data of the image.
-    public init(image: KFCrossPlatformImage, url: URL? = nil, originalData: Data) {
+    ///   - metrics: The network metrics collected during the download.
+    public init(image: KFCrossPlatformImage, url: URL? = nil, originalData: Data, metrics: NetworkMetrics? = nil) {
         self.image = image
         self.url = url
         self.originalData = originalData
+        self.metrics = metrics
     }
 }
 
@@ -444,7 +449,7 @@ open class ImageDownloader: @unchecked Sendable {
 
                     self.reportDidProcessImage(result: result, url: context.url, response: response)
 
-                    let imageResult = result.map { ImageLoadingResult(image: $0, url: context.url, originalData: data) }
+                    let imageResult = result.map { ImageLoadingResult(image: $0, url: context.url, originalData: data, metrics: sessionTask.metrics) }
                     let queue = callback.options.callbackQueue
                     queue.execute { callback.onCompleted?.call(imageResult) }
                 }

--- a/Sources/Networking/NetworkMetrics.swift
+++ b/Sources/Networking/NetworkMetrics.swift
@@ -1,0 +1,151 @@
+//
+//  NetworkMetrics.swift
+//  Kingfisher
+//
+//  Created by FunnyValentine on 2025/07/25.
+//
+//  Copyright (c) 2025 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import Foundation
+
+/// Represents the network performance metrics collected during an image download task.
+public struct NetworkMetrics: Sendable {
+
+    /// The original URLSessionTaskMetrics for advanced use cases.
+    public let rawMetrics: URLSessionTaskMetrics
+
+    /// The duration of the actual image retrieval (excluding redirects).
+    public let retrieveImageDuration: TimeInterval
+
+    /// The total time from request start to completion (including redirects).
+    public let totalRequestDuration: TimeInterval
+
+    /// The time it took to perform DNS lookup.
+    public let domainLookupDuration: TimeInterval?
+    
+    /// The time it took to establish the TCP connection.
+    public let connectDuration: TimeInterval?
+    
+    /// The time it took to perform TLS handshake.
+    public let secureConnectionDuration: TimeInterval?
+    
+    /// The number of bytes sent in the request body.
+    public let requestBodyBytesSent: Int64
+    
+    /// The number of bytes received in the response body.
+    public let responseBodyBytesReceived: Int64
+    
+    /// The HTTP response status code, if available.
+    public let httpStatusCode: Int?
+    
+    /// The number of redirects that occurred during the request.
+    public let redirectCount: Int
+    
+    /// Creates a NetworkMetrics instance from URLSessionTaskMetrics
+    init?(from urlMetrics: URLSessionTaskMetrics) {
+        // Find the first successful transaction (200-299 status) ignoring redirects
+        // We need to ensure we get metrics from an actual successful download, not from 
+        // intermediate redirects (301/302) which don't represent real download performance
+        var successfulTransaction: URLSessionTaskTransactionMetrics?
+        for transaction in urlMetrics.transactionMetrics {
+            if let httpResponse = transaction.response as? HTTPURLResponse,
+               (200...299).contains(httpResponse.statusCode) {
+                successfulTransaction = transaction
+                break
+            }
+        }
+
+        // make sure we have a valid successful transaction
+        guard let successfulTransaction else {
+            return nil
+        }
+
+        // Store raw metrics for advanced use cases
+        self.rawMetrics = urlMetrics
+        
+        // Calculate the image retrieval duration from the successful transaction
+        self.retrieveImageDuration = Self.calculateRetrieveImageDuration(from: successfulTransaction)
+        
+        // Calculate the total request duration from the task interval
+        self.totalRequestDuration = urlMetrics.taskInterval.duration
+        
+        // Calculate timing metrics from the successful transaction
+        self.domainLookupDuration = Self.calculateDomainLookupDuration(from: successfulTransaction)
+        self.connectDuration = Self.calculateConnectDuration(from: successfulTransaction)
+        self.secureConnectionDuration = Self.calculateSecureConnectionDuration(from: successfulTransaction)
+        
+        // Extract data transfer information from the successful transaction
+        self.requestBodyBytesSent = successfulTransaction.countOfRequestBodyBytesSent
+        self.responseBodyBytesReceived = successfulTransaction.countOfResponseBodyBytesReceived
+        
+        // Extract HTTP status code from the successful transaction
+        self.httpStatusCode = Self.extractHTTPStatusCode(from: successfulTransaction)
+        
+        // Extract redirect count
+        self.redirectCount = urlMetrics.redirectCount
+    }
+    
+    // MARK: - Private Calculation Methods
+    
+    /// Calculates DNS lookup duration
+    /// Formula: domainLookupEndDate - domainLookupStartDate
+    /// Represents: Time spent resolving domain name to IP address
+    private static func calculateDomainLookupDuration(from transaction: URLSessionTaskTransactionMetrics) -> TimeInterval? {
+        guard let start = transaction.domainLookupStartDate,
+              let end = transaction.domainLookupEndDate else { return nil }
+        return end.timeIntervalSince(start)
+    }
+    
+    /// Calculates TCP connection establishment duration
+    /// Formula: connectEndDate - connectStartDate
+    /// Represents: Time spent establishing TCP connection to server
+    private static func calculateConnectDuration(from transaction: URLSessionTaskTransactionMetrics) -> TimeInterval? {
+        guard let start = transaction.connectStartDate,
+              let end = transaction.connectEndDate else { return nil }
+        return end.timeIntervalSince(start)
+    }
+    
+    /// Calculates TLS/SSL handshake duration
+    /// Formula: secureConnectionEndDate - secureConnectionStartDate  
+    /// Represents: Time spent performing TLS/SSL handshake for HTTPS connections
+    private static func calculateSecureConnectionDuration(from transaction: URLSessionTaskTransactionMetrics) -> TimeInterval? {
+        guard let start = transaction.secureConnectionStartDate,
+              let end = transaction.secureConnectionEndDate else { return nil }
+        return end.timeIntervalSince(start)
+    }
+    
+    /// Calculates the image retrieval duration for a single transaction 
+    /// Formula: responseEndDate - requestStartDate
+    /// Represents: Time from sending HTTP request to receiving complete image response
+    private static func calculateRetrieveImageDuration(from transaction: URLSessionTaskTransactionMetrics) -> TimeInterval {
+        guard let start = transaction.requestStartDate,
+              let end = transaction.responseEndDate else { 
+            return 0 
+        }
+        return end.timeIntervalSince(start)
+    }
+    
+    /// Extracts HTTP status code from response
+    /// Returns: HTTP status code (200, 404, etc.) or nil for non-HTTP responses
+    private static func extractHTTPStatusCode(from transaction: URLSessionTaskTransactionMetrics) -> Int? {
+        return (transaction.response as? HTTPURLResponse)?.statusCode
+    }
+}

--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -68,6 +68,14 @@ public class SessionDataTask: @unchecked Sendable {
 
     private var currentToken = 0
     private let lock = NSLock()
+    
+    private var _metrics: NetworkMetrics?
+    /// The network metrics collected during the download task.
+    public var metrics: NetworkMetrics? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _metrics
+    }
 
     let onTaskDone = Delegate<(Result<(Data, URLResponse?), KingfisherError>, [TaskCallback]), Void>()
     let onCallbackCancelled = Delegate<(CancelToken, TaskCallback), Void>()
@@ -138,5 +146,11 @@ public class SessionDataTask: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         _mutableData.append(data)
+    }
+    
+    func didCollectMetrics(_ metrics: NetworkMetrics) {
+        lock.lock()
+        defer { lock.unlock() }
+        _metrics = metrics
     }
 }

--- a/Sources/Networking/SessionDelegate.swift
+++ b/Sources/Networking/SessionDelegate.swift
@@ -258,6 +258,15 @@ extension SessionDelegate: URLSessionDataDelegate {
             newRequest: request
         )
     }
+    
+    open func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        guard let sessionTask = self.task(for: task) else { return }
+        
+        // Collect network metrics for the completed task
+        if let networkMetrics = NetworkMetrics(from: metrics) {
+            sessionTask.didCollectMetrics(networkMetrics)
+        }
+    }
 
     private func onCompleted(task: URLSessionTask, result: Result<(Data, URLResponse?), KingfisherError>) {
         guard let sessionTask = self.task(for: task) else {

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -591,7 +591,7 @@ class ImageDownloaderTests: XCTestCase {
             init(_ expectation:XCTestExpectation) {
                 exp = expectation
             }
-            func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+            override func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
                 exp.fulfill()
             }
         }


### PR DESCRIPTION
# Add network metrics collection for #2412 

## Summary
Add `NetworkMetrics` to track download performance metrics like DNS lookup time, connection time, and image retrieving time.

## Changes
- Add NetworkMetrics struct to capture URLSessionTaskMetrics data
- Collect metrics in SessionDelegate through URLSession delegate method
- Pass metrics through ImageLoadingResult to RetrieveImageResult
- Metrics only available for network downloads, nil for cached results
- Support timing breakdown (DNS, TCP, TLS), data transfer, and HTTP details
- Add NetworkMetrics demo for SwiftUI and UIKit

## Features
- Track network request performance for image downloads
- View all network transactions including redirects
- Monitor download data usage and transfer sizes
- Thread-safe access from any queue

## Usage
- UIKit:
```
imageView.kf.setImage(with: url) { result in
    switch result {
    case .success(let value):
        if let metrics = value.metrics {
            print("Total time: \(metrics.totalRequestDuration)s")
            print("DNS: \(metrics.domainLookupDuration?.description ?? "N/A")")
        }
    case .failure(let error):
        print(error)
    }
}
```       

- SwiftUI:
```
KFImage(imageURL)
    .onSuccess { result in
        if let metrics = result.metrics {
            print("Retrieve time: \(metrics.retrieveImageDuration)s")
            print("Response size: \(metrics.responseBodyBytesReceived) bytes")
        }
    }
```

  Testing

- [x] Tested with demo app with data from cache and remote
- [x] Verified delegate methods trigger correctly.
- [ ] Skipped unit testing: URLSessionTaskMetrics is unmockable.
