### PR TITLE
Correctly calculate animated image cost

### DIFF
--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -165,10 +165,14 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
             return pixels * 4
         }
         let bytesPerPixel = cgImage.bitsPerPixel / 8
-        guard let imageCount = images?.count else {
-            return pixels * bytesPerPixel
+        let bytesPerFrame = pixels * bytesPerPixel
+
+        if let images {
+            let uniqueFrameCount = Set(images.map { ObjectIdentifier($0) }).count
+            return bytesPerFrame * uniqueFrameCount
+        } else {
+            return bytesPerFrame
         }
-        return pixels * bytesPerPixel * imageCount
     }
 }
 

--- a/Sources/Image/Image.swift
+++ b/Sources/Image/Image.swift
@@ -160,15 +160,15 @@ extension KingfisherWrapper where Base: KFCrossPlatformImage {
 
     // Bitmap memory cost with bytes.
     var cost: Int {
-        let pixel = Int(size.width * size.height * scale * scale)
+        let pixels = Int(size.width * size.height * scale * scale)
         guard let cgImage = cgImage else {
-            return pixel * 4
+            return pixels * 4
         }
         let bytesPerPixel = cgImage.bitsPerPixel / 8
         guard let imageCount = images?.count else {
-            return pixel * bytesPerPixel
+            return pixels * bytesPerPixel
         }
-        return pixel * bytesPerPixel * imageCount
+        return pixels * bytesPerPixel * imageCount
     }
 }
 


### PR DESCRIPTION
## Summary

When calculating the cost of an image that contains animation frames within the underlying `images` property, we assume that all of these `images` are unique, adding to the memory cost of the image. This is an incorrect assumption. 

## Problem

It is possible to insert duplicate objects in the `images` array, meaning you can have multiple elements that are pointing to the same image in memory - so not every image in the array actually adds to the memory cost. 

## Solution

The solution is to only count unique frames in the `images` array. This gives us a much-more accurate representation of actual memory cost. 

## Files Changes

- `Sources/Image/Image.swift` - A small rename of `pixel` to `pixels`, and only counting unique frames of `images` rather than the entire count. 

## Use Case

For my own use case, I had converted a WebP image into an array of images for animation using `UIImage`, but to persist dynamic frame timings, the serializer duplicated images to match the original animation timing. In one instance, this created an image of 500 frames that used 40 unique frames, so the cache cost was massively overestimated. 

### Note

With this fix in-place, existing cached images will still retain the previously calculated `cacheCost` until the image expires, and / or is replaced. 