### PR TITLE
feat: Add purgeFramesOnBackground modifier to KFAnimatedImage

### DIFF
--- a/Sources/SwiftUI/KFAnimatedImage.swift
+++ b/Sources/SwiftUI/KFAnimatedImage.swift
@@ -54,6 +54,21 @@ public struct KFAnimatedImage: KFImageProtocol {
         context.renderConfigurations.append(block)
         return self
     }
+
+#if os(iOS)
+    /// Whether the animated frame buffer should be purged when the app enters background.
+    ///
+    /// This is an opt-in behavior to reduce memory footprint when your app is in background. When enabled,
+    /// the internal `AnimatedImageView` stops animating and purges preloaded frames on
+    /// `UIApplication.didEnterBackgroundNotification`. If the view was animating before entering background, it will
+    /// prepare frames and resume animation on `UIApplication.willEnterForegroundNotification`.
+    ///
+    /// - Parameter purge: Whether to enable the frame purging behavior. Default is `true`.
+    /// - Returns: A `KFAnimatedImage` view that configures the behavior.
+    public func purgeFramesOnBackground(_ purge: Bool = true) -> Self {
+        configure { $0.purgeFramesOnBackground = purge }
+    }
+#endif
 }
 
 #if os(macOS)


### PR DESCRIPTION
## Summary

This PR adds a `purgeFramesOnBackground(_:)` modifier to `KFAnimatedImage` (SwiftUI), exposing the existing `purgeFramesOnBackground` property of `AnimatedImageView` (UIKit) that was recently added in #2482.

## Motivation

PR #2482 introduced the memory optimization logic in the underlying `AnimatedImageView`, but this property is not yet accessible to SwiftUI users using `KFAnimatedImage`. This PR bridges that gap.

## Changes

- Added `purgeFramesOnBackground(_:)` modifier to `KFAnimatedImage`
- Passthrough to the underlying `AnimatedImageView.purgeFramesOnBackground`

## Usage

```swift
KFAnimatedImage(source: .network(url))
    .purgeFramesOnBackground(true)
```