### PR TITLE
Fix flakiness in async request modifier test

### DIFF
--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -144,31 +144,27 @@ class ImageDownloaderTests: XCTestCase {
     }
 
     func testDownloadWithAsyncModifyingRequest() {
-        let downloadCompleted = expectation(description: #function)
-        let downloadTaskStarted = expectation(description: "downloadTaskStarted")
+        let exp = expectation(description: #function)
+        let downloadTaskStarted = LockIsolated(false)
 
         let url = testURLs[0]
         stub(url, data: testImageData)
 
         let asyncModifier = AsyncURLModifier(url: url, onDownloadTaskStarted: { task in
             XCTAssertNotNil(task)
-            downloadTaskStarted.fulfill()
+            downloadTaskStarted.setValue(true)
         })
 
         let someURL = URL(string: "some_strange_url")!
         let task = downloader.downloadImage(with: someURL, options: [.requestModifier(asyncModifier)]) { result in
             XCTAssertNotNil(result.value)
             XCTAssertEqual(result.value?.url, url)
-            downloadCompleted.fulfill()
+            XCTAssertTrue(downloadTaskStarted.value)
+            exp.fulfill()
         }
         // The returned task is nil since the download is not starting immediately.
         XCTAssertFalse(task.isInitialized)
-        XCTAssertEqual(
-            // `enforceOrder: true` requires the expectations to be fulfilled in order:
-            // `downloadTaskStarted` must happen before `downloadCompleted`.
-            XCTWaiter.wait(for: [downloadTaskStarted, downloadCompleted], timeout: 3, enforceOrder: true),
-            .completed
-        )
+        waitForExpectations(timeout: 3, handler: nil)
     }
 
     func testDownloadWithModifyingRequestToNil() {


### PR DESCRIPTION
Reworks `ImageDownloaderTests.testDownloadWithAsyncModifyingRequest` to avoid `XCTWaiter.wait(..., enforceOrder:)` timeouts by waiting only for the completion expectation and asserting `onDownloadTaskStarted` synchronously via a `LockIsolated` flag.
