### PR TITLE
Apply retryStrategy in ImagePrefetcher load path

### DIFF
--- a/Sources/Networking/ImagePrefetcher.swift
+++ b/Sources/Networking/ImagePrefetcher.swift
@@ -253,19 +253,12 @@ public class ImagePrefetcher: CustomStringConvertible, @unchecked Sendable {
         }
     }
     
-    private func downloadAndCache(_ source: Source) {
+    private func downloadAndCache(_ source: Source, retryContext: RetryContext? = nil) {
 
-        let downloadTaskCompletionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void) = {
-            result in
-            
-            self.tasks.removeValue(forKey: source.cacheKey)
-            do {
-                let _ = try result.get()
-                self.completedSources.append(source)
-            } catch {
-                self.failedSources.append(source)
-            }
-            
+        let retryStrategy = optionsInfo.retryStrategy
+
+        @Sendable func completeWithSuccess() {
+            self.completedSources.append(source)
             self.reportProgress()
             if self.stopped {
                 if self.tasks.isEmpty {
@@ -274,6 +267,52 @@ public class ImagePrefetcher: CustomStringConvertible, @unchecked Sendable {
                 }
             } else {
                 self.reportCompletionOrStartNext()
+            }
+        }
+
+        @Sendable func completeWithFailure() {
+            self.failedSources.append(source)
+            self.reportProgress()
+            if self.stopped {
+                if self.tasks.isEmpty {
+                    self.failedSources.append(contentsOf: self.pendingSources)
+                    self.handleComplete()
+                }
+            } else {
+                self.reportCompletionOrStartNext()
+            }
+        }
+
+        let downloadTaskCompletionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void) = {
+            result in
+
+            self.tasks.removeValue(forKey: source.cacheKey)
+            switch result {
+            case .success:
+                completeWithSuccess()
+            case .failure(let error):
+                guard let retryStrategy else {
+                    completeWithFailure()
+                    return
+                }
+
+                let context = retryContext?.increaseRetryCount() ?? RetryContext(source: source, error: error)
+                retryStrategy.retry(context: context) { decision in
+                    self.prefetchQueue.async {
+                        guard !self.stopped else {
+                            completeWithFailure()
+                            return
+                        }
+
+                        switch decision {
+                        case .retry(let userInfo):
+                            context.userInfo = userInfo
+                            self.downloadAndCache(source, retryContext: context)
+                        case .stop:
+                            completeWithFailure()
+                        }
+                    }
+                }
             }
         }
 

--- a/Tests/KingfisherTests/RetryStrategyTests.swift
+++ b/Tests/KingfisherTests/RetryStrategyTests.swift
@@ -102,6 +102,28 @@ class RetryStrategyTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testImagePrefetcherCanRetry() {
+        let exp = expectation(description: #function)
+
+        let brokenURL = URL(string: "brokenurl")!
+        stub(brokenURL, data: Data())
+
+        let retry = StubRetryStrategy()
+        let prefetcher = ImagePrefetcher(
+            urls: [brokenURL],
+            options: [.retryStrategy(retry)],
+            completionHandler: { skippedResources, failedResources, completedResources in
+                XCTAssertEqual(retry.count, 3)
+                XCTAssertEqual(skippedResources.count, 0)
+                XCTAssertEqual(failedResources.count, 1)
+                XCTAssertEqual(completedResources.count, 0)
+                exp.fulfill()
+            }
+        )
+        prefetcher.start()
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
     // MARK: - DelayRetryStrategy Tests
 
     func testDelayRetryStrategyExceededCount() {


### PR DESCRIPTION
## Summary
- apply `retryStrategy` for `ImagePrefetcher` download failures when prefetching uncached sources
- keep prefetcher bookkeeping (`tasks`, progress, completion) consistent across retry attempts
- add a regression test to verify retries are performed for prefetching

## Why
`ImagePrefetcher` currently uses `loadAndCacheImage` directly, which bypasses the retry flow used by `retrieveImage`. As a result, `.retryStrategy(...)` in prefetch options is ignored.

This change aligns prefetch behavior with retry expectations discussed in #2314.

## Test
- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination "platform=iOS Simulator,name=iPhone 16" -only-testing:KingfisherTests/RetryStrategyTests`
