### PR TITLE
Stabilize watchOS CI destination selection

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,8 @@ jobs:
             destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.2'
             label: 'tvOS 18.2'
           - xcode: '16.2'
-            destination: 'watchOS Simulator,name=Apple Watch Series 10 (42mm),OS=11.2'
-            label: 'watchOS 11.2'
+            destination: 'watchOS Simulator,name=Any watchOS Simulator Device'
+            label: 'watchOS SDK 11.2'
 
           - xcode: '16.3'
             destination: 'macOS'
@@ -45,8 +45,8 @@ jobs:
             destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.4'
             label: 'tvOS 18.4'
           - xcode: '16.3'
-            destination: 'watchOS Simulator,name=Apple Watch Series 10 (42mm),OS=11.4'
-            label: 'watchOS 11.4'
+            destination: 'watchOS Simulator,name=Any watchOS Simulator Device'
+            label: 'watchOS SDK 11.4'
 
           - xcode: '26.0.1'
             destination: 'macOS'
@@ -58,8 +58,8 @@ jobs:
             destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.0'
             label: 'tvOS 26.0'
           - xcode: '26.0.1'
-            destination: 'watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.0'
-            label: 'watchOS 26.0'
+            destination: 'watchOS Simulator,name=Any watchOS Simulator Device'
+            label: 'watchOS SDK 26.0'
 
           - xcode: '26.1.1'
             destination: 'macOS'
@@ -71,8 +71,8 @@ jobs:
             destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.1'
             label: 'tvOS 26.1'
           - xcode: '26.1.1'
-            destination: 'watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.1'
-            label: 'watchOS 26.1'
+            destination: 'watchOS Simulator,name=Any watchOS Simulator Device'
+            label: 'watchOS SDK 26.1'
 
           - xcode: '26.2'
             destination: 'macOS'
@@ -84,8 +84,8 @@ jobs:
             destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.2'
             label: 'tvOS 26.2'
           - xcode: '26.2'
-            destination: 'watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.2'
-            label: 'watchOS 26.2'
+            destination: 'watchOS Simulator,name=Any watchOS Simulator Device'
+            label: 'watchOS SDK 26.2'
     steps:
       - uses: actions/checkout@v4
       - name: Install Gems

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,8 +32,8 @@ jobs:
             destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5'
             label: 'tvOS 18.5'
           - xcode: '16.4'
-            destination: 'watchOS Simulator,name=Apple Watch Series 10 (42mm),OS=11.5'
-            label: 'watchOS 11.5'
+            destination: 'watchOS Simulator,name=Any watchOS Simulator Device'
+            label: 'watchOS SDK 11.5'
 
           - xcode: '26.3'
             destination: 'macOS'
@@ -45,8 +45,8 @@ jobs:
             destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.2'
             label: 'tvOS 26.2'
           - xcode: '26.3'
-            destination: 'watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.2'
-            label: 'watchOS 26.2'
+            destination: 'watchOS Simulator,name=Any watchOS Simulator Device'
+            label: 'watchOS SDK 26.2'
     steps:
       - uses: actions/checkout@v4
       - name: Install Gems

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,7 +8,7 @@ platform :ios do
     test(destination: "platform=macOS")
     test(destination: "platform=iOS Simulator,name=iPhone 16,OS=18.5")
     test(destination: "platform=tvOS Simulator,name=Apple TV,OS=18.5")
-    build(destination: "platform=watchOS Simulator,name=Apple Watch Series 10 (42mm),OS=11.5")
+    build(destination: "platform=watchOS Simulator,name=Any watchOS Simulator Device")
   end
     
   lane :test_ci do


### PR DESCRIPTION
## Summary
- switch watchOS CI destinations from device-specific names to `Any watchOS Simulator Device`
- keep watchOS coverage via Xcode matrix and make labels explicit as `watchOS SDK ...`
- align `fastlane tests` watch destination with the same generic watch simulator target

## Root Cause
The failed job used a device-specific watch destination (`Apple Watch Series ...`) in a `build` lane. For this scheme/action, Xcode reports generic watch simulator destinations and may not match concrete device names reliably, causing destination resolution failure.

## Validation
- inspected failing run logs: https://github.com/onevcat/Kingfisher/actions/runs/24509610743/job/71636898078
- attempted local `bundle exec fastlane test_ci` for watchOS; blocked by this Codex sandbox environment (`CoreSimulatorService`/filesystem restrictions), so final verification should rely on CI run in normal runner context
