### PR TITLE
Fix callback handling when original cached data cannot be decoded

### DIFF
--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -715,7 +715,8 @@ public class KingfisherManager: @unchecked Sendable {
                 result.match(
                     onSuccess: { cacheResult in
                         guard let image = cacheResult.image else {
-                            assertionFailure("The image (under key: \(key) should be existing in the original cache.")
+                            let error = KingfisherError.cacheError(reason: .imageNotExisting(key: key))
+                            options.callbackQueue.execute { completionHandler?(.failure(error)) }
                             return
                         }
 

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -638,6 +638,56 @@ class KingfisherManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
+
+    func testRetrieveImageFromCacheCallsCompletionWhenOriginalCacheDataCannotBeDecoded() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+
+        let originalCache = ImageCache(name: "test-originalCache-invalid-data")
+
+        originalCache.clearMemoryCache()
+        originalCache.clearDiskCache {
+            do {
+                try originalCache.diskStorage.store(value: Data([0x00, 0x01, 0x02]), forKey: url.cacheKey)
+            } catch {
+                XCTFail("Failed to set up original cache data: \(error)")
+                exp.fulfill()
+                return
+            }
+
+            XCTAssertEqual(originalCache.imageCachedType(forKey: url.cacheKey), .disk)
+
+            let processor = SimpleProcessor()
+            let source = Source.network(url)
+            let options = KingfisherParsedOptionsInfo([.processor(processor), .originalCache(originalCache)])
+            let context = RetrievingContext(options: options, originalSource: source)
+
+            let loaded = self.manager.retrieveImageFromCache(source: source, context: context) { result in
+                switch result {
+                case .success:
+                    XCTFail("Expected a cache error when cached original data cannot be decoded.")
+                case .failure(let error):
+                    guard case .cacheError(let reason) = error else {
+                        XCTFail("Unexpected error: \(error)")
+                        exp.fulfill()
+                        return
+                    }
+                    guard case .imageNotExisting(let key) = reason else {
+                        XCTFail("Unexpected cache error reason: \(reason)")
+                        exp.fulfill()
+                        return
+                    }
+                    XCTAssertEqual(key, url.cacheKey)
+                    XCTAssertFalse(processor.processed)
+                }
+                exp.fulfill()
+            }
+
+            XCTAssertTrue(loaded)
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
     
     func testCouldProcessDoNotHappenWhenSerializerCachesTheProcessedData() {
         let exp = expectation(description: #function)


### PR DESCRIPTION
## Summary
- return `KingfisherError.cacheError(.imageNotExisting)` when the original-cache branch cannot decode cached data into an image
- make sure the completion callback is still invoked for this edge case
- add a regression test that stores invalid original cache data and verifies the callback failure path

## Why
When a disk entry exists but cannot be decoded, callers should receive a deterministic failure callback instead of an interrupted control flow.

## Test
- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination "platform=iOS Simulator,name=iPhone 16" -only-testing:KingfisherTests/KingfisherManagerTests`
