### PR TITLE
Fix non-atomic task creation for concurrent same-URL requests

### DIFF
--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -248,6 +248,8 @@ open class ImageDownloader: @unchecked Sendable {
     // The session bound to the downloader.
     private var session: URLSession
 
+    private let lock = NSLock()
+
     // MARK: Initializers
 
     /// Creates a downloader with a given name.
@@ -375,6 +377,9 @@ open class ImageDownloader: @unchecked Sendable {
         callback: SessionDataTask.TaskCallback
     ) -> DownloadTask
     {
+        lock.lock()
+        defer { lock.unlock() }
+
         // Ready to start download. Add it to session task manager (`sessionHandler`)
         let downloadTask: DownloadTask
         if let existingTask = sessionDelegate.task(for: context.url) {


### PR DESCRIPTION
# Related issues
#2437 
#2231
#2342
#2314

# Reason
When registering multiple `SessionDataTasks` for the same URL concurrently, task overwriting may occur, resulting in callback loss.

# Fix
Add a lock to the `addDownloadTask()` method to ensure atomic append-or-add operations when registering tasks.