### PR TITLE
Fix SessionDataTask mutable data COW sharing

### DIFF
--- a/Sources/General/KingfisherOptionsInfo.swift
+++ b/Sources/General/KingfisherOptionsInfo.swift
@@ -539,7 +539,7 @@ class ImageLoadingProgressSideEffect: DataReceivingSideEffect, @unchecked Sendab
                 return
             }
 
-            let dataLength = Int64(task.mutableData.count)
+            let dataLength = Int64(task.mutableDataCount)
             self.block(dataLength, expectedContentLength)
         }
     }

--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -45,7 +45,13 @@ public class SessionDataTask: @unchecked Sendable {
     public var mutableData: Data {
         lock.lock()
         defer { lock.unlock() }
-        return _mutableData
+        return Data(_mutableData)
+    }
+
+    var mutableDataCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _mutableData.count
     }
 
     // This is a copy of `task.originalRequest?.url`. It is for obtaining race-safe behavior for a pitfall on iOS 13.

--- a/Tests/KingfisherTests/DataReceivingSideEffectTests.swift
+++ b/Tests/KingfisherTests/DataReceivingSideEffectTests.swift
@@ -31,6 +31,33 @@ class DataReceivingSideEffectTests: XCTestCase {
 
     var manager: KingfisherManager!
 
+    func testSessionDataTaskMutableDataGetterDoesNotShareStorage() {
+        for attempt in 0..<100 {
+            let url = URL(string: "https://example.com/image-\(attempt).png")!
+            let urlTask = URLSession(configuration: .ephemeral).dataTask(with: url)
+            let task = SessionDataTask(task: urlTask)
+
+            // Use a large buffer to avoid inline Data storage, making COW storage sharing observable.
+            task.didReceiveData(Data(repeating: 0x11, count: 1024 * 1024))
+
+            let snapshot = task.mutableData
+            let secondSnapshot = task.mutableData
+
+            XCTAssertEqual(snapshot.count, secondSnapshot.count)
+            XCTAssertNotEqual(
+                storageAddress(of: snapshot),
+                storageAddress(of: secondSnapshot),
+                "mutableData should return an independent Data copy instead of sharing the internal COW storage. Attempt: \(attempt)."
+            )
+        }
+    }
+
+    private func storageAddress(of data: Data) -> UInt {
+        data.withUnsafeBytes { buffer in
+            UInt(bitPattern: buffer.baseAddress!)
+        }
+    }
+
     override class func setUp() {
         super.setUp()
         LSNocilla.sharedInstance().start()

--- a/Tests/KingfisherTests/DataReceivingSideEffectTests.swift
+++ b/Tests/KingfisherTests/DataReceivingSideEffectTests.swift
@@ -32,24 +32,22 @@ class DataReceivingSideEffectTests: XCTestCase {
     var manager: KingfisherManager!
 
     func testSessionDataTaskMutableDataGetterDoesNotShareStorage() {
-        for attempt in 0..<100 {
-            let url = URL(string: "https://example.com/image-\(attempt).png")!
-            let urlTask = URLSession(configuration: .ephemeral).dataTask(with: url)
-            let task = SessionDataTask(task: urlTask)
+        let url = URL(string: "https://example.com/image.png")!
+        let urlTask = URLSession(configuration: .ephemeral).dataTask(with: url)
+        let task = SessionDataTask(task: urlTask)
 
-            // Use a large buffer to avoid inline Data storage, making COW storage sharing observable.
-            task.didReceiveData(Data(repeating: 0x11, count: 1024 * 1024))
+        // Use a large buffer to avoid inline Data storage, making COW storage sharing observable.
+        task.didReceiveData(Data(repeating: 0x11, count: 1024 * 1024))
 
-            let snapshot = task.mutableData
-            let secondSnapshot = task.mutableData
+        let snapshot = task.mutableData
+        let secondSnapshot = task.mutableData
 
-            XCTAssertEqual(snapshot.count, secondSnapshot.count)
-            XCTAssertNotEqual(
-                storageAddress(of: snapshot),
-                storageAddress(of: secondSnapshot),
-                "mutableData should return an independent Data copy instead of sharing the internal COW storage. Attempt: \(attempt)."
-            )
-        }
+        XCTAssertEqual(snapshot.count, secondSnapshot.count)
+        XCTAssertNotEqual(
+            storageAddress(of: snapshot),
+            storageAddress(of: secondSnapshot),
+            "mutableData should return an independent Data copy instead of sharing the internal COW storage."
+        )
     }
 
     private func storageAddress(of data: Data) -> UInt {


### PR DESCRIPTION
## Summary

- make `SessionDataTask.mutableData` return an independent `Data` snapshot instead of sharing internal COW storage
- add `mutableDataCount` for progress reporting so progress callbacks do not copy the full buffer on every chunk
- add a regression test that verifies repeated `mutableData` snapshots do not share storage

Fixes #2523.

## Tests

- `xcodebuild test -project Kingfisher.xcodeproj -scheme Kingfisher -destination 'platform=macOS,arch=arm64' -only-testing:KingfisherTests/DataReceivingSideEffectTests/testSessionDataTaskMutableDataGetterDoesNotShareStorage`
- `xcodebuild test -project Kingfisher.xcodeproj -scheme Kingfisher -destination 'platform=macOS,arch=arm64' -only-testing:KingfisherTests/DataReceivingSideEffectTests -only-testing:KingfisherTests/KingfisherOptionsInfoTests -quiet`
- `xcodebuild test -project Kingfisher.xcodeproj -scheme Kingfisher -destination 'platform=macOS,arch=arm64' -quiet`
