### PR TITLE
docs: document forcedCacheFileExtension option case

### DIFF
--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -363,7 +363,14 @@ public enum KingfisherOptionsInfoItem: Sendable {
     /// If not set or if the associated optional ``Source`` value is `nil`, the device's Low Data Mode will be ignored,
     /// and the original source will be loaded following the system default behavior.
     case lowDataMode(Source?)
-    
+
+    /// Forces the disk cache to use a specific file extension when persisting the image.
+    ///
+    /// By default, Kingfisher determines the file extension based on the disk storage configuration. When this option
+    /// is set, the associated `String` value is used verbatim as the extension for the cached file instead.
+    ///
+    /// If the associated value is `nil`, the behavior is the same as not setting this option: the file extension is
+    /// determined by the disk storage configuration.
     case forcedCacheFileExtension(String?)
 }
 


### PR DESCRIPTION
## Summary

Adds a `///` doc comment to the `forcedCacheFileExtension(String?)` case
of `KingfisherOptionsInfoItem`. This was the only case in the enum
without documentation, so DocC output was missing a description for it.

The wording mirrors the existing documentation for the corresponding
`forcedExtension:` parameter on
`ImageCache.store(_:original:forKey:processorIdentifier:forcedExtension:…)`
so both entry points describe the feature the same way.

## Diff

```swift
+    /// Forces the disk cache to use a specific file extension when persisting the image.
+    ///
+    /// By default, Kingfisher determines the file extension based on the disk storage configuration. When this option
+    /// is set, the associated `String` value is used verbatim as the extension for the cached file instead.
+    ///
+    /// If the associated value is `nil`, the behavior is the same as not setting this option: the file extension is
+    /// determined by the disk storage configuration.
     case forcedCacheFileExtension(String?)
```

## Test plan

- [x] `swift build` succeeds locally (Swift 6.3 / Xcode 26)
- [x] No behavior change — comment-only addition to a public enum case