### PR TITLE
Fix AnimatedImageView deinit for older Swift 6 toolchains

### DIFF
--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -272,14 +272,16 @@ open class AnimatedImageView: KFCrossPlatformImageView {
 #endif
     
     deinit {
-        #if os(iOS)
-        removeBackgroundFramePurgeObservers()
-        #endif
+        // `@MainActor deinit` requires isolated deinit support and broke older Swift 6 toolchains.
+        // Keep a single code path that assumes UIKit/AppKit deallocation on the main thread.
+        MainActor.runUnsafely {
+            #if os(iOS)
+            removeBackgroundFramePurgeObservers()
+            #endif
 
-        if isDisplayLinkInitialized {
-            // `@MainActor deinit` requires isolated deinit support and broke older Swift 6 toolchains.
-            // Keep a single code path that assumes UIKit/AppKit deallocation on the main thread.
-            MainActor.runUnsafely { displayLink.invalidate() }
+            if isDisplayLinkInitialized {
+                displayLink.invalidate()
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
Re-open the old #2483 fix from a clean branch based on current `master`.

The original CI failure came from annotating `deinit` with `@MainActor`, which triggered:

- `'isolated' deinit requires frontend flag -enable-experimental-feature IsolatedDeinit`

on older Swift 6 toolchains in the CI matrix.

## Change
- Remove `@MainActor deinit` in `AnimatedImageView`
- Use a single `deinit` path with `MainActor.runUnsafely { displayLink.invalidate() }`
- Keep the iOS observer cleanup behavior unchanged

This avoids requiring isolated-deinit support while preserving the intended main-thread deinit behavior.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode-16.4.0.app/Contents/Developer xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=macOS' SWIFT_VERSION=5.0`
- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' SWIFT_VERSION=5.0`
