### PR TITLE
Add opt-in asyncCacheTypeCheck to move cache probe off caller thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 -----
 
+## [Next]
+
+#### Add
+* Add opt-in `asyncCacheTypeCheck` for `KingfisherManager` retrieval to move cache-type probing off the caller thread while preserving cache-only behavior, callback queue delivery, forced cache extensions, and task cancellation for provider-backed or async request-modified loads. [#2521](https://github.com/onevcat/Kingfisher/pull/2521) @onevcat
+
+---
+
 ## [8.8.1 - Fresh Cache](https://github.com/onevcat/Kingfisher/releases/tag/8.8.1) (2026-04-01)
 
 #### Fix
@@ -2027,5 +2034,4 @@
 ## [1.0.0 - Kingfisher, take off](https://github.com/onevcat/Kingfisher/releases/tag/1.0.0) (2015-04-13)
 
 First public release.
-
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Kingfisher is a powerful, pure-Swift library for downloading and caching images 
 - [x] Useful image processors and filters provided.
 - [x] Multiple-layer hybrid cache for both memory and disk.
 - [x] Fine control on cache behavior. Customizable expiration date and size limit.
+- [x] Opt-in async cache probing in `KingfisherManager` to avoid blocking the caller thread on disk cache checks.
 - [x] Cancelable downloading and auto-reusing previous downloaded content to improve performance.
 - [x] Independent components. Use the downloader, caching system, and image processors separately as you need.
 - [x] Prefetching images and showing them from the cache to boost your app.

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -464,7 +464,9 @@ public class KingfisherManager: @unchecked Sendable {
 
         if options.onlyFromCache {
             let error = KingfisherError.cacheError(reason: .imageNotExisting(key: source.cacheKey))
-            completionHandler?(.failure(error))
+            options.callbackQueue.execute {
+                completionHandler?(.failure(error))
+            }
             return nil
         }
 

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -745,7 +745,10 @@ public class KingfisherManager: @unchecked Sendable {
         let targetCache = options.targetCache ?? cache
         let key = source.cacheKey
         let targetImageCached = targetCache.imageCachedType(
-            forKey: key, processorIdentifier: options.processor.identifier)
+            forKey: key,
+            processorIdentifier: options.processor.identifier,
+            forcedExtension: options.forcedExtension
+        )
 
         let validCache = targetImageCached.cached &&
             (options.fromMemoryCacheOrRefresh == false || targetImageCached == .memory)
@@ -769,7 +772,10 @@ public class KingfisherManager: @unchecked Sendable {
 
         // Check whether the unprocessed image existing or not.
         let originalImageCacheType = originalCache.imageCachedType(
-            forKey: key, processorIdentifier: DefaultImageProcessor.default.identifier)
+            forKey: key,
+            processorIdentifier: DefaultImageProcessor.default.identifier,
+            forcedExtension: options.forcedExtension
+        )
         let canAcceptDiskCache = !options.fromMemoryCacheOrRefresh
 
         let canUseOriginalImageCache =

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -441,29 +441,91 @@ public class KingfisherManager: @unchecked Sendable {
                 source: source,
                 context: context,
                 completionHandler: completionHandler)?.value
-            
-        } else {
-            let loadedFromCache = retrieveImageFromCache(
+
+        }
+
+        if options.asyncCacheTypeCheck {
+            return retrieveImageAsyncCacheTypeCheck(
                 source: source,
                 context: context,
                 downloadTaskUpdated: downloadTaskUpdated,
                 completionHandler: completionHandler)
-            
-            if loadedFromCache {
-                return nil
-            }
-            
+        }
+
+        let loadedFromCache = retrieveImageFromCache(
+            source: source,
+            context: context,
+            downloadTaskUpdated: downloadTaskUpdated,
+            completionHandler: completionHandler)
+
+        if loadedFromCache {
+            return nil
+        }
+
+        if options.onlyFromCache {
+            let error = KingfisherError.cacheError(reason: .imageNotExisting(key: source.cacheKey))
+            completionHandler?(.failure(error))
+            return nil
+        }
+
+        return loadAndCacheImage(
+            source: source,
+            context: context,
+            completionHandler: completionHandler)?.value
+    }
+
+    /// Opt-in async cache-type probe path.
+    ///
+    /// Allocates a `DownloadTask` shell and returns it synchronously. The cache existence probe runs through
+    /// ``ImageCache/imageCachedTypeAsync(forKey:processorIdentifier:forcedExtension:callbackQueue:completionHandler:)``
+    /// so the caller thread never performs a `stat` syscall. On cache miss, the resulting network task is linked onto
+    /// the shell via ``DownloadTask/linkToTask(_:)``.
+    private func retrieveImageAsyncCacheTypeCheck(
+        source: Source,
+        context: RetrievingContext<Source>,
+        downloadTaskUpdated: DownloadTaskUpdatedBlock?,
+        completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask?
+    {
+        let options = context.options
+        let shell = DownloadTask()
+
+        @Sendable func proceedToDownload() {
             if options.onlyFromCache {
                 let error = KingfisherError.cacheError(reason: .imageNotExisting(key: source.cacheKey))
-                completionHandler?(.failure(error))
-                return nil
+                options.callbackQueue.execute { completionHandler?(.failure(error)) }
+                return
             }
-            
-            return loadAndCacheImage(
+            if options.isSourceTaskStale {
+                let error = KingfisherError.cacheError(reason: .imageNotExisting(key: source.cacheKey))
+                options.callbackQueue.execute { completionHandler?(.failure(error)) }
+                return
+            }
+            let wrapped = self.loadAndCacheImage(
                 source: source,
                 context: context,
-                completionHandler: completionHandler)?.value
+                completionHandler: completionHandler)
+            if let realTask = wrapped?.value {
+                shell.linkToTask(realTask)
+            }
         }
+
+        retrieveImageFromCacheAsync(
+            source: source,
+            context: context,
+            downloadTaskUpdated: { task in
+                // For non-shell fallback downloads started from original-cache fallback paths,
+                // surface the real task to the caller. The shell is still the primary handle.
+                downloadTaskUpdated?(task)
+            },
+            completionHandler: completionHandler,
+            onCacheMiss: proceedToDownload,
+            onOriginalCacheFallbackDownload: { wrapped in
+                if let realTask = wrapped?.value {
+                    shell.linkToTask(realTask)
+                }
+            })
+
+        return shell
     }
 
     /// Drives an ``ImageDataProvider`` load inside a `Task` so that cancelling the
@@ -685,67 +747,17 @@ public class KingfisherManager: @unchecked Sendable {
         let key = source.cacheKey
         let targetImageCached = targetCache.imageCachedType(
             forKey: key, processorIdentifier: options.processor.identifier)
-        
+
         let validCache = targetImageCached.cached &&
             (options.fromMemoryCacheOrRefresh == false || targetImageCached == .memory)
         if validCache {
-            targetCache.retrieveImage(forKey: key, options: options) { result in
-                guard let completionHandler = completionHandler else { return }
-                
-                // TODO: Optimize it when we can use async across all the project.
-                @Sendable func checkResultImageAndCallback(_ inputImage: KFCrossPlatformImage) {
-                    var image = inputImage
-                    if image.kf.imageFrameCount != nil && image.kf.imageFrameCount != 1, options.imageCreatingOptions != image.kf.imageCreatingOptions, let data = image.kf.animatedImageData {
-                        // Recreate animated image representation when loaded in different options.
-                        // https://github.com/onevcat/Kingfisher/issues/1923
-                        image = options.processor.process(item: .data(data), options: options) ?? .init()
-                    }
-                    if let modifier = options.imageModifier {
-                        image = modifier.modify(image)
-                    }
-                    let value = result.map {
-                        RetrieveImageResult(
-                            image: image,
-                            cacheType: $0.cacheType,
-                            source: source,
-                            originalSource: context.originalSource,
-                            data: { [image] in options.cacheSerializer.data(with: image, original: nil) }
-                        )
-                    }
-                    completionHandler(value)
-                }
-                
-                result.match { cacheResult in
-                    options.callbackQueue.execute {
-                        guard let image = cacheResult.image else {
-                            completionHandler(.failure(KingfisherError.cacheError(reason: .imageNotExisting(key: key))))
-                            return
-                        }
-                        
-                        if options.cacheSerializer.originalDataUsed {
-                            let processor = options.processor
-                            (options.processingQueue ?? self.processingQueue).execute {
-                                let item = ImageProcessItem.image(image)
-                                guard let processedImage = processor.process(item: item, options: options) else {
-                                    let error = KingfisherError.processorError(
-                                        reason: .processingFailed(processor: processor, item: item))
-                                    options.callbackQueue.execute { completionHandler(.failure(error)) }
-                                    return
-                                }
-                                options.callbackQueue.execute {
-                                    checkResultImageAndCallback(processedImage)
-                                }
-                            }
-                        } else {
-                            checkResultImageAndCallback(image)
-                        }
-                    }
-                } onFailure: { error in
-                    options.callbackQueue.execute {
-                        completionHandler(.failure(error))
-                    }
-                }
-            }
+            deliverTargetCacheHit(
+                targetCache: targetCache,
+                key: key,
+                source: source,
+                context: context,
+                options: options,
+                completionHandler: completionHandler)
             return true
         }
 
@@ -760,99 +772,272 @@ public class KingfisherManager: @unchecked Sendable {
         let originalImageCacheType = originalCache.imageCachedType(
             forKey: key, processorIdentifier: DefaultImageProcessor.default.identifier)
         let canAcceptDiskCache = !options.fromMemoryCacheOrRefresh
-        
+
         let canUseOriginalImageCache =
             (canAcceptDiskCache && originalImageCacheType.cached) ||
             (!canAcceptDiskCache && originalImageCacheType == .memory)
-        
+
         if canUseOriginalImageCache {
-            // Now we are ready to get found the original image from cache. We need the unprocessed image, so remove
-            // any processor from options first.
-            var optionsWithoutProcessor = options
-            optionsWithoutProcessor.processor = DefaultImageProcessor.default
-            originalCache.retrieveImage(forKey: key, options: optionsWithoutProcessor) { result in
+            deliverOriginalCacheHit(
+                originalCache: originalCache,
+                targetCache: targetCache,
+                key: key,
+                source: source,
+                context: context,
+                options: options,
+                fallbackToDownload: { [weak self] in
+                    guard let self else { return }
+                    let task = self.loadAndCacheImage(
+                        source: source,
+                        context: context,
+                        completionHandler: completionHandler)
+                    downloadTaskUpdated?(task?.value)
+                },
+                completionHandler: completionHandler)
+            return true
+        }
 
-                result.match(
-                    onSuccess: { cacheResult in
-                        guard let image = cacheResult.image else {
-                            // If the task is stale, report error instead of downloading.
-                            if options.isSourceTaskStale {
-                                let error = KingfisherError.cacheError(reason: .imageNotExisting(key: key))
-                                options.callbackQueue.execute { completionHandler?(.failure(error)) }
-                                return
-                            }
+        return false
+    }
 
-                            // The original cache type check is not a strong guarantee. When it happens, treat it as a cache miss.
-                            // In this case, fall back to download or provider loading.
-                            if options.onlyFromCache {
-                                let error = KingfisherError.cacheError(reason: .imageNotExisting(key: key))
-                                options.callbackQueue.execute { completionHandler?(.failure(error)) }
-                            } else {
-                                let task = self.loadAndCacheImage(
-                                    source: source,
-                                    context: context,
-                                    completionHandler: completionHandler
-                                )
-                                downloadTaskUpdated?(task?.value)
-                            }
-                            return
-                        }
+    /// Async counterpart of ``retrieveImageFromCache(source:context:downloadTaskUpdated:completionHandler:)`` used
+    /// exclusively by the opt-in ``KingfisherOptionsInfoItem/asyncCacheTypeCheck`` path.
+    ///
+    /// Performs cache existence probes on the cache's I/O queue and invokes:
+    /// - ``completionHandler`` when the cache ultimately serves the image (memory hit or disk retrieval),
+    /// - ``onCacheMiss`` when neither the target nor the original cache can serve the request,
+    /// - ``onOriginalCacheFallbackDownload`` when a suspected original-cache hit turned out to be missing and a
+    ///   download was issued as a fallback; the caller uses this to link the real task onto its shell.
+    private func retrieveImageFromCacheAsync(
+        source: Source,
+        context: RetrievingContext<Source>,
+        downloadTaskUpdated: DownloadTaskUpdatedBlock?,
+        completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?,
+        onCacheMiss: @escaping @Sendable () -> Void,
+        onOriginalCacheFallbackDownload: @escaping @Sendable (DownloadTask.WrappedTask?) -> Void)
+    {
+        let options = context.options
+        let targetCache = options.targetCache ?? cache
+        let key = source.cacheKey
 
+        targetCache.imageCachedTypeAsync(
+            forKey: key,
+            processorIdentifier: options.processor.identifier,
+            forcedExtension: options.forcedExtension,
+            callbackQueue: .untouch
+        ) { [weak self] targetImageCached in
+            guard let self else { return }
+
+            let validCache = targetImageCached.cached &&
+                (options.fromMemoryCacheOrRefresh == false || targetImageCached == .memory)
+            if validCache {
+                self.deliverTargetCacheHit(
+                    targetCache: targetCache,
+                    key: key,
+                    source: source,
+                    context: context,
+                    options: options,
+                    completionHandler: completionHandler)
+                return
+            }
+
+            let originalCache = options.originalCache ?? targetCache
+            if originalCache === targetCache && options.processor == DefaultImageProcessor.default {
+                onCacheMiss()
+                return
+            }
+
+            originalCache.imageCachedTypeAsync(
+                forKey: key,
+                processorIdentifier: DefaultImageProcessor.default.identifier,
+                forcedExtension: options.forcedExtension,
+                callbackQueue: .untouch
+            ) { originalImageCacheType in
+                let canAcceptDiskCache = !options.fromMemoryCacheOrRefresh
+                let canUseOriginalImageCache =
+                    (canAcceptDiskCache && originalImageCacheType.cached) ||
+                    (!canAcceptDiskCache && originalImageCacheType == .memory)
+
+                if canUseOriginalImageCache {
+                    self.deliverOriginalCacheHit(
+                        originalCache: originalCache,
+                        targetCache: targetCache,
+                        key: key,
+                        source: source,
+                        context: context,
+                        options: options,
+                        fallbackToDownload: { [weak self] in
+                            guard let self else { return }
+                            let wrapped = self.loadAndCacheImage(
+                                source: source,
+                                context: context,
+                                completionHandler: completionHandler)
+                            onOriginalCacheFallbackDownload(wrapped)
+                            downloadTaskUpdated?(wrapped?.value)
+                        },
+                        completionHandler: completionHandler)
+                } else {
+                    onCacheMiss()
+                }
+            }
+        }
+    }
+
+    private func deliverTargetCacheHit(
+        targetCache: ImageCache,
+        key: String,
+        source: Source,
+        context: RetrievingContext<Source>,
+        options: KingfisherParsedOptionsInfo,
+        completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?)
+    {
+        targetCache.retrieveImage(forKey: key, options: options) { result in
+            guard let completionHandler = completionHandler else { return }
+
+            // TODO: Optimize it when we can use async across all the project.
+            @Sendable func checkResultImageAndCallback(_ inputImage: KFCrossPlatformImage) {
+                var image = inputImage
+                if image.kf.imageFrameCount != nil && image.kf.imageFrameCount != 1, options.imageCreatingOptions != image.kf.imageCreatingOptions, let data = image.kf.animatedImageData {
+                    // Recreate animated image representation when loaded in different options.
+                    // https://github.com/onevcat/Kingfisher/issues/1923
+                    image = options.processor.process(item: .data(data), options: options) ?? .init()
+                }
+                if let modifier = options.imageModifier {
+                    image = modifier.modify(image)
+                }
+                let value = result.map {
+                    RetrieveImageResult(
+                        image: image,
+                        cacheType: $0.cacheType,
+                        source: source,
+                        originalSource: context.originalSource,
+                        data: { [image] in options.cacheSerializer.data(with: image, original: nil) }
+                    )
+                }
+                completionHandler(value)
+            }
+
+            result.match { cacheResult in
+                options.callbackQueue.execute {
+                    guard let image = cacheResult.image else {
+                        completionHandler(.failure(KingfisherError.cacheError(reason: .imageNotExisting(key: key))))
+                        return
+                    }
+
+                    if options.cacheSerializer.originalDataUsed {
                         let processor = options.processor
                         (options.processingQueue ?? self.processingQueue).execute {
                             let item = ImageProcessItem.image(image)
                             guard let processedImage = processor.process(item: item, options: options) else {
                                 let error = KingfisherError.processorError(
                                     reason: .processingFailed(processor: processor, item: item))
-                                options.callbackQueue.execute { completionHandler?(.failure(error)) }
+                                options.callbackQueue.execute { completionHandler(.failure(error)) }
                                 return
                             }
-
-                            var cacheOptions = options
-                            cacheOptions.callbackQueue = .untouch
-
-                            let coordinator = CacheCallbackCoordinator(
-                                shouldWaitForCache: options.waitForCache, shouldCacheOriginal: false)
-
-                            let image = options.imageModifier?.modify(processedImage) ?? processedImage
-                            let result = RetrieveImageResult(
-                                image: image,
-                                cacheType: .none,
-                                source: source,
-                                originalSource: context.originalSource,
-                                data: { options.cacheSerializer.data(with: processedImage, original: nil) }
-                            )
-
-                            targetCache.store(
-                                processedImage,
-                                forKey: key,
-                                options: cacheOptions,
-                                toDisk: !options.cacheMemoryOnly)
-                            {
-                                _ in
-                                coordinator.apply(.cachingImage) {
-                                    options.callbackQueue.execute { completionHandler?(.success(result)) }
-                                }
+                            options.callbackQueue.execute {
+                                checkResultImageAndCallback(processedImage)
                             }
+                        }
+                    } else {
+                        checkResultImageAndCallback(image)
+                    }
+                }
+            } onFailure: { error in
+                options.callbackQueue.execute {
+                    completionHandler(.failure(error))
+                }
+            }
+        }
+    }
 
-                            coordinator.apply(.cacheInitiated) {
+    private func deliverOriginalCacheHit(
+        originalCache: ImageCache,
+        targetCache: ImageCache,
+        key: String,
+        source: Source,
+        context: RetrievingContext<Source>,
+        options: KingfisherParsedOptionsInfo,
+        fallbackToDownload: @escaping @Sendable () -> Void,
+        completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?)
+    {
+        // Now we are ready to get found the original image from cache. We need the unprocessed image, so remove
+        // any processor from options first.
+        var optionsWithoutProcessor = options
+        optionsWithoutProcessor.processor = DefaultImageProcessor.default
+        originalCache.retrieveImage(forKey: key, options: optionsWithoutProcessor) { result in
+
+            result.match(
+                onSuccess: { cacheResult in
+                    guard let image = cacheResult.image else {
+                        // If the task is stale, report error instead of downloading.
+                        if options.isSourceTaskStale {
+                            let error = KingfisherError.cacheError(reason: .imageNotExisting(key: key))
+                            options.callbackQueue.execute { completionHandler?(.failure(error)) }
+                            return
+                        }
+
+                        // The original cache type check is not a strong guarantee. When it happens, treat it as a cache miss.
+                        // In this case, fall back to download or provider loading.
+                        if options.onlyFromCache {
+                            let error = KingfisherError.cacheError(reason: .imageNotExisting(key: key))
+                            options.callbackQueue.execute { completionHandler?(.failure(error)) }
+                        } else {
+                            fallbackToDownload()
+                        }
+                        return
+                    }
+
+                    let processor = options.processor
+                    (options.processingQueue ?? self.processingQueue).execute {
+                        let item = ImageProcessItem.image(image)
+                        guard let processedImage = processor.process(item: item, options: options) else {
+                            let error = KingfisherError.processorError(
+                                reason: .processingFailed(processor: processor, item: item))
+                            options.callbackQueue.execute { completionHandler?(.failure(error)) }
+                            return
+                        }
+
+                        var cacheOptions = options
+                        cacheOptions.callbackQueue = .untouch
+
+                        let coordinator = CacheCallbackCoordinator(
+                            shouldWaitForCache: options.waitForCache, shouldCacheOriginal: false)
+
+                        let image = options.imageModifier?.modify(processedImage) ?? processedImage
+                        let result = RetrieveImageResult(
+                            image: image,
+                            cacheType: .none,
+                            source: source,
+                            originalSource: context.originalSource,
+                            data: { options.cacheSerializer.data(with: processedImage, original: nil) }
+                        )
+
+                        targetCache.store(
+                            processedImage,
+                            forKey: key,
+                            options: cacheOptions,
+                            toDisk: !options.cacheMemoryOnly)
+                        {
+                            _ in
+                            coordinator.apply(.cachingImage) {
                                 options.callbackQueue.execute { completionHandler?(.success(result)) }
                             }
                         }
-                    },
-                    onFailure: { error in
-                        // This should not happen actually, since we already confirmed `originalImageCached` is `true`.
-                        // Just in case...
-                        if let completionHandler = completionHandler {
-                            options.callbackQueue.execute { completionHandler(.failure(error)) }
+
+                        coordinator.apply(.cacheInitiated) {
+                            options.callbackQueue.execute { completionHandler?(.success(result)) }
                         }
                     }
-                )
-            }
-            return true
+                },
+                onFailure: { error in
+                    // This should not happen actually, since we already confirmed `originalImageCached` is `true`.
+                    // Just in case...
+                    if let completionHandler = completionHandler {
+                        options.callbackQueue.execute { completionHandler(.failure(error)) }
+                    }
+                }
+            )
         }
-
-        return false
     }
 }
 

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -500,30 +500,24 @@ public class KingfisherManager: @unchecked Sendable {
                 options.callbackQueue.execute { completionHandler?(.failure(error)) }
                 return
             }
-            let wrapped = self.loadAndCacheImage(
+            _ = self.loadAndCacheImage(
                 source: source,
                 context: context,
-                completionHandler: completionHandler)
-            if let realTask = wrapped?.value {
-                shell.linkToTask(realTask)
-            }
+                completionHandler: completionHandler,
+                downloadTaskCreated: { task in shell.linkToTask(task) })
         }
 
         retrieveImageFromCacheAsync(
             source: source,
             context: context,
-            downloadTaskUpdated: { task in
+            fallbackDownloadTaskCreated: { task in
+                shell.linkToTask(task)
                 // For non-shell fallback downloads started from original-cache fallback paths,
                 // surface the real task to the caller. The shell is still the primary handle.
                 downloadTaskUpdated?(task)
             },
             completionHandler: completionHandler,
-            onCacheMiss: proceedToDownload,
-            onOriginalCacheFallbackDownload: { wrapped in
-                if let realTask = wrapped?.value {
-                    shell.linkToTask(realTask)
-                }
-            })
+            onCacheMiss: proceedToDownload)
 
         return shell
     }
@@ -673,7 +667,9 @@ public class KingfisherManager: @unchecked Sendable {
     func loadAndCacheImage(
         source: Source,
         context: RetrievingContext<Source>,
-        completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask.WrappedTask?
+        completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?,
+        downloadTaskCreated: (@Sendable (DownloadTask) -> Void)? = nil
+    ) -> DownloadTask.WrappedTask?
     {
         let options = context.options
         @Sendable func _cacheImage(_ result: Result<ImageLoadingResult, KingfisherError>) {
@@ -692,6 +688,7 @@ public class KingfisherManager: @unchecked Sendable {
             let task = downloader.downloadImage(
                 with: resource.downloadURL, options: options, completionHandler: _cacheImage
             )
+            downloadTaskCreated?(task)
 
 
             // The code below is neat, but it fails the Swift 5.2 compiler with a runtime crash when 
@@ -712,7 +709,9 @@ public class KingfisherManager: @unchecked Sendable {
             guard let task = provideImage(provider: provider, options: options, completionHandler: _cacheImage) else {
                 return .dataProviding(nil)
             }
-            return .dataProviding(DownloadTask(providerTask: task))
+            let downloadTask = DownloadTask(providerTask: task)
+            downloadTaskCreated?(downloadTask)
+            return .dataProviding(downloadTask)
         }
     }
     
@@ -811,10 +810,9 @@ public class KingfisherManager: @unchecked Sendable {
     private func retrieveImageFromCacheAsync(
         source: Source,
         context: RetrievingContext<Source>,
-        downloadTaskUpdated: DownloadTaskUpdatedBlock?,
+        fallbackDownloadTaskCreated: @escaping @Sendable (DownloadTask) -> Void,
         completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?,
-        onCacheMiss: @escaping @Sendable () -> Void,
-        onOriginalCacheFallbackDownload: @escaping @Sendable (DownloadTask.WrappedTask?) -> Void)
+        onCacheMiss: @escaping @Sendable () -> Void)
     {
         let options = context.options
         let targetCache = options.targetCache ?? cache
@@ -868,12 +866,11 @@ public class KingfisherManager: @unchecked Sendable {
                         options: options,
                         fallbackToDownload: { [weak self] in
                             guard let self else { return }
-                            let wrapped = self.loadAndCacheImage(
+                            _ = self.loadAndCacheImage(
                                 source: source,
                                 context: context,
-                                completionHandler: completionHandler)
-                            onOriginalCacheFallbackDownload(wrapped)
-                            downloadTaskUpdated?(wrapped?.value)
+                                completionHandler: completionHandler,
+                                downloadTaskCreated: fallbackDownloadTaskCreated)
                         },
                         completionHandler: completionHandler)
                 } else {

--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -231,14 +231,32 @@ public enum KingfisherOptionsInfoItem: Sendable {
     
     /// When set, disk storage loading will occur in the same calling queue.
     ///
-    /// By default, disk storage file loading operates on its own queue with asynchronous dispatch behavior. While this 
+    /// By default, disk storage file loading operates on its own queue with asynchronous dispatch behavior. While this
     /// provides improved non-blocking disk loading performance, it can lead to flickering when you reload an image from
     /// disk if the image view already has an image set.
     ///
-    /// Setting this option will eliminate that flickering by keeping all loading in the same queue (typically the UI 
+    /// Setting this option will eliminate that flickering by keeping all loading in the same queue (typically the UI
     /// queue if you are using Kingfisher's extension methods to set an image). However, this comes with a tradeoff in
     /// loading performance.
     case loadDiskFileSynchronously
+
+    /// When set, the cache existence probe that decides whether an image is already cached is dispatched onto the cache's
+    /// I/O queue instead of running synchronously on the caller thread.
+    ///
+    /// By default, ``KingfisherManager`` calls ``ImageCache/imageCachedType(forKey:processorIdentifier:forcedExtension:)``
+    /// before deciding between a cache read and a network download. That call performs file-system `stat` syscalls on
+    /// whatever thread invoked `setImage`. When `setImage` is called from UIKit layout callbacks such as
+    /// `tableView(_:cellForRowAt:)` or `collectionView(_:cellForItemAt:)` on a device under disk pressure, those syscalls
+    /// can hang the main thread.
+    ///
+    /// Opt in to this flag to move the probe onto the cache's I/O queue via
+    /// ``ImageCache/imageCachedTypeAsync(forKey:processorIdentifier:forcedExtension:callbackQueue:completionHandler:)``.
+    /// The ``DownloadTask`` returned from `setImage` is still delivered synchronously; if the probe discovers a cache
+    /// miss, the resulting network task is linked to the returned shell via ``DownloadTask/linkToTask(_:)``.
+    ///
+    /// - Note: If ``KingfisherOptionsInfoItem/loadDiskFileSynchronously`` is set, that option continues to govern the
+    ///   actual disk read. This flag only affects the existence probe that precedes the read.
+    case asyncCacheTypeCheck
 
     /// Options for controlling the data writing process to disk storage.
     ///
@@ -405,6 +423,7 @@ public struct KingfisherParsedOptionsInfo: Sendable {
     public var onFailureImage: Optional<KFCrossPlatformImage?> = .none
     public var alsoPrefetchToMemory = false
     public var loadDiskFileSynchronously = false
+    public var asyncCacheTypeCheck = false
     public var diskStoreWriteOptions: Data.WritingOptions = []
     public var memoryCacheExpiration: StorageExpiration? = nil
     public var memoryCacheAccessExtendingExpiration: ExpirationExtending = .cacheTime
@@ -451,6 +470,7 @@ public struct KingfisherParsedOptionsInfo: Sendable {
             case .onFailureImage(let value): onFailureImage = .some(value)
             case .alsoPrefetchToMemory: alsoPrefetchToMemory = true
             case .loadDiskFileSynchronously: loadDiskFileSynchronously = true
+            case .asyncCacheTypeCheck: asyncCacheTypeCheck = true
             case .diskStoreWriteOptions(let options): diskStoreWriteOptions = options
             case .memoryCacheExpiration(let expiration): memoryCacheExpiration = expiration
             case .memoryCacheAccessExtendingExpiration(let expirationExtending): memoryCacheAccessExtendingExpiration = expirationExtending

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -85,12 +85,14 @@ public final class DownloadTask: @unchecked Sendable {
         _providerTask = providerTask
     }
 
+    private var _linkedTask: DownloadTask? = nil
+
     private var _providerTask: Task<Void, Never>? = nil
 
     /// The Swift concurrency `Task` driving an ``ImageDataProvider`` load, if this
     /// `DownloadTask` represents a provider-backed load.
     var providerTask: Task<Void, Never>? {
-        get { propertyQueue.sync { _providerTask } }
+        get { propertyQueue.sync { _providerTask ?? _linkedTask?.providerTask } }
         set { propertyQueue.sync { _providerTask = newValue } }
     }
 
@@ -103,7 +105,7 @@ public final class DownloadTask: @unchecked Sendable {
     /// When you call ``DownloadTask/cancel()``, this ``SessionDataTask`` and its cancellation token will be passed
     /// along. You can use them to identify the cancelled task.
     public private(set) var sessionTask: SessionDataTask? {
-        get { propertyQueue.sync { _sessionTask } }
+        get { propertyQueue.sync { _sessionTask ?? _linkedTask?.sessionTask } }
         set { propertyQueue.sync { _sessionTask = newValue } }
     }
 
@@ -114,7 +116,7 @@ public final class DownloadTask: @unchecked Sendable {
     /// This is solely for identifying the task when it is cancelled. To cancel a ``DownloadTask``, call
     ///  ``DownloadTask/cancelToken``.
     public private(set) var cancelToken: SessionDataTask.CancelToken? {
-        get { propertyQueue.sync { _cancelToken } }
+        get { propertyQueue.sync { _cancelToken ?? _linkedTask?.cancelToken } }
         set { propertyQueue.sync { _cancelToken = newValue } }
     }
 
@@ -145,13 +147,16 @@ public final class DownloadTask: @unchecked Sendable {
     
     public var isInitialized: Bool {
         propertyQueue.sync {
-            _sessionTask != nil && _cancelToken != nil
+            (_sessionTask != nil && _cancelToken != nil) ||
+            _providerTask != nil ||
+            (_linkedTask?.isInitialized ?? false)
         }
     }
     
     func linkToTask(_ task: DownloadTask) {
-        self.sessionTask = task.sessionTask
-        self.cancelToken = task.cancelToken
+        propertyQueue.sync {
+            _linkedTask = task
+        }
     }
 }
 

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -27,7 +27,7 @@
 import XCTest
 @testable import Kingfisher
 
-class ImageViewExtensionTests: XCTestCase {
+class ImageViewExtensionTests: XCTestCase, @unchecked Sendable {
 
     var imageView: KFCrossPlatformImageView!
     
@@ -677,32 +677,55 @@ class ImageViewExtensionTests: XCTestCase {
     @MainActor func testSetSameURLWithDifferentProcessors() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
-        
-        stub(url, data: testImageData)
-        
         let size1 = CGSize(width: 10, height: 10)
         let p1 = ResizingImageProcessor(referenceSize: size1)
-        
         let size2 = CGSize(width: 20, height: 20)
         let p2 = ResizingImageProcessor(referenceSize: size2)
-        
-        let group = DispatchGroup()
-        
-        group.enter()
-        imageView.kf.setImage(with: url, options: [.processor(p1), .cacheMemoryOnly]) { result in
-            XCTAssertNotNil(result.error)
-            XCTAssertTrue(result.error!.isNotCurrentTask)
-            group.leave()
+        let coordinator = CoordinatingCacheSerializer()
+        let cache = KingfisherManager.shared.cache
+
+        cache.store(testImage, original: testImageData, forKey: url.cacheKey, toDisk: true) { _ in
+            Task { @MainActor in
+                cache.clearMemoryCache()
+
+                let completionGroup = DispatchGroup()
+
+                completionGroup.enter()
+                self.imageView.kf.setImage(
+                    with: url,
+                    options: [.processor(p1), .cacheSerializer(coordinator)]
+                ) { result in
+                    XCTAssertNotNil(result.error)
+                    XCTAssertTrue(result.error!.isNotCurrentTask)
+                    completionGroup.leave()
+                }
+
+                DispatchQueue.global().async {
+                    coordinator.waitUntilFirstCallEntered()
+
+                    DispatchQueue.main.async {
+                        MainActor.assumeIsolated {
+                            completionGroup.enter()
+                            self.imageView.kf.setImage(
+                                with: url,
+                                options: [.processor(p2), .cacheSerializer(coordinator)]
+                            ) { result in
+                                XCTAssertNotNil(result.value)
+                                XCTAssertEqual(result.value!.image.size, size2)
+                                completionGroup.leave()
+                            }
+
+                            coordinator.allowFirstCallToProceed()
+                        }
+                    }
+                }
+
+                completionGroup.notify(queue: .main) {
+                    exp.fulfill()
+                }
+            }
         }
-        
-        group.enter()
-        imageView.kf.setImage(with: url, options: [.processor(p2), .cacheMemoryOnly]) { result in
-            XCTAssertNotNil(result.value)
-            XCTAssertEqual(result.value!.image.size, size2)
-            group.leave()
-        }
-        
-        group.notify(queue: .main) { exp.fulfill() }
+
         waitForExpectations(timeout: 5, handler: nil)
     }
     

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1886,25 +1886,29 @@ class KingfisherManagerTests: XCTestCase {
 
     func testRetrieveImageWithAsyncCacheTypeCheckReturnsCancellableShellOnMiss() {
         let completionExp = expectation(description: "\(#function) completion")
-        let teardownExp = expectation(description: "\(#function) teardown")
+        let downloadStartedExp = expectation(description: "\(#function) download started")
         let url = testURLs[0]
         let stub = delayedStub(url, data: testImageData, length: 123)
+        let asyncModifier = AsyncURLModifier(url: url, onDownloadTaskStarted: { task in
+            XCTAssertNotNil(task)
+            downloadStartedExp.fulfill()
+        })
+        let rewrittenURL = URL(string: "https://example.com/async-cache-type-check-shell")!
 
-        let task = manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck]) { result in
+        let task = manager.retrieveImage(
+            with: rewrittenURL,
+            options: [.asyncCacheTypeCheck, .requestModifier(asyncModifier)]
+        ) { result in
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error!.isTaskCancelled)
             completionExp.fulfill()
         }
         XCTAssertNotNil(task, "asyncCacheTypeCheck path should return a task shell synchronously.")
 
-        // Give the async cache probe time to resolve and link the real download task onto the shell,
-        // then cancel through the shell before flushing the delayed stub.
-        DispatchQueue.global().asyncAfter(deadline: .now() + 0.3) {
-            task?.cancel()
-            _ = stub.go()
-            teardownExp.fulfill()
-        }
-        wait(for: [completionExp, teardownExp], timeout: 5)
+        wait(for: [downloadStartedExp], timeout: 2)
+        task?.cancel()
+        _ = stub.go()
+        wait(for: [completionExp], timeout: 5)
     }
 
     func testRetrieveImageWithAsyncCacheTypeCheckHonoursOnlyFromCache() {

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1778,6 +1778,61 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertEqual(cacheType, .none)
     }
 
+    func testRetrieveImageFromDiskCacheWithForcedExtension() async throws {
+        let url = URL(string: "https://example.com/forced-extension-target")!
+        stub(url, data: testImageData)
+
+        let options: KingfisherOptionsInfo = [.forcedCacheFileExtension("heic")]
+
+        var result = try await manager.retrieveImage(with: url, options: options)
+        XCTAssertEqual(result.cacheType, .none)
+
+        manager.cache.clearMemoryCache()
+        LSNocilla.sharedInstance().clearStubs()
+
+        result = try await manager.retrieveImage(with: url, options: options)
+        XCTAssertEqual(result.cacheType, .disk)
+    }
+
+    func testRetrieveImageFromOriginalCacheWithForcedExtension() async throws {
+        let url = URL(string: "https://example.com/forced-extension-original")!
+        let originalCache = ImageCache(name: "test-original-forced-\(UUID().uuidString)")
+        addTeardownBlock {
+            clearCaches([originalCache])
+        }
+
+        try await originalCache.store(
+            testImage,
+            original: testImageData,
+            forKey: url.cacheKey,
+            processorIdentifier: DefaultImageProcessor.default.identifier,
+            forcedExtension: "heic",
+            toDisk: true
+        )
+        originalCache.clearMemoryCache()
+        manager.cache.clearMemoryCache()
+        LSNocilla.sharedInstance().clearStubs()
+
+        let processor = RoundCornerImageProcessor(cornerRadius: 20)
+        let result = try await manager.retrieveImage(
+            with: url,
+            options: [
+                .processor(processor),
+                .originalCache(originalCache),
+                .forcedCacheFileExtension("heic")
+            ]
+        )
+
+        XCTAssertEqual(result.cacheType, .none)
+        XCTAssertTrue(
+            manager.cache.imageCachedType(
+                forKey: url.cacheKey,
+                processorIdentifier: processor.identifier,
+                forcedExtension: "heic"
+            ).cached
+        )
+    }
+    
     // MARK: - Async cache-type check (issue #2512)
 
     func testRetrieveImageWithAsyncCacheTypeCheckAcrossCacheStates() {

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1861,26 +1861,37 @@ class KingfisherManagerTests: XCTestCase {
         stub(url, data: testImageData)
 
         let manager = self.manager!
-        manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck]) { result in
-            XCTAssertNotNil(result.value?.image)
-            XCTAssertEqual(result.value!.cacheType, .none)
+        let expectedCacheTypes: [CacheType] = [.none, .memory, .disk, .none]
 
-        manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck]) { result in
-            XCTAssertNotNil(result.value?.image)
-            XCTAssertEqual(result.value!.cacheType, .memory)
-
-        manager.cache.clearMemoryCache()
-        manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck]) { result in
-            XCTAssertNotNil(result.value?.image)
-            XCTAssertEqual(result.value!.cacheType, .disk)
-
-        manager.cache.clearMemoryCache()
-        manager.cache.clearDiskCache {
+        func runStep(_ index: Int) {
             manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck]) { result in
-                XCTAssertNotNil(result.value?.image)
-                XCTAssertEqual(result.value!.cacheType, .none)
-                exp.fulfill()
-        }}}}}
+                guard let value = result.value else {
+                    XCTFail("Expected cached image result at step \(index), got \(String(describing: result.error))")
+                    exp.fulfill()
+                    return
+                }
+
+                XCTAssertNotNil(value.image)
+                XCTAssertEqual(value.cacheType, expectedCacheTypes[index])
+
+                switch index {
+                case 0:
+                    runStep(1)
+                case 1:
+                    manager.cache.clearMemoryCache()
+                    runStep(2)
+                case 2:
+                    manager.cache.clearMemoryCache()
+                    manager.cache.clearDiskCache {
+                        runStep(3)
+                    }
+                default:
+                    exp.fulfill()
+                }
+            }
+        }
+
+        runStep(0)
         waitForExpectations(timeout: 3, handler: nil)
     }
 

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1777,6 +1777,114 @@ class KingfisherManagerTests: XCTestCase {
         cacheType = manager.cache.imageCachedType(forKey: resource.cacheKey)
         XCTAssertEqual(cacheType, .none)
     }
+
+    // MARK: - Async cache-type check (issue #2512)
+
+    func testRetrieveImageWithAsyncCacheTypeCheckAcrossCacheStates() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        stub(url, data: testImageData)
+
+        let manager = self.manager!
+        manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck]) { result in
+            XCTAssertNotNil(result.value?.image)
+            XCTAssertEqual(result.value!.cacheType, .none)
+
+        manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck]) { result in
+            XCTAssertNotNil(result.value?.image)
+            XCTAssertEqual(result.value!.cacheType, .memory)
+
+        manager.cache.clearMemoryCache()
+        manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck]) { result in
+            XCTAssertNotNil(result.value?.image)
+            XCTAssertEqual(result.value!.cacheType, .disk)
+
+        manager.cache.clearMemoryCache()
+        manager.cache.clearDiskCache {
+            manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck]) { result in
+                XCTAssertNotNil(result.value?.image)
+                XCTAssertEqual(result.value!.cacheType, .none)
+                exp.fulfill()
+        }}}}}
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testRetrieveImageWithAsyncCacheTypeCheckReturnsCancellableShellOnMiss() {
+        let completionExp = expectation(description: "\(#function) completion")
+        let teardownExp = expectation(description: "\(#function) teardown")
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData, length: 123)
+
+        let task = manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck]) { result in
+            XCTAssertNotNil(result.error)
+            XCTAssertTrue(result.error!.isTaskCancelled)
+            completionExp.fulfill()
+        }
+        XCTAssertNotNil(task, "asyncCacheTypeCheck path should return a task shell synchronously.")
+
+        // Give the async cache probe time to resolve and link the real download task onto the shell,
+        // then cancel through the shell before flushing the delayed stub.
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.3) {
+            task?.cancel()
+            _ = stub.go()
+            teardownExp.fulfill()
+        }
+        wait(for: [completionExp, teardownExp], timeout: 5)
+    }
+
+    func testRetrieveImageWithAsyncCacheTypeCheckHonoursOnlyFromCache() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+
+        manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck, .onlyFromCache]) { result in
+            XCTAssertNil(result.value)
+            XCTAssertNotNil(result.error)
+            if case .cacheError(reason: .imageNotExisting) = result.error! {
+                // expected
+            } else {
+                XCTFail("Expected imageNotExisting error but got \(String(describing: result.error))")
+            }
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testRetrieveImageWithAsyncCacheTypeCheckUsesOriginalCacheFallback() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        stub(url, data: testImageData)
+
+        let processor = RoundCornerImageProcessor(cornerRadius: 20)
+        let manager = self.manager!
+
+        // Warm the default cache (which acts as `originalCache`) with the unprocessed image.
+        manager.retrieveImage(with: url) { result in
+            XCTAssertNotNil(result.value?.image)
+            XCTAssertEqual(result.value!.cacheType, .none)
+
+            // Drop the memory layer so the async probe must hit the disk path.
+            manager.cache.clearMemoryCache()
+
+            manager.retrieveImage(
+                with: url,
+                options: [.processor(processor), .asyncCacheTypeCheck, .cacheOriginalImage]
+            ) { result in
+                // Original was cached, processed image built from it; first time returns .none.
+                XCTAssertNotNil(result.value?.image)
+                XCTAssertEqual(result.value!.cacheType, .none)
+
+                manager.retrieveImage(
+                    with: url,
+                    options: [.processor(processor), .asyncCacheTypeCheck]
+                ) { result in
+                    XCTAssertNotNil(result.value?.image)
+                    XCTAssertEqual(result.value!.cacheType, .memory)
+                    exp.fulfill()
+                }
+            }
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
 }
 
 private var imageCreatingOptionsKey: Void?

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -706,61 +706,49 @@ class KingfisherManagerTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
     
-    func testCouldProcessDoNotHappenWhenSerializerCachesTheProcessedData() {
-        let exp = expectation(description: #function)
-        let url = testURLs[0]
-        
-        stub(url, data: testImageData)
-        
+    func testCouldProcessDoNotHappenWhenSerializerCachesTheProcessedData() async throws {
+        let provider = SimpleImageDataProvider(cacheKey: #function) { .success(testImageData) }
         let s = DefaultCacheSerializer()
 
         let p1 = SimpleProcessor()
         let options1: KingfisherOptionsInfo = [.processor(p1), .cacheSerializer(s), .waitForCache]
-        let source = Source.network(url)
-        
-        manager.retrieveImage(with: source, options: options1) { result in
-            XCTAssertTrue(p1.processed)
-            
-            let p2 = SimpleProcessor()
-            let options2: KingfisherOptionsInfo = [.processor(p2), .cacheSerializer(s), .waitForCache]
-            self.manager.cache.clearMemoryCache()
-            
-            self.manager.retrieveImage(with: source, options: options2) { result in
-                XCTAssertEqual(result.value?.cacheType, .disk)
-                XCTAssertFalse(p2.processed)
-                exp.fulfill()
-            }
-        }
-        waitForExpectations(timeout: 3, handler: nil)
+        let source = Source.provider(provider)
+
+        let first = try await manager.retrieveImage(with: source, options: options1)
+        XCTAssertEqual(first.cacheType, .none)
+        XCTAssertTrue(p1.processed)
+
+        let p2 = SimpleProcessor()
+        let options2: KingfisherOptionsInfo = [.processor(p2), .cacheSerializer(s), .waitForCache]
+        manager.cache.clearMemoryCache()
+
+        let second = try await manager.retrieveImage(with: source, options: options2)
+        XCTAssertNotNil(second.image)
+        XCTAssertEqual(second.cacheType, .disk)
+        XCTAssertFalse(p2.processed)
     }
     
-    func testCouldProcessAgainWhenSerializerCachesOriginalData() {
-        let exp = expectation(description: #function)
-        let url = testURLs[0]
-        
-        stub(url, data: testImageData)
-        
+    func testCouldProcessAgainWhenSerializerCachesOriginalData() async throws {
+        let provider = SimpleImageDataProvider(cacheKey: #function) { .success(testImageData) }
         var s = DefaultCacheSerializer()
         s.preferCacheOriginalData = true
 
         let p1 = SimpleProcessor()
         let options1: KingfisherOptionsInfo = [.processor(p1), .cacheSerializer(s), .waitForCache]
-        let source = Source.network(url)
-        
-        manager.retrieveImage(with: source, options: options1) { [s] result in
-            XCTAssertTrue(p1.processed)
-            
-            let p2 = SimpleProcessor()
-            let options2: KingfisherOptionsInfo = [.processor(p2), .cacheSerializer(s), .waitForCache]
-            self.manager.cache.clearMemoryCache()
-            
-            self.manager.retrieveImage(with: source, options: options2) { result in
-                XCTAssertEqual(result.value?.cacheType, .disk)
-                XCTAssertTrue(p2.processed)
-                exp.fulfill()
-            }
-        }
-        waitForExpectations(timeout: 3, handler: nil)
+        let source = Source.provider(provider)
+
+        let first = try await manager.retrieveImage(with: source, options: options1)
+        XCTAssertEqual(first.cacheType, .none)
+        XCTAssertTrue(p1.processed)
+
+        let p2 = SimpleProcessor()
+        let options2: KingfisherOptionsInfo = [.processor(p2), .cacheSerializer(s), .waitForCache]
+        manager.cache.clearMemoryCache()
+
+        let second = try await manager.retrieveImage(with: source, options: options2)
+        XCTAssertNotNil(second.image)
+        XCTAssertEqual(second.cacheType, .disk)
+        XCTAssertTrue(p2.processed)
     }
     
     func testWaitForCacheOnRetrieveImage() {
@@ -874,34 +862,26 @@ class KingfisherManagerTests: XCTestCase {
         waitForExpectations(timeout: 5, handler: nil)
     }
 
-    func testShouldDownloadAndCacheProcessedImage() {
-        let exp = expectation(description: #function)
-        let url = testURLs[0]
-        stub(url, data: testImageData)
-
+    func testShouldDownloadAndCacheProcessedImage() async throws {
+        let provider = SimpleImageDataProvider(cacheKey: #function) { .success(testImageData) }
         let size = CGSize(width: 1, height: 1)
         let processor = ResizingImageProcessor(referenceSize: size)
+        let source = Source.provider(provider)
 
-        manager.retrieveImage(with: url, options: [.processor(processor)]) { result in
-            // Can download and cache normally
-            XCTAssertNotNil(result.value?.image)
-            XCTAssertEqual(result.value!.image.size, size)
-            XCTAssertEqual(result.value!.cacheType, .none)
+        let first = try await manager.retrieveImage(with: source, options: [.processor(processor)])
+        XCTAssertNotNil(first.image)
+        XCTAssertEqual(first.image.size, size)
+        XCTAssertEqual(first.cacheType, .none)
 
-            self.manager.cache.clearMemoryCache()
-            let cached = self.manager.cache.imageCachedType(
-                forKey: url.cacheKey, processorIdentifier: processor.identifier)
-            XCTAssertEqual(cached, .disk)
+        manager.cache.clearMemoryCache()
+        let cached = manager.cache.imageCachedType(
+            forKey: provider.cacheKey, processorIdentifier: processor.identifier)
+        XCTAssertEqual(cached, .disk)
 
-            self.manager.retrieveImage(with: url, options: [.processor(processor)]) { result in
-                XCTAssertNotNil(result.value?.image)
-                XCTAssertEqual(result.value!.image.size, size)
-                XCTAssertEqual(result.value!.cacheType, .disk)
-
-                exp.fulfill()
-            }
-        }
-        waitForExpectations(timeout: 3, handler: nil)
+        let second = try await manager.retrieveImage(with: source, options: [.processor(processor)])
+        XCTAssertNotNil(second.image)
+        XCTAssertEqual(second.image.size, size)
+        XCTAssertEqual(second.cacheType, .disk)
     }
 
 #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1885,6 +1885,68 @@ class KingfisherManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
+
+    func testRetrieveImageWithAsyncCacheTypeCheckCancelsProviderBackedShell() {
+        let providerStarted = expectation(description: "\(#function) provider started")
+        let completionExp = expectation(description: "\(#function) completion")
+
+        let provider = AsyncCacheTypeCheckProvider(
+            cacheKey: "provider-\(UUID().uuidString)",
+            payload: testImageData,
+            onStart: { providerStarted.fulfill() }
+        )
+
+        let task = manager.retrieveImage(with: .provider(provider), options: [.asyncCacheTypeCheck]) { result in
+            switch result {
+            case .success:
+                XCTFail("provider-backed asyncCacheTypeCheck shell should cancel the underlying load")
+            case .failure(let error):
+                guard case .requestError(reason: .dataProviderCancelled) = error else {
+                    XCTFail("expected .dataProviderCancelled, got: \(error)")
+                    completionExp.fulfill()
+                    return
+                }
+            }
+            completionExp.fulfill()
+        }
+
+        XCTAssertNotNil(task, "asyncCacheTypeCheck should still return a cancellable shell for provider sources.")
+        wait(for: [providerStarted], timeout: 2)
+        task?.cancel()
+        wait(for: [completionExp], timeout: 2)
+    }
+
+    func testRetrieveImageWithAsyncCacheTypeCheckCancelsAsyncRequestModifierShell() {
+        let downloadStarted = expectation(description: "\(#function) download started")
+        let completionExp = expectation(description: "\(#function) completion")
+        let url = testURLs[0]
+        let delayedResponse = delayedStub(url, data: testImageData, length: 123)
+
+        let asyncModifier = AsyncURLModifier(url: url, onDownloadTaskStarted: { task in
+            XCTAssertNotNil(task)
+            downloadStarted.fulfill()
+        })
+
+        let rewrittenURL = URL(string: "https://example.com/async-modifier-shell")!
+        let task = manager.retrieveImage(
+            with: rewrittenURL,
+            options: [.asyncCacheTypeCheck, .requestModifier(asyncModifier)]
+        ) { result in
+            guard let error = result.error else {
+                XCTFail("async request modifier shell should cancel the underlying download")
+                completionExp.fulfill()
+                return
+            }
+            XCTAssertTrue(error.isTaskCancelled)
+            completionExp.fulfill()
+        }
+
+        XCTAssertNotNil(task, "asyncCacheTypeCheck should always return a shell synchronously.")
+        wait(for: [downloadStarted], timeout: 2)
+        task?.cancel()
+        _ = delayedResponse.go()
+        wait(for: [completionExp], timeout: 2)
+    }
 }
 
 private var imageCreatingOptionsKey: Void?
@@ -1921,6 +1983,24 @@ final class SimpleProcessor: ImageProcessor, @unchecked Sendable {
             image?.creatingOptions = creatingOptions
             return image
         }
+    }
+}
+
+private final class AsyncCacheTypeCheckProvider: ImageDataProvider, @unchecked Sendable {
+    let cacheKey: String
+    private let payload: Data
+    private let onStart: @Sendable () -> Void
+
+    init(cacheKey: String, payload: Data, onStart: @escaping @Sendable () -> Void) {
+        self.cacheKey = cacheKey
+        self.payload = payload
+        self.onStart = onStart
+    }
+
+    func data() async throws -> Data {
+        onStart()
+        try await Task.sleep(nanoseconds: 1_000_000_000)
+        return payload
     }
 }
 

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -458,6 +458,26 @@ class KingfisherManagerTests: XCTestCase {
         }
         waitForExpectations(timeout: 3, handler: nil)
     }
+
+    func testOnlyFromCacheMissCompletionHandlerRunningOnCustomQueue() {
+        let completionExpectation = expectation(description: "completionHandler running on custom queue")
+        let customQueue = DispatchQueue(label: "com.kingfisher.testQueue.onlyFromCache")
+        let queueKey = DispatchSpecificKey<String>()
+        customQueue.setSpecific(key: queueKey, value: customQueue.label)
+
+        let url = URL(string: "https://example.com/only-from-cache-miss")!
+        manager.retrieveImage(
+            with: url,
+            options: [.onlyFromCache, .callbackQueue(.dispatch(customQueue))]
+        ) { result in
+            XCTAssertNil(result.value)
+            XCTAssertNotNil(result.error)
+            XCTAssertEqual(DispatchQueue.getSpecific(key: queueKey), customQueue.label)
+            completionExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
     
     func testDefaultOptionCouldApply() {
         let exp = expectation(description: #function)

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1863,7 +1863,7 @@ class KingfisherManagerTests: XCTestCase {
         let manager = self.manager!
         let expectedCacheTypes: [CacheType] = [.none, .memory, .disk, .none]
 
-        func runStep(_ index: Int) {
+        @Sendable func runStep(_ index: Int) {
             manager.retrieveImage(with: url, options: [.asyncCacheTypeCheck]) { result in
                 guard let value = result.value else {
                     XCTFail("Expected cached image result at step \(index), got \(String(describing: result.error))")


### PR DESCRIPTION
## Summary

- Adds `KingfisherOptionsInfoItem.asyncCacheTypeCheck`. When set, the cache-existence probe that precedes every `retrieveImage` call is dispatched onto the cache's I/O queue via `imageCachedTypeAsync`, instead of running `stat` syscalls synchronously on the caller thread.
- `retrieveImage` still returns a `DownloadTask` synchronously. With the opt-in flag it returns a shell, probes the cache asynchronously, and on cache miss links the resulting session task onto the shell via `DownloadTask.linkToTask(_:)`.
- Default behavior is unchanged; callers that do not pass the new option continue to go through the existing synchronous probe path.
- Extracts `deliverTargetCacheHit` / `deliverOriginalCacheHit` helpers so both sync and async paths share their cache-hit delivery logic.

## Motivation

Reported in #2512: under disk pressure, `ImageCache.imageCachedType` → `DiskStorage.Backend.isCached` → `fileManager.fileExists` performs `stat` syscalls on whatever thread called `setImage`. When `setImage` runs from UIKit layout callbacks (`tableView(_:cellForRowAt:)`, `collectionView(_:cellForItemAt:)`) these syscalls hang the main thread.

## Usage

```swift
imageView.kf.setImage(with: url, options: [.asyncCacheTypeCheck])
```

## Test plan

- [x] `bundle exec fastlane test destination:"platform=iOS Simulator,name=iPhone 17"` — 336 tests pass.
- [x] New cases in `KingfisherManagerTests` covering memory hit, disk hit, cache miss → download, `onlyFromCache`, `originalCache` fallback, and cancellation of the returned shell.

Fixes #2512
