### PR TITLE
Make provider loads cancellable via Swift concurrency

### DIFF
--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		2F6023D252BE169414B01D8B /* CancellationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAE088D96F2BF3FACCBD355 /* CancellationToken.swift */; };
 		388F37382B4D9CDB0089705C /* DisplayLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388F37372B4D9CDB0089705C /* DisplayLink.swift */; };
 		38D5D3A32C5C757E00BF1D01 /* PixelFormatDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D5D3A42C5C757E00BF1D01 /* PixelFormatDecodingTests.swift */; };
+		38D5D4A12C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D5D4A22C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift */; };
 		38D5D3C12C5C7A1800BF1D01 /* gradient-8b-srgb-opaque.png in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3AC2C5C784700BF1D01 /* gradient-8b-srgb-opaque.png */; };
 		38D5D3C22C5C7A1800BF1D01 /* gradient-8b-srgb-alpha.png in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3AD2C5C784700BF1D01 /* gradient-8b-srgb-alpha.png */; };
 		38D5D3C32C5C7A1800BF1D01 /* gradient-8b-displayp3-alpha.png in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3AE2C5C784700BF1D01 /* gradient-8b-displayp3-alpha.png */; };
@@ -177,6 +178,7 @@
 		22FDCE0D2700078B0044D11E /* CPListItem+Kingfisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CPListItem+Kingfisher.swift"; sourceTree = "<group>"; };
 		388F37372B4D9CDB0089705C /* DisplayLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayLink.swift; sourceTree = "<group>"; };
 		38D5D3A42C5C757E00BF1D01 /* PixelFormatDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelFormatDecodingTests.swift; sourceTree = "<group>"; };
+		38D5D4A22C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDataProviderCancellationTests.swift; sourceTree = "<group>"; };
 		38D5D3AC2C5C784700BF1D01 /* gradient-8b-srgb-opaque.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gradient-8b-srgb-opaque.png"; sourceTree = "<group>"; };
 		38D5D3AD2C5C784700BF1D01 /* gradient-8b-srgb-alpha.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gradient-8b-srgb-alpha.png"; sourceTree = "<group>"; };
 		38D5D3AE2C5C784700BF1D01 /* gradient-8b-displayp3-alpha.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gradient-8b-displayp3-alpha.png"; sourceTree = "<group>"; };
@@ -533,6 +535,7 @@
 				D12E0C461C47F23500AC98AD /* ImageDownloaderTests.swift */,
 				D12E0C471C47F23500AC98AD /* ImageExtensionTests.swift */,
 				38D5D3A42C5C757E00BF1D01 /* PixelFormatDecodingTests.swift */,
+				38D5D4A22C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift */,
 				D186696C21834261002B502E /* ImageDrawingTests.swift */,
 				D9638BA41C7DC71F0046523D /* ImagePrefetcherTests.swift */,
 				D12E0C481C47F23500AC98AD /* ImageViewExtensionTests.swift */,
@@ -999,6 +1002,7 @@
 				D16FEA3F23078C63006E67D5 /* LSHTTPRequestDiff.m in Sources */,
 				D186696D21834261002B502E /* ImageDrawingTests.swift in Sources */,
 				38D5D3A32C5C757E00BF1D01 /* PixelFormatDecodingTests.swift in Sources */,
+				38D5D4A12C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift in Sources */,
 				D16FEA4323078C63006E67D5 /* NSURLRequest+DSL.m in Sources */,
 				D16FEA5323078C63006E67D5 /* LSStubResponseDSL.m in Sources */,
 				D16FEA4C23078C63006E67D5 /* LSDataMatcher.m in Sources */,

--- a/Sources/General/ImageSource/ImageDataProvider.swift
+++ b/Sources/General/ImageSource/ImageDataProvider.swift
@@ -102,6 +102,15 @@ public extension ImageDataProvider {
     }
 
     /// Default callback-based entry point. Bridges to ``data()`` by spawning a `Task`.
+    ///
+    /// > Note: The `Task` opened here is unstructured and does **not** inherit
+    /// > cancellation from any surrounding `Task` on the caller side. If a caller
+    /// > outside Kingfisher invokes this default bridge from within a cancelled
+    /// > parent task, the parent's cancellation will not automatically propagate
+    /// > into the provider's `data()` call. For Kingfisher's own provider loads
+    /// > this is not a concern because the framework drives providers through
+    /// > ``ImageDataProvider/data()`` directly, with the owning `Task` cancelled
+    /// > by ``DownloadTask/cancel()``.
     func data(handler: @escaping @Sendable (Result<Data, any Error>) -> Void) {
         Task {
             do {

--- a/Sources/General/ImageSource/ImageDataProvider.swift
+++ b/Sources/General/ImageSource/ImageDataProvider.swift
@@ -32,36 +32,87 @@ import ImageIO
 /// to load some image data in your own way, as long as you can provide the data
 /// representation for the image.
 public protocol ImageDataProvider: Sendable {
-    
+
     /// The key used in cache.
     var cacheKey: String { get }
-    
-    /// Provides the data which represents image. Kingfisher uses the data you pass in the
-    /// handler to process images and caches it for later use.
+
+    /// Asynchronously provides the data which represents the image.
     ///
-    /// - Parameter handler: The handler you should call when you prepared your data.
-    ///                      If the data is loaded successfully, call the handler with
-    ///                      a `.success` with the data associated. Otherwise, call it
-    ///                      with a `.failure` and pass the error.
+    /// Kingfisher calls this method inside a `Task` that it owns. When the corresponding
+    /// ``DownloadTask`` is cancelled by the caller (e.g. via
+    /// ``DownloadTask/cancel()`` or `imageView.kf.cancelDownloadTask()`), the owning `Task`
+    /// is cancelled as well. Implementations are expected to cooperate with Swift
+    /// concurrency cancellation:
+    ///
+    /// - Use cancellation-aware APIs (such as `URLSession.data(for:)`) whose underlying
+    ///   work is interrupted when the surrounding task is cancelled.
+    /// - Insert `try Task.checkCancellation()` at sensible checkpoints in long-running
+    ///   logic.
+    /// - Use `withTaskCancellationHandler(operation:onCancel:)` to bridge into
+    ///   non-async resources that expose their own cancellation hook.
+    ///
+    /// When the task is cancelled, implementations should throw (typically by letting
+    /// `CancellationError` propagate). Kingfisher will translate this into a
+    /// ``KingfisherError/RequestErrorReason/dataProviderCancelled(provider:)`` for the
+    /// completion handler, matching the semantics of a cancelled network source.
+    ///
+    /// - Returns: The image data.
+    /// - Throws: Any error produced while loading the data, including `CancellationError`
+    ///           when the loading was cancelled.
+    ///
+    /// > A default implementation is provided that bridges to ``data(handler:)`` via
+    /// > `withCheckedThrowingContinuation`. That bridge cannot interrupt callback-based
+    /// > work: such providers will still complete in the background after cancel, and
+    /// > Kingfisher will discard their result. Override this method to participate in
+    /// > cooperative cancellation.
+    func data() async throws -> Data
+
+    /// Provides the data which represents the image via a completion handler.
+    ///
+    /// - Parameter handler: The handler to call when the data is prepared. Pass
+    ///                      `.success(data)` on success, or `.failure(error)` on failure.
     ///
     /// - Note: If the `handler` is called with a `.failure` with error,
     /// a ``KingfisherError/ImageSettingErrorReason/dataProviderError(provider:error:)`` will be finally thrown out to
     /// you as the ``KingfisherError`` from the framework.
+    ///
+    /// > A default implementation is provided that bridges to ``data()`` by spinning up
+    /// > a `Task`. Implement at least one of ``data()`` or ``data(handler:)``; implementing
+    /// > neither results in mutual recursion at runtime.
     func data(handler: @escaping @Sendable (Result<Data, any Error>) -> Void)
 
     /// The content URL represents this provider, if exists.
     var contentURL: URL? { get }
 }
 
-extension ImageDataProvider {
+public extension ImageDataProvider {
+
+    /// Default asynchronous entry point. Bridges to the legacy ``data(handler:)``
+    /// requirement via `withCheckedThrowingContinuation`.
+    ///
+    /// > Important: Bridging a callback-based implementation through this default does
+    /// > **not** propagate `Task` cancellation into the callback. To participate in
+    /// > cooperative cancellation, override this method with an implementation that
+    /// > honors `Task.isCancelled` / `try Task.checkCancellation()` or uses
+    /// > cancellation-aware async APIs.
     func data() async throws -> Data {
         try await withCheckedThrowingContinuation { continuation in
             data(handler: { continuation.resume(with: $0) })
         }
     }
-}
 
-public extension ImageDataProvider {
+    /// Default callback-based entry point. Bridges to ``data()`` by spawning a `Task`.
+    func data(handler: @escaping @Sendable (Result<Data, any Error>) -> Void) {
+        Task {
+            do {
+                let data = try await data()
+                handler(.success(data))
+            } catch {
+                handler(.failure(error))
+            }
+        }
+    }
+
     var contentURL: URL? { return nil }
     func convertToSource() -> Source {
         .provider(self)

--- a/Sources/General/KingfisherError.swift
+++ b/Sources/General/KingfisherError.swift
@@ -74,8 +74,29 @@ public enum KingfisherError: Error {
         ///
         /// Error Code: 1004
         case livePhotoTaskCancelled(source: LivePhotoSource)
-        
+
         case asyncTaskContextCancelled
+
+        /// The loading task of an ``ImageDataProvider`` was cancelled.
+        ///
+        /// Emitted when a provider-backed load is cancelled via
+        /// ``DownloadTask/cancel()`` (including through
+        /// `imageView.kf.cancelDownloadTask()`). Kingfisher cancels the `Task` in which
+        /// the provider's ``ImageDataProvider/data()`` runs; this error is delivered to
+        /// the completion handler instead of ``ImageLoadingResult``, matching the
+        /// behavior of a cancelled network source.
+        ///
+        /// Whether the provider's underlying work is actually interrupted depends on
+        /// its implementation. Providers that override ``ImageDataProvider/data()`` to
+        /// use cancellation-aware async APIs (for example `URLSession.data(for:)`) or
+        /// to call `try Task.checkCancellation()` will stop eagerly. Providers that
+        /// rely on the default bridge to the callback-based ``ImageDataProvider/data(handler:)``
+        /// may still complete in the background, but their result is discarded.
+        ///
+        /// - Parameter provider: The image data provider whose load was cancelled.
+        ///
+        /// Error Code: 1006
+        case dataProviderCancelled(provider: any ImageDataProvider)
     }
     
     /// Represents the error reason during networking response phase.
@@ -504,9 +525,11 @@ extension KingfisherError.RequestErrorReason {
             return "The live photo download task was cancelled. Source: \(source)"
         case .asyncTaskContextCancelled:
             return "The async task context was cancelled. This usually happens when the task is cancelled before it starts."
+        case .dataProviderCancelled(let provider):
+            return "The image data provider task was cancelled. Provider cache key: \(provider.cacheKey)"
         }
     }
-    
+
     var errorCode: Int {
         switch self {
         case .emptyRequest: return 1001
@@ -514,6 +537,7 @@ extension KingfisherError.RequestErrorReason {
         case .taskCancelled: return 1003
         case .livePhotoTaskCancelled: return 1004
         case .asyncTaskContextCancelled: return 1005
+        case .dataProviderCancelled: return 1006
         }
     }
 }

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -466,39 +466,80 @@ public class KingfisherManager: @unchecked Sendable {
         }
     }
 
+    /// Drives an ``ImageDataProvider`` load inside a `Task` so that cancelling the
+    /// returned task cooperatively cancels both the provider's `data()` call and the
+    /// subsequent processing step.
+    ///
+    /// - Returns: The `Task` driving the load, or `nil` when no completion handler is
+    ///   supplied (in which case no work is started).
+    @discardableResult
     func provideImage(
         provider: any ImageDataProvider,
         options: KingfisherParsedOptionsInfo,
-        completionHandler: (@Sendable (Result<ImageLoadingResult, KingfisherError>) -> Void)?)
-    {
-        guard let  completionHandler = completionHandler else { return }
-        provider.data { result in
-            switch result {
-            case .success(let data):
-                (options.processingQueue ?? self.processingQueue).execute {
-                    let processor = options.processor
-                    let processingItem = ImageProcessItem.data(data)
-                    guard let image = processor.process(item: processingItem, options: options) else {
-                        options.callbackQueue.execute {
-                            let error = KingfisherError.processorError(
-                                reason: .processingFailed(processor: processor, item: processingItem))
-                            completionHandler(.failure(error))
-                        }
-                        return
-                    }
-
-                    options.callbackQueue.execute {
-                        let result = ImageLoadingResult(image: image, url: nil, originalData: data)
-                        completionHandler(.success(result))
-                    }
-                }
-            case .failure(let error):
+        completionHandler: (@Sendable (Result<ImageLoadingResult, KingfisherError>) -> Void)?
+    ) -> Task<Void, Never>? {
+        guard let completionHandler else { return nil }
+        let defaultProcessingQueue = processingQueue
+        return Task {
+            @Sendable func deliverCancelled() {
                 options.callbackQueue.execute {
-                    let error = KingfisherError.imageSettingError(
-                        reason: .dataProviderError(provider: provider, error: error))
-                    completionHandler(.failure(error))
+                    completionHandler(.failure(
+                        KingfisherError.requestError(reason: .dataProviderCancelled(provider: provider))
+                    ))
                 }
+            }
 
+            let data: Data
+            do {
+                data = try await provider.data()
+            } catch is CancellationError {
+                deliverCancelled()
+                return
+            } catch {
+                if Task.isCancelled {
+                    deliverCancelled()
+                } else {
+                    options.callbackQueue.execute {
+                        completionHandler(.failure(
+                            KingfisherError.imageSettingError(
+                                reason: .dataProviderError(provider: provider, error: error))
+                        ))
+                    }
+                }
+                return
+            }
+
+            if Task.isCancelled {
+                deliverCancelled()
+                return
+            }
+
+            let processor = options.processor
+            let processingItem = ImageProcessItem.data(data)
+            let processingQueue = options.processingQueue ?? defaultProcessingQueue
+            let image: KFCrossPlatformImage? = await withCheckedContinuation { continuation in
+                processingQueue.execute {
+                    continuation.resume(returning: processor.process(item: processingItem, options: options))
+                }
+            }
+
+            if Task.isCancelled {
+                deliverCancelled()
+                return
+            }
+
+            guard let image else {
+                options.callbackQueue.execute {
+                    completionHandler(.failure(
+                        KingfisherError.processorError(
+                            reason: .processingFailed(processor: processor, item: processingItem))
+                    ))
+                }
+                return
+            }
+
+            options.callbackQueue.execute {
+                completionHandler(.success(ImageLoadingResult(image: image, url: nil, originalData: data)))
             }
         }
     }
@@ -606,8 +647,8 @@ public class KingfisherManager: @unchecked Sendable {
             }
 
         case .provider(let provider):
-            provideImage(provider: provider, options: options, completionHandler: _cacheImage)
-            return .dataProviding
+            let task = provideImage(provider: provider, options: options, completionHandler: _cacheImage)
+            return .dataProviding(task)
         }
     }
     

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -647,8 +647,10 @@ public class KingfisherManager: @unchecked Sendable {
             }
 
         case .provider(let provider):
-            let task = provideImage(provider: provider, options: options, completionHandler: _cacheImage)
-            return .dataProviding(task)
+            guard let task = provideImage(provider: provider, options: options, completionHandler: _cacheImage) else {
+                return .dataProviding(nil)
+            }
+            return .dataProviding(DownloadTask(providerTask: task))
         }
     }
     

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -75,8 +75,24 @@ public final class DownloadTask: @unchecked Sendable {
         _sessionTask = sessionTask
         _cancelToken = cancelToken
     }
-    
+
     init() { }
+
+    /// Internal initializer used for non-network sources backed by an
+    /// ``ImageDataProvider``. The returned task carries the `Task` that drives the
+    /// provider load; calling ``cancel()`` cancels that `Task`.
+    init(providerTask: Task<Void, Never>) {
+        _providerTask = providerTask
+    }
+
+    private var _providerTask: Task<Void, Never>? = nil
+
+    /// The Swift concurrency `Task` driving an ``ImageDataProvider`` load, if this
+    /// `DownloadTask` represents a provider-backed load.
+    var providerTask: Task<Void, Never>? {
+        get { propertyQueue.sync { _providerTask } }
+        set { propertyQueue.sync { _providerTask = newValue } }
+    }
 
     private var _sessionTask: SessionDataTask? = nil
     
@@ -119,6 +135,10 @@ public final class DownloadTask: @unchecked Sendable {
     /// ``ImageDownloader/cancel(url:)``. If you need to cancel all downloading tasks of an ``ImageDownloader``, 
     /// use ``ImageDownloader/cancelAll()``.
     public func cancel() {
+        if let providerTask {
+            providerTask.cancel()
+            return
+        }
         guard let sessionTask, let cancelToken else { return }
         sessionTask.cancel(token: cancelToken)
     }
@@ -145,19 +165,21 @@ actor CancellationDownloadTask {
 extension DownloadTask {
     enum WrappedTask {
         case download(DownloadTask)
-        case dataProviding
+        case dataProviding(Task<Void, Never>?)
 
         func cancel() {
             switch self {
             case .download(let task): task.cancel()
-            case .dataProviding: break
+            case .dataProviding(let task): task?.cancel()
             }
         }
 
         var value: DownloadTask? {
             switch self {
             case .download(let task): return task
-            case .dataProviding: return nil
+            case .dataProviding(let task):
+                guard let task else { return nil }
+                return DownloadTask(providerTask: task)
             }
         }
     }

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -165,7 +165,7 @@ actor CancellationDownloadTask {
 extension DownloadTask {
     enum WrappedTask {
         case download(DownloadTask)
-        case dataProviding(Task<Void, Never>?)
+        case dataProviding(DownloadTask?)
 
         func cancel() {
             switch self {
@@ -177,9 +177,7 @@ extension DownloadTask {
         var value: DownloadTask? {
             switch self {
             case .download(let task): return task
-            case .dataProviding(let task):
-                guard let task else { return nil }
-                return DownloadTask(providerTask: task)
+            case .dataProviding(let task): return task
             }
         }
     }

--- a/Tests/KingfisherTests/ImageDataProviderCancellationTests.swift
+++ b/Tests/KingfisherTests/ImageDataProviderCancellationTests.swift
@@ -1,0 +1,293 @@
+//
+//  ImageDataProviderCancellationTests.swift
+//  Kingfisher
+//
+//  Created by onevcat on 2026/04/18.
+//
+//  Copyright (c) 2026 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import XCTest
+@testable import Kingfisher
+
+// MARK: - Test Providers
+
+/// A callback-based provider that delivers after a delay, without honoring cancellation.
+/// Exercises the default `data() async throws` bridge path: when Kingfisher cancels the
+/// owning Task, the underlying `data(handler:)` still completes in the background, but
+/// the caller sees `.dataProviderCancelled` because the post-await `Task.isCancelled`
+/// check intercepts the result.
+private final class DelayedCallbackProvider: ImageDataProvider, @unchecked Sendable {
+    let cacheKey: String
+    let delay: TimeInterval
+    let payload: Data
+    private let handlerInvoked: UnfairLockBox<Bool> = .init(false)
+
+    var didInvokeHandler: Bool { handlerInvoked.value }
+
+    init(
+        cacheKey: String = "delayed-callback-\(UUID().uuidString)",
+        delay: TimeInterval,
+        payload: Data
+    ) {
+        self.cacheKey = cacheKey
+        self.delay = delay
+        self.payload = payload
+    }
+
+    func data(handler: @escaping @Sendable (Result<Data, any Error>) -> Void) {
+        let payload = self.payload
+        let handlerInvoked = self.handlerInvoked
+        DispatchQueue.global().asyncAfter(deadline: .now() + delay) {
+            handlerInvoked.value = true
+            handler(.success(payload))
+        }
+    }
+}
+
+/// A cooperative async provider that polls `Task.isCancelled` between short sleeps.
+/// Used to verify that Kingfisher's internal Task actually propagates cancellation into
+/// the provider's own `data()` implementation — i.e. the work stops, not just the callback.
+private final class CooperativeAsyncProvider: ImageDataProvider, @unchecked Sendable {
+    let cacheKey: String
+    let iterations: Int
+    let iterationDelay: TimeInterval
+    let payload: Data
+    private let completedIterations: UnfairLockBox<Int> = .init(0)
+    private let observedCancellation: UnfairLockBox<Bool> = .init(false)
+
+    var completedIterationCount: Int { completedIterations.value }
+    var didObserveCancellation: Bool { observedCancellation.value }
+
+    init(
+        cacheKey: String = "cooperative-async-\(UUID().uuidString)",
+        iterations: Int,
+        iterationDelay: TimeInterval,
+        payload: Data
+    ) {
+        self.cacheKey = cacheKey
+        self.iterations = iterations
+        self.iterationDelay = iterationDelay
+        self.payload = payload
+    }
+
+    func data() async throws -> Data {
+        do {
+            for _ in 0..<iterations {
+                try Task.checkCancellation()
+                try await Task.sleep(nanoseconds: UInt64(iterationDelay * 1_000_000_000))
+                completedIterations.value += 1
+            }
+        } catch is CancellationError {
+            observedCancellation.value = true
+            throw CancellationError()
+        }
+        return payload
+    }
+}
+
+/// Minimal thread-safe box for counters/flags used from multiple queues in tests.
+private final class UnfairLockBox<T>: @unchecked Sendable {
+    private var storage: T
+    private let lock = NSLock()
+
+    init(_ value: T) { self.storage = value }
+
+    var value: T {
+        get { lock.lock(); defer { lock.unlock() }; return storage }
+        set { lock.lock(); defer { lock.unlock() }; storage = newValue }
+    }
+}
+
+extension UnfairLockBox where T == Int {
+    static func += (lhs: UnfairLockBox<Int>, rhs: Int) {
+        lhs.value += rhs
+    }
+}
+
+// MARK: - Tests
+
+final class ImageDataProviderCancellationTests: XCTestCase {
+
+    private func makeManager() -> KingfisherManager {
+        KingfisherManager(
+            downloader: .default,
+            cache: ImageCache(name: "provider-cancel-\(UUID().uuidString.prefix(8))")
+        )
+    }
+
+    // Baseline: without cancellation the completion fires with `.success` and the
+    // underlying provider handler runs to completion.
+    func testProviderDeliversWhenNotCancelled() {
+        let manager = makeManager()
+        let provider = DelayedCallbackProvider(delay: 0.1, payload: testImageData)
+        let done = expectation(description: "manager completion")
+
+        _ = manager.retrieveImage(with: .provider(provider), options: nil) { result in
+            if case .failure(let error) = result {
+                XCTFail("unexpected failure: \(error)")
+            }
+            done.fulfill()
+        }
+        wait(for: [done], timeout: 2.0)
+        XCTAssertTrue(provider.didInvokeHandler)
+    }
+
+    // The `DownloadTask` returned for a provider source must now be non-nil and its
+    // `cancel()` must deliver `.dataProviderCancelled` instead of letting the delayed
+    // `.success` leak through to the caller.
+    func testCancellingProviderTaskDeliversCancelledError() {
+        let manager = makeManager()
+        let provider = DelayedCallbackProvider(delay: 0.3, payload: testImageData)
+        let done = expectation(description: "manager completion")
+
+        let task = manager.retrieveImage(with: .provider(provider), options: nil) { result in
+            switch result {
+            case .success:
+                XCTFail("provider load should have been cancelled, but got .success")
+            case .failure(let error):
+                guard case .requestError(reason: .dataProviderCancelled) = error else {
+                    XCTFail("expected .dataProviderCancelled, got: \(error)")
+                    done.fulfill()
+                    return
+                }
+            }
+            done.fulfill()
+        }
+
+        XCTAssertNotNil(task, "retrieveImage should return a cancellable task for provider sources (#2511)")
+        task?.cancel()
+
+        wait(for: [done], timeout: 2.0)
+    }
+
+    // End-to-end through the UIImageView/NSImageView extension path.
+    @MainActor
+    func testImageViewCancelDownloadTaskCancelsProvider() {
+        let imageView = KFCrossPlatformImageView()
+        let provider = DelayedCallbackProvider(delay: 0.3, payload: testImageData)
+        let done = expectation(description: "setImage completion")
+
+        imageView.kf.setImage(with: .provider(provider)) { result in
+            switch result {
+            case .success:
+                XCTFail("setImage should have been cancelled, but got .success")
+            case .failure(let error):
+                guard case .requestError(reason: .dataProviderCancelled) = error else {
+                    XCTFail("expected .dataProviderCancelled, got: \(error)")
+                    done.fulfill()
+                    return
+                }
+            }
+            done.fulfill()
+        }
+
+        imageView.kf.cancelDownloadTask()
+        wait(for: [done], timeout: 2.0)
+    }
+
+    // A cooperative provider overriding `data() async throws` must observe the cancel
+    // signal: the provider's own iteration loop breaks early, proving the cancellation
+    // propagates into the implementation (not just the caller-facing callback).
+    func testCancelPropagatesIntoCooperativeAsyncProvider() {
+        let manager = makeManager()
+        // Long loop: without cancellation it would take ~20s to finish. If cooperative
+        // cancellation works, the provider's loop exits within a few iterations.
+        let provider = CooperativeAsyncProvider(
+            iterations: 1_000,
+            iterationDelay: 0.02,
+            payload: testImageData
+        )
+        let done = expectation(description: "manager completion")
+
+        let task = manager.retrieveImage(with: .provider(provider), options: nil) { result in
+            switch result {
+            case .success:
+                XCTFail("cooperative provider should have been cancelled")
+            case .failure(let error):
+                guard case .requestError(reason: .dataProviderCancelled) = error else {
+                    XCTFail("expected .dataProviderCancelled, got: \(error)")
+                    done.fulfill()
+                    return
+                }
+            }
+            done.fulfill()
+        }
+
+        XCTAssertNotNil(task, "provider source must vend a cancellable DownloadTask")
+
+        // Let a few iterations run, then cancel.
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.08) {
+            task?.cancel()
+        }
+
+        // With cooperative cancel this completes well before 2s; without it the loop
+        // would run for ~20s and this test would time out.
+        wait(for: [done], timeout: 2.0)
+
+        XCTAssertTrue(
+            provider.didObserveCancellation,
+            "CooperativeAsyncProvider should see Task.checkCancellation() throw after cancel"
+        )
+        XCTAssertGreaterThanOrEqual(
+            provider.completedIterationCount,
+            1,
+            "provider loop must make progress before cancel; otherwise the test doesn't prove mid-flight interruption"
+        )
+        XCTAssertLessThan(
+            provider.completedIterationCount,
+            provider.iterations,
+            "provider loop should have exited early due to cancellation"
+        )
+    }
+
+    // Non-cooperative callback providers: the background work still runs, but the
+    // caller sees `.dataProviderCancelled` — matches the suppression semantics we
+    // document, so callers don't get a late `.success` after `cancel()`.
+    func testCancelSuppressesLateSuccessFromNonCooperativeProvider() {
+        let manager = makeManager()
+        let provider = DelayedCallbackProvider(delay: 0.4, payload: testImageData)
+        let done = expectation(description: "manager completion")
+        let handlerRan = expectation(description: "provider handler still runs")
+        handlerRan.assertForOverFulfill = false
+
+        let task = manager.retrieveImage(with: .provider(provider), options: nil) { result in
+            switch result {
+            case .success:
+                XCTFail("non-cooperative provider cancel should deliver .dataProviderCancelled")
+            case .failure(let error):
+                guard case .requestError(reason: .dataProviderCancelled) = error else {
+                    XCTFail("expected .dataProviderCancelled, got: \(error)")
+                    done.fulfill()
+                    return
+                }
+            }
+            done.fulfill()
+        }
+        task?.cancel()
+
+        // Poll the provider flag to confirm the handler eventually ran in the background.
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+            if provider.didInvokeHandler { handlerRan.fulfill() }
+        }
+
+        wait(for: [done, handlerRan], timeout: 2.0)
+    }
+}


### PR DESCRIPTION
Fixes #2511.

Provider-backed loads now run inside a `Task`. Calling `cancel()` on the returned `DownloadTask` (or `imageView.kf.cancelDownloadTask()`) cancels that task, and the completion fires with `.dataProviderCancelled` instead of a late `.success`.

`ImageDataProvider` gains `data() async throws -> Data` next to the existing `data(handler:)`. Both come with default bridges, so existing providers compile unchanged. Providers that override the async one pick up Swift concurrency cancellation: `URLSession.data(for:)` stops, `try Task.checkCancellation()` works, `withTaskCancellationHandler` works.

Providers that keep using the callback API will still finish their work in the background after a cancel. The caller no longer sees a late `.success` though, which matches how a cancelled network source behaves today.

## Tests

New `ImageDataProviderCancellationTests` covers:

- baseline (no cancel → `.success`)
- direct `task.cancel()` → `.dataProviderCancelled`
- `imageView.kf.cancelDownloadTask()` → `.dataProviderCancelled`
- a cooperative async provider that stops mid-loop on cancel (proves the signal reaches the implementation, not just the callback)
- a callback-only provider whose late result is suppressed

Results:

- macOS (macOS 26.2 SDK): 312 / 312 pass
- iPhone 17e simulator (iOS 26.4): new suite 5 / 5 pass

## Credit

Built on top of @friday-refined's #2517, which pinned down exactly where the cancel signal was getting dropped (the `nil` return, the `WrappedTask` no-op, the imageView path). I went with a protocol-level `data() async throws` rather than an internal cancel token so providers can stop their own work, not just have the callback suppressed.

Closes #2517.
