### PR TITLE
Fix a crash when trying to access KingfisherWrapper<UIApplication>.shared in a Unit Test

### DIFF
--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -1292,7 +1292,8 @@ extension KingfisherWrapper where Base: UIApplication {
     public static var shared: UIApplication? {
         let selector = NSSelectorFromString("sharedApplication")
         guard Base.responds(to: selector) else { return nil }
-        return Base.perform(selector).takeUnretainedValue() as? UIApplication
+        guard let unmanaged = Base.perform(selector) else { return nil }
+        return unmanaged.takeUnretainedValue() as? UIApplication
     }
 }
 #endif

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -895,7 +895,15 @@ class ImageCacheTests: XCTestCase {
         let result = try XCTUnwrap(fileURL)
         XCTAssertTrue(result.absoluteString.hasSuffix(".myExt"))
     }
-    
+
+#if !os(macOS) && !os(watchOS)
+    func testKingfisherWrapperUIApplicationSharedReturnsNilInUnitTest() {
+        // UIApplication.shared is not available in some Unit Tests contexts.
+        // This tests that accessing it via KingfisherWrapper does not cause a crash.
+        XCTAssertNil(KingfisherWrapper<UIApplication>.shared)
+    }
+#endif
+
     // MARK: - Helper
     private func storeMultipleImages(_ completionHandler: @escaping () -> Void) {
         let group = DispatchGroup()


### PR DESCRIPTION
## Problem
When `ImageCache.default` is first used, Kingfisher starts listening for `UIApplication.didEnterBackgroundNotification` so it can call `backgroundCleanExpiredDiskCache`. This accesses `KingfisherWrapper<UIApplication>.shared`.

In our project, we take snapshot tests as part of our unit test suite. This causes `ImageCache.default` to be initialised. 

Later, when we run a test that posts `UIApplication.didEnterBackgroundNotification`, `KingfisherWrapper<UIApplication>.shared` crashes due to `takeUnretainedValue()` being called on a `nil` object (as `UIApplication.shared` is not available when running unit tests).

## Solution
Because `KingfisherWrapper<UIApplication>.shared` already returns an optional, we can safely unwrap `Base.perform(selector)` before trying to `takeUnretainedValue()`