### PR TITLE
Fix missing callback when original cache claims cached but returns none

### DIFF
--- a/Sources/Networking/ImagePrefetcher.swift
+++ b/Sources/Networking/ImagePrefetcher.swift
@@ -319,7 +319,8 @@ public class ImagePrefetcher: CustomStringConvertible, @unchecked Sendable {
                 let context = RetrievingContext(options: optionsInfo, originalSource: source)
                 _ = manager.retrieveImageFromCache(
                     source: source,
-                    context: context)
+                    context: context,
+                    downloadTaskUpdated: nil)
                 {
                     _ in
                     self.append(cached: source)


### PR DESCRIPTION
Fixes a missing-callback edge case in `KingfisherManager.retrieveImageFromCache` when falling back to the original cache.

Context
- `imageCachedType` can report the original image as cached (disk), but `retrieveImage` may still return `.success(.none)` (e.g. corrupt/un-decodable data, race/cleanup).
- The previous code path hit an `assertionFailure` and returned without calling the completion handler, which can lead to async continuation misuse (continuation not resumed).

Changes
- Treat `cacheResult.image == nil` as a cache miss and fall back to the normal load-and-cache path.
- Preserve `.onlyFromCache` semantics by failing with `imageNotExisting`.
- Add a regression test that stores invalid original-cache data to reproduce the scenario.

Related: #2472
