### PR TITLE
chore: bump json gem to 2.19.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -233,7 +233,7 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
-    json (2.19.2)
+    json (2.19.3)
     jwt (2.10.2)
       base64
     logger (1.7.0)


### PR DESCRIPTION
## Summary
- run `bundle update json`
- bump `json` in `Gemfile.lock` from `2.19.2` to `2.19.3`

## Why
Issue #2499 reported vulnerability concerns around older `json` versions shipped in past releases.
This keeps the CI/tooling bundle dependency current on `master`.

## Validation
- `bundle update json` completed successfully
