### PR TITLE
Harden tests against Task scheduling races

### DIFF
--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -539,33 +539,28 @@ class ImageDownloaderTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
     
-#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
-    func testModifierShouldOnlyApplyForFinalResultWhenDownload() {
-        let exp = expectation(description: #function)
+	#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
+	    func testModifierShouldOnlyApplyForFinalResultWhenDownload() {
+	        let exp = expectation(description: #function)
 
-        let url = testURLs[0]
-        stub(url, data: testImageData)
+	        let url = testURLs[0]
+	        stub(url, data: testImageData)
 
-        let modifierCalled = ActorBox(false)
-        let modifier = AnyImageModifier { image in
-            Task {
-                await modifierCalled.setValue(true)
-            }
-            return image.withRenderingMode(.alwaysTemplate)
-        }
+	        let modifierCalled = LockIsolated(false)
+	        let modifier = AnyImageModifier { image in
+	            modifierCalled.setValue(true)
+	            return image.withRenderingMode(.alwaysTemplate)
+	        }
 
-        downloader.downloadImage(with: url, options: [.imageModifier(modifier)]) { result in
-            XCTAssertEqual(result.value?.image.renderingMode, .automatic)
-            Task {
-                let called = await modifierCalled.value
-                XCTAssertFalse(called)
-                exp.fulfill()
-            }
-        }
+	        downloader.downloadImage(with: url, options: [.imageModifier(modifier)]) { result in
+	            XCTAssertEqual(result.value?.image.renderingMode, .automatic)
+	            XCTAssertFalse(modifierCalled.value)
+	            exp.fulfill()
+	        }
 
-        waitForExpectations(timeout: 3, handler: nil)
-    }
-#endif
+	        waitForExpectations(timeout: 3, handler: nil)
+	    }
+	#endif
     
     func testDownloadTaskTakePriorityOption() {
         let exp = expectation(description: #function)


### PR DESCRIPTION
This PR removes a recurring test anti-pattern:

- A boolean/count stored in `ActorBox`
- Flipped inside `Task { ... }` from a synchronous callback
- Read/asserted from another `Task { ... }` (or without waiting)

That pattern can race on task scheduling and cause CI-only flakes (or silently weaken negative assertions).

Changes:
- Rewrite `KingfisherManagerTests.testFailingProcessOnDataProviderImage` to use an XCTest expectation.
- Replace several `ActorBox + Task` markers with `LockIsolated` and synchronous writes/reads in:
  - `KingfisherManagerTests` image modifier tests
  - alternative source task update tests
  - `ImageDownloaderTests` and `ImageCacheTests` “modifier should not apply” tests

No production code changes.
