### PR TITLE
Fix .onFailureImage applying configurations to failure images

### DIFF
--- a/Demo/Demo/Kingfisher-Demo/SwiftUIViews/LoadingFailureDemo.swift
+++ b/Demo/Demo/Kingfisher-Demo/SwiftUIViews/LoadingFailureDemo.swift
@@ -45,7 +45,6 @@ struct LoadingFailureDemo: View {
     var body: some View {
         VStack {
             KFImage(url)
-                .onFailureImage(warningImage) // onFailureImage should not work
                 .onFailureView {
                     ZStack {
                         RoundedRectangle(cornerRadius: 20)

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -42,7 +42,7 @@ extension KFImage {
         private var loading = false
 
         var loadingOrSucceeded: Bool {
-            return loading || loadedImage != nil
+            return loading || loadedImage != nil || failureImage != nil
         }
 
         // Do not use @Published due to https://github.com/onevcat/Kingfisher/issues/1717. Revert to @Published once
@@ -52,6 +52,8 @@ extension KFImage {
         private(set) var animating = false
 
         var loadedImage: KFCrossPlatformImage? = nil { willSet { objectWillChange.send() } }
+        var failureImage: KFCrossPlatformImage? = nil { willSet { objectWillChange.send() } }
+        var isFailureImage = false { willSet { objectWillChange.send() } }
         var failureView: (() -> AnyView)? = nil { willSet { objectWillChange.send() } }
         var progress: Progress = .init()
 
@@ -73,7 +75,8 @@ extension KFImage {
                     if let view = context.failureView {
                         self.failureView = view
                     } else if let image = context.options.onFailureImage {
-                        self.loadedImage = image
+                        self.failureImage = image
+                        self.isFailureImage = true
                     }
                     self.loading = false
                     self.markLoaded(sendChangeEvent: false)
@@ -140,7 +143,8 @@ extension KFImage {
                                 if let view = context.failureView {
                                     self.failureView = view
                                 } else if let image = context.options.onFailureImage {
-                                    self.loadedImage = image
+                                    self.failureImage = image
+                                    self.isFailureImage = true
                                 }
                                 self.markLoaded(sendChangeEvent: false)
                             }

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -113,11 +113,13 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
     
     @ViewBuilder
     private var configuredImage: some View {
-        let configuredImage = context.configurations
-            .reduce(HoldingView.created(from: binder.loadedImage, context: context)) {
-                current, config in config(current)
-            }
-        
+        let image = binder.loadedImage ?? binder.failureImage
+        let baseImage = HoldingView.created(from: image, context: context)
+
+        let configuredImage = binder.isFailureImage ?
+            baseImage :
+            context.configurations.reduce(baseImage) { current, config in config(current) }
+
         // Apply contentConfiguration first, then loadTransition as the final step
         if let contentConfiguration = context.contentConfiguration {
             contentConfiguration(configuredImage)


### PR DESCRIPTION
# Fix `.onFailureImage` Configuration Application Issue

## Description

The `.onFailureImage` modifier in SwiftUI's `KFImage` was applying all image configurations (resizable, aspectRatio, etc.) to the failure image, which could lead to unexpected styling. This fix ensures failure images are displayed without unwanted transformations while maintaining backward compatibility.

## Problem

When using `.onFailureImage` with configurations like `.resizable()`, `.aspectRatio()`, etc., the failure image would inherit all these transformations, potentially causing layout issues or unexpected appearance.

**Problematic Code:**
```swift
KFImage.url(URL(string: imageUrl))
    .placeholder { ProgressView() }
    .resizable()           // Applied to failure image too
    .aspectRatio(contentMode: .fit)  // Applied to failure image too
    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
    .frame(width: 60, height: 60)
    .cornerRadius(10)
    .onFailureImage(someImage)  // Configurations applied here unexpectedly
```

## Solution

Modified the failure handling to display failure images without applying `KFImage` configurations, providing clean separation between success and failure image rendering.

**Solution Code:**
```swift
KFImage.url(URL(string: imageUrl))
    .placeholder { ProgressView() }
    .resizable()
    .aspectRatio(contentMode: .fit)
    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
    .frame(width: 60, height: 60)
    .cornerRadius(10)
    .onFailureImage(someImage)  // Now displays without configurations
```

For styled failure content, use `.onFailureView`:
```swift
.onFailureView {
    Image(systemName: "photo")
        .resizable()
        .aspectRatio(contentMode: .fit)
        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
        .frame(width: 60, height: 60)
        .cornerRadius(10)
}
```

## Approach

1. **Added separate failure image handling** in `ImageBinder` to avoid configuration application
2. **Modified renderer logic** to skip configurations for failure images
3. **Maintained priority order**: `failureView` > `failureImage` > placeholder
4. **Ensured backward compatibility** with existing code

## Files Changed

- `Sources/SwiftUI/ImageBinder.swift`: Added `failureImage` and `isFailureImage` properties, updated failure handling logic
- `Sources/SwiftUI/KFImageRenderer.swift`: Modified `configuredImage` to skip configurations for failure images
- `Demo/Demo/Kingfisher-Demo/SwiftUIViews/LoadingFailureDemo.swift`: Updated demo to remove conflicting usage

## Testing

- Verified that `.onFailureImage` displays failure images without configurations
- Confirmed `.onFailureView` still takes precedence when both are set
- Ensured existing functionality remains intact
- Updated demo to reflect correct usage patterns

## Related Issue

Closes #2321: "How to add an image in case the loading of the url fails? SwiftUI"

Issue Link: https://github.com/onevcat/Kingfisher/issues/2321#issue-2672702086

This addresses the issue where `.onFailureImage` was applying unwanted configurations to failure images, improving the developer experience for failure state handling in SwiftUI.