### PR TITLE
Use GitHub-hosted macOS CI runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,81 +18,145 @@ concurrency:
 jobs:
   build-framework:
     name: build (Xcode ${{ matrix.xcode }}, ${{ matrix.label }})
-    runs-on: self-hosted
+    runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - xcode: '16.2'
-            destination: 'macOS'
+            runner: macos-15
+            destination: 'platform=macOS'
             label: 'macOS'
+            cache-key: xcode-16.2-macos
           - xcode: '16.2'
-            destination: 'iOS Simulator,name=iPhone 16,OS=18.2'
-            label: 'iOS 18.2'
+            runner: macos-15
+            destination: 'generic/platform=iOS Simulator'
+            label: 'iOS Simulator'
+            cache-key: xcode-16.2-ios
           - xcode: '16.2'
-            destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.2'
-            label: 'tvOS 18.2'
+            runner: macos-15
+            destination: 'generic/platform=tvOS Simulator'
+            label: 'tvOS Simulator'
+            cache-key: xcode-16.2-tvos
           - xcode: '16.2'
-            destination: 'watchOS Simulator,name=Apple Watch Series 10 (42mm),OS=11.2'
-            label: 'watchOS 11.2'
+            runner: macos-15
+            destination: 'generic/platform=watchOS Simulator'
+            label: 'watchOS Simulator'
+            cache-key: xcode-16.2-watchos
 
           - xcode: '16.3'
-            destination: 'macOS'
+            runner: macos-15
+            destination: 'platform=macOS'
             label: 'macOS'
+            cache-key: xcode-16.3-macos
           - xcode: '16.3'
-            destination: 'iOS Simulator,name=iPhone 16,OS=18.4'
-            label: 'iOS 18.4'
+            runner: macos-15
+            destination: 'generic/platform=iOS Simulator'
+            label: 'iOS Simulator'
+            cache-key: xcode-16.3-ios
           - xcode: '16.3'
-            destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.4'
-            label: 'tvOS 18.4'
+            runner: macos-15
+            destination: 'generic/platform=tvOS Simulator'
+            label: 'tvOS Simulator'
+            cache-key: xcode-16.3-tvos
           - xcode: '16.3'
-            destination: 'watchOS Simulator,name=Apple Watch Series 10 (42mm),OS=11.4'
-            label: 'watchOS 11.4'
+            runner: macos-15
+            destination: 'generic/platform=watchOS Simulator'
+            label: 'watchOS Simulator'
+            cache-key: xcode-16.3-watchos
 
           - xcode: '26.0.1'
-            destination: 'macOS'
+            runner: macos-26
+            destination: 'platform=macOS'
             label: 'macOS'
+            cache-key: xcode-26.0.1-macos
           - xcode: '26.0.1'
-            destination: 'iOS Simulator,name=iPhone 17,OS=26.0.1'
-            label: 'iOS 26.0.1'
+            runner: macos-26
+            destination: 'generic/platform=iOS Simulator'
+            label: 'iOS Simulator'
+            cache-key: xcode-26.0.1-ios
           - xcode: '26.0.1'
-            destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.0'
-            label: 'tvOS 26.0'
+            runner: macos-26
+            destination: 'generic/platform=tvOS Simulator'
+            label: 'tvOS Simulator'
+            cache-key: xcode-26.0.1-tvos
           - xcode: '26.0.1'
-            destination: 'watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.0'
-            label: 'watchOS 26.0'
-
-          - xcode: '26.3'
-            destination: 'macOS'
-            label: 'macOS'
-          - xcode: '26.3'
-            destination: 'iOS Simulator,name=iPhone 17,OS=26.2'
-            label: 'iOS 26.2'
-          - xcode: '26.3'
-            destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.2'
-            label: 'tvOS 26.2'
-          - xcode: '26.3'
-            destination: 'watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.2'
-            label: 'watchOS 26.2'
+            runner: macos-26
+            destination: 'generic/platform=watchOS Simulator'
+            label: 'watchOS Simulator'
+            cache-key: xcode-26.0.1-watchos
 
           - xcode: '26.2'
-            destination: 'macOS'
+            runner: macos-26
+            destination: 'platform=macOS'
             label: 'macOS'
+            cache-key: xcode-26.2-macos
           - xcode: '26.2'
-            destination: 'iOS Simulator,name=iPhone 17,OS=26.2'
-            label: 'iOS 26.2'
+            runner: macos-26
+            destination: 'generic/platform=iOS Simulator'
+            label: 'iOS Simulator'
+            cache-key: xcode-26.2-ios
           - xcode: '26.2'
-            destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.2'
-            label: 'tvOS 26.2'
+            runner: macos-26
+            destination: 'generic/platform=tvOS Simulator'
+            label: 'tvOS Simulator'
+            cache-key: xcode-26.2-tvos
           - xcode: '26.2'
-            destination: 'watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.2'
-            label: 'watchOS 26.2'
+            runner: macos-26
+            destination: 'generic/platform=watchOS Simulator'
+            label: 'watchOS Simulator'
+            cache-key: xcode-26.2-watchos
+
+          - xcode: '26.3'
+            runner: macos-26
+            destination: 'platform=macOS'
+            label: 'macOS'
+            cache-key: xcode-26.3-macos
+          - xcode: '26.3'
+            runner: macos-26
+            destination: 'generic/platform=iOS Simulator'
+            label: 'iOS Simulator'
+            cache-key: xcode-26.3-ios
+          - xcode: '26.3'
+            runner: macos-26
+            destination: 'generic/platform=tvOS Simulator'
+            label: 'tvOS Simulator'
+            cache-key: xcode-26.3-tvos
+          - xcode: '26.3'
+            runner: macos-26
+            destination: 'generic/platform=watchOS Simulator'
+            label: 'watchOS Simulator'
+            cache-key: xcode-26.3-watchos
     steps:
       - uses: actions/checkout@v4
-      - name: Install Gems
-        run: bundle install
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.swiftpm
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-spm-${{ hashFiles('Package.swift', 'Package@swift-5.9.swift', 'Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-spm-
+      - name: Cache Xcode build support
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/DerivedData/${{ matrix.cache-key }}/ModuleCache.noindex
+            build/DerivedData/${{ matrix.cache-key }}/SDKStatCaches.noindex
+            build/DerivedData/${{ matrix.cache-key }}/SourcePackages
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-${{ matrix.cache-key }}-xcode-${{ hashFiles('Gemfile.lock', 'Package.swift', 'Package@swift-5.9.swift', 'Kingfisher.xcodeproj/project.pbxproj') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-${{ matrix.cache-key }}-xcode-
       - name: Build framework
         env:
-          DESTINATION: platform=${{ matrix.destination }}
+          DESTINATION: ${{ matrix.destination }}
+          DERIVED_DATA_PATH: build/DerivedData/${{ matrix.cache-key }}
           XCODE_VERSION: ${{ matrix.xcode }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '60'
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: '4'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: build
 
 defaults:
   run:
-    shell: bash -leo pipefail {0}
+    shell: bash -eo pipefail {0}
 
 on:
   push:
@@ -128,31 +128,12 @@ jobs:
             label: 'watchOS Simulator'
             cache-key: xcode-26.3-watchos
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-      - name: Cache SwiftPM
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.swiftpm
-            ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-spm-${{ hashFiles('Package.swift', 'Package@swift-5.9.swift', 'Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-spm-
-      - name: Cache Xcode build support
-        uses: actions/cache@v4
-        with:
-          path: |
-            build/DerivedData/${{ matrix.cache-key }}/ModuleCache.noindex
-            build/DerivedData/${{ matrix.cache-key }}/SDKStatCaches.noindex
-            build/DerivedData/${{ matrix.cache-key }}/SourcePackages
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-${{ matrix.cache-key }}-xcode-${{ hashFiles('Gemfile.lock', 'Package.swift', 'Package@swift-5.9.swift', 'Kingfisher.xcodeproj/project.pbxproj') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-${{ matrix.cache-key }}-xcode-
       - name: Build framework
         env:
           DESTINATION: ${{ matrix.destination }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,17 +30,17 @@ jobs:
             cache-key: xcode-16.2-macos
           - xcode: '16.2'
             runner: macos-15
-            destination: 'generic/platform=iOS Simulator'
+            sdk: iphonesimulator
             label: 'iOS Simulator'
             cache-key: xcode-16.2-ios
           - xcode: '16.2'
             runner: macos-15
-            destination: 'generic/platform=tvOS Simulator'
+            sdk: appletvsimulator
             label: 'tvOS Simulator'
             cache-key: xcode-16.2-tvos
           - xcode: '16.2'
             runner: macos-15
-            destination: 'generic/platform=watchOS Simulator'
+            sdk: watchsimulator
             label: 'watchOS Simulator'
             cache-key: xcode-16.2-watchos
 
@@ -51,17 +51,17 @@ jobs:
             cache-key: xcode-16.3-macos
           - xcode: '16.3'
             runner: macos-15
-            destination: 'generic/platform=iOS Simulator'
+            sdk: iphonesimulator
             label: 'iOS Simulator'
             cache-key: xcode-16.3-ios
           - xcode: '16.3'
             runner: macos-15
-            destination: 'generic/platform=tvOS Simulator'
+            sdk: appletvsimulator
             label: 'tvOS Simulator'
             cache-key: xcode-16.3-tvos
           - xcode: '16.3'
             runner: macos-15
-            destination: 'generic/platform=watchOS Simulator'
+            sdk: watchsimulator
             label: 'watchOS Simulator'
             cache-key: xcode-16.3-watchos
 
@@ -72,17 +72,17 @@ jobs:
             cache-key: xcode-26.0.1-macos
           - xcode: '26.0.1'
             runner: macos-26
-            destination: 'generic/platform=iOS Simulator'
+            sdk: iphonesimulator
             label: 'iOS Simulator'
             cache-key: xcode-26.0.1-ios
           - xcode: '26.0.1'
             runner: macos-26
-            destination: 'generic/platform=tvOS Simulator'
+            sdk: appletvsimulator
             label: 'tvOS Simulator'
             cache-key: xcode-26.0.1-tvos
           - xcode: '26.0.1'
             runner: macos-26
-            destination: 'generic/platform=watchOS Simulator'
+            sdk: watchsimulator
             label: 'watchOS Simulator'
             cache-key: xcode-26.0.1-watchos
 
@@ -93,17 +93,17 @@ jobs:
             cache-key: xcode-26.2-macos
           - xcode: '26.2'
             runner: macos-26
-            destination: 'generic/platform=iOS Simulator'
+            sdk: iphonesimulator
             label: 'iOS Simulator'
             cache-key: xcode-26.2-ios
           - xcode: '26.2'
             runner: macos-26
-            destination: 'generic/platform=tvOS Simulator'
+            sdk: appletvsimulator
             label: 'tvOS Simulator'
             cache-key: xcode-26.2-tvos
           - xcode: '26.2'
             runner: macos-26
-            destination: 'generic/platform=watchOS Simulator'
+            sdk: watchsimulator
             label: 'watchOS Simulator'
             cache-key: xcode-26.2-watchos
 
@@ -114,17 +114,17 @@ jobs:
             cache-key: xcode-26.3-macos
           - xcode: '26.3'
             runner: macos-26
-            destination: 'generic/platform=iOS Simulator'
+            sdk: iphonesimulator
             label: 'iOS Simulator'
             cache-key: xcode-26.3-ios
           - xcode: '26.3'
             runner: macos-26
-            destination: 'generic/platform=tvOS Simulator'
+            sdk: appletvsimulator
             label: 'tvOS Simulator'
             cache-key: xcode-26.3-tvos
           - xcode: '26.3'
             runner: macos-26
-            destination: 'generic/platform=watchOS Simulator'
+            sdk: watchsimulator
             label: 'watchOS Simulator'
             cache-key: xcode-26.3-watchos
     steps:
@@ -137,6 +137,7 @@ jobs:
       - name: Build framework
         env:
           DESTINATION: ${{ matrix.destination }}
+          SDK: ${{ matrix.sdk }}
           DERIVED_DATA_PATH: build/DerivedData/${{ matrix.cache-key }}
           XCODE_VERSION: ${{ matrix.xcode }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '60'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
             cache-key: xcode-16.4-tvos
           - xcode: '16.4'
             runner: macos-15
-            destination: 'platform=watchOS Simulator,name=Apple Watch Series 10 (42mm),OS=11.5'
+            sdk: watchsimulator
             label: 'watchOS 11.5'
             cache-key: xcode-16.4-watchos
 
@@ -61,7 +61,7 @@ jobs:
             cache-key: xcode-26.4.1-tvos
           - xcode: '26.4.1'
             runner: macos-26
-            destination: 'platform=watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.4'
+            sdk: watchsimulator
             label: 'watchOS 26.4'
             cache-key: xcode-26.4.1-watchos
     steps:
@@ -74,6 +74,7 @@ jobs:
       - name: Run tests
         env:
           DESTINATION: ${{ matrix.destination }}
+          SDK: ${{ matrix.sdk }}
           DERIVED_DATA_PATH: build/DerivedData/${{ matrix.cache-key }}
           XCODE_VERSION: ${{ matrix.xcode }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '60'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: test
 
 defaults:
   run:
-    shell: bash -leo pipefail {0}
+    shell: bash -eo pipefail {0}
 
 on:
   push:
@@ -65,31 +65,12 @@ jobs:
             label: 'watchOS 26.4'
             cache-key: xcode-26.4.1-watchos
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-      - name: Cache SwiftPM
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.swiftpm
-            ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-spm-${{ hashFiles('Package.swift', 'Package@swift-5.9.swift', 'Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-spm-
-      - name: Cache Xcode build support
-        uses: actions/cache@v4
-        with:
-          path: |
-            build/DerivedData/${{ matrix.cache-key }}/ModuleCache.noindex
-            build/DerivedData/${{ matrix.cache-key }}/SDKStatCaches.noindex
-            build/DerivedData/${{ matrix.cache-key }}/SourcePackages
-          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-${{ matrix.cache-key }}-xcode-${{ hashFiles('Gemfile.lock', 'Package.swift', 'Package@swift-5.9.swift', 'Kingfisher.xcodeproj/project.pbxproj') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-${{ matrix.cache-key }}-xcode-
       - name: Run tests
         env:
           DESTINATION: ${{ matrix.destination }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,8 +51,8 @@ jobs:
             cache-key: xcode-26.4.1-macos
           - xcode: '26.4.1'
             runner: macos-26
-            destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.4'
-            label: 'iOS 26.4'
+            destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1'
+            label: 'iOS 26.4.1'
             cache-key: xcode-26.4.1-ios
           - xcode: '26.4.1'
             runner: macos-26

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,42 +18,82 @@ concurrency:
 jobs:
   run-tests:
     name: test (Xcode ${{ matrix.xcode }}, ${{ matrix.label }})
-    runs-on: self-hosted
+    runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - xcode: '16.4'
-            destination: 'macOS'
+            runner: macos-15
+            destination: 'platform=macOS'
             label: 'macOS'
+            cache-key: xcode-16.4-macos
           - xcode: '16.4'
-            destination: 'iOS Simulator,name=iPhone 16,OS=18.5'
+            runner: macos-15
+            destination: 'platform=iOS Simulator,name=iPhone 16,OS=18.5'
             label: 'iOS 18.5'
+            cache-key: xcode-16.4-ios
           - xcode: '16.4'
-            destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5'
+            runner: macos-15
+            destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5'
             label: 'tvOS 18.5'
+            cache-key: xcode-16.4-tvos
           - xcode: '16.4'
-            destination: 'watchOS Simulator,name=Apple Watch Series 10 (42mm),OS=11.5'
+            runner: macos-15
+            destination: 'platform=watchOS Simulator,name=Apple Watch Series 10 (42mm),OS=11.5'
             label: 'watchOS 11.5'
+            cache-key: xcode-16.4-watchos
 
-          - xcode: '26.4'
-            destination: 'macOS'
+          - xcode: '26.4.1'
+            runner: macos-26
+            destination: 'platform=macOS'
             label: 'macOS'
-          - xcode: '26.4'
-            destination: 'iOS Simulator,name=iPhone 17,OS=26.4'
+            cache-key: xcode-26.4.1-macos
+          - xcode: '26.4.1'
+            runner: macos-26
+            destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.4'
             label: 'iOS 26.4'
-          - xcode: '26.4'
-            destination: 'tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.4'
+            cache-key: xcode-26.4.1-ios
+          - xcode: '26.4.1'
+            runner: macos-26
+            destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.4'
             label: 'tvOS 26.4'
-          - xcode: '26.4'
-            destination: 'watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.4'
+            cache-key: xcode-26.4.1-tvos
+          - xcode: '26.4.1'
+            runner: macos-26
+            destination: 'platform=watchOS Simulator,name=Apple Watch Series 11 (42mm),OS=26.4'
             label: 'watchOS 26.4'
+            cache-key: xcode-26.4.1-watchos
     steps:
       - uses: actions/checkout@v4
-      - name: Install Gems
-        run: bundle install
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.swiftpm
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-spm-${{ hashFiles('Package.swift', 'Package@swift-5.9.swift', 'Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-spm-
+      - name: Cache Xcode build support
+        uses: actions/cache@v4
+        with:
+          path: |
+            build/DerivedData/${{ matrix.cache-key }}/ModuleCache.noindex
+            build/DerivedData/${{ matrix.cache-key }}/SDKStatCaches.noindex
+            build/DerivedData/${{ matrix.cache-key }}/SourcePackages
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-${{ matrix.cache-key }}-xcode-${{ hashFiles('Gemfile.lock', 'Package.swift', 'Package@swift-5.9.swift', 'Kingfisher.xcodeproj/project.pbxproj') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner }}-${{ matrix.cache-key }}-xcode-
       - name: Run tests
         env:
-          DESTINATION: platform=${{ matrix.destination }}
+          DESTINATION: ${{ matrix.destination }}
+          DERIVED_DATA_PATH: build/DerivedData/${{ matrix.cache-key }}
           XCODE_VERSION: ${{ matrix.xcode }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: '60'
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: '4'

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -219,7 +219,7 @@ class ImageDownloaderTests: XCTestCase {
             }
         }
         
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
     
     func testDownloadEmptyURL() {

--- a/Tests/KingfisherTests/RetryStrategyTests.swift
+++ b/Tests/KingfisherTests/RetryStrategyTests.swift
@@ -307,7 +307,7 @@ class RetryStrategyTests: XCTestCase {
             exp.fulfill()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 3, handler: nil)
     }
 
     func testNetworkRetryStrategyStopsForTaskCancelled() {
@@ -333,7 +333,7 @@ class RetryStrategyTests: XCTestCase {
             exp.fulfill()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 3, handler: nil)
     }
 
     func testNetworkRetryStrategyStopsForNonResponseError() {
@@ -358,7 +358,7 @@ class RetryStrategyTests: XCTestCase {
             exp.fulfill()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 3, handler: nil)
     }
 
     func testNetworkRetryStrategyWithTimeout() {
@@ -381,7 +381,7 @@ class RetryStrategyTests: XCTestCase {
             exp.fulfill()
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 3, handler: nil)
     }
 
     func testNetworkRetryStrategyWaitsForReconnection() {
@@ -413,7 +413,7 @@ class RetryStrategyTests: XCTestCase {
             networkMonitor.simulateNetworkChange(isConnected: true)
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 3, handler: nil)
     }
 
     func testNetworkRetryStrategyCancelsPreviousObserver() {
@@ -451,7 +451,7 @@ class RetryStrategyTests: XCTestCase {
             networkMonitor.simulateNetworkChange(isConnected: true)
         }
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 3, handler: nil)
     }
 }
 

--- a/Tests/KingfisherTests/RetryStrategyTests.swift
+++ b/Tests/KingfisherTests/RetryStrategyTests.swift
@@ -99,7 +99,7 @@ class RetryStrategyTests: XCTestCase {
                 exp.fulfill()
             }
         )
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testImagePrefetcherCanRetry() {
@@ -126,7 +126,7 @@ class RetryStrategyTests: XCTestCase {
             }
         )
         prefetcher.start()
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testImagePrefetcherRetryStrategyStopDoesNotRetry() {
@@ -149,7 +149,7 @@ class RetryStrategyTests: XCTestCase {
         )
 
         prefetcher.start()
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     // MARK: - DelayRetryStrategy Tests
@@ -207,7 +207,7 @@ class RetryStrategyTests: XCTestCase {
                 exp.fulfill()
             }
         }
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testDelayRetryStrategyNotRetryForErrorReason() {
@@ -260,7 +260,7 @@ class RetryStrategyTests: XCTestCase {
                 exp.fulfill()
             }
         }
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testDelayRetryStrategyDidRetried() {
@@ -279,7 +279,7 @@ class RetryStrategyTests: XCTestCase {
             exp.fulfill()
         }
 
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     // MARK: - NetworkRetryStrategy Tests
@@ -307,7 +307,7 @@ class RetryStrategyTests: XCTestCase {
             exp.fulfill()
         }
 
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testNetworkRetryStrategyStopsForTaskCancelled() {
@@ -333,7 +333,7 @@ class RetryStrategyTests: XCTestCase {
             exp.fulfill()
         }
 
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testNetworkRetryStrategyStopsForNonResponseError() {
@@ -358,7 +358,7 @@ class RetryStrategyTests: XCTestCase {
             exp.fulfill()
         }
 
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testNetworkRetryStrategyWithTimeout() {
@@ -381,7 +381,7 @@ class RetryStrategyTests: XCTestCase {
             exp.fulfill()
         }
 
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testNetworkRetryStrategyWaitsForReconnection() {
@@ -413,7 +413,7 @@ class RetryStrategyTests: XCTestCase {
             networkMonitor.simulateNetworkChange(isConnected: true)
         }
 
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 
     func testNetworkRetryStrategyCancelsPreviousObserver() {
@@ -451,7 +451,7 @@ class RetryStrategyTests: XCTestCase {
             networkMonitor.simulateNetworkChange(isConnected: true)
         }
 
-        waitForExpectations(timeout: 3, handler: nil)
+        waitForExpectations(timeout: 10, handler: nil)
     }
 }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,9 @@ platform :ios do
   end
 
   lane :test_ci do
-    if ENV["DESTINATION"].include? "watchOS" then
+    if !ENV["SDK"].to_s.empty?
+        build(sdk: ENV["SDK"])
+    elsif ENV["DESTINATION"].include? "watchOS" then
         build(destination: ENV["DESTINATION"])
     else
         test(destination: ENV["DESTINATION"])

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,7 +29,11 @@ platform :ios do
   end
 
   lane :build_ci do
-    build(destination: ENV["DESTINATION"])
+    if ENV["SDK"].to_s.empty?
+      build(destination: ENV["DESTINATION"])
+    else
+      build(sdk: ENV["SDK"])
+    end
   end
 
   lane :test do |options|
@@ -43,18 +47,25 @@ platform :ios do
   end
 
   lane :build do |options|
-    xcodebuild(
+    build_options = {
       workspace: "Kingfisher.xcworkspace",
       configuration: "Debug",
       scheme: "Kingfisher",
-      destination: options[:destination],
-      derivedDataPath: derived_data_path(options[:destination]),
+      derivedDataPath: derived_data_path(options[:destination] || options[:sdk]),
       clean: true,
       build: true,
       build_settings: {
         "SWIFT_VERSION" => "5.0"
       }
-    )
+    }
+
+    if options[:sdk].to_s.empty?
+      build_options[:destination] = options[:destination]
+    else
+      build_options[:sdk] = options[:sdk]
+    end
+
+    xcodebuild(build_options)
   end
 
   desc "Lint"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,6 +4,8 @@ default_platform :ios
 
 platform :ios do
   def derived_data_path(destination)
+    return File.expand_path(ENV["DERIVED_DATA_PATH"], Dir.pwd) unless ENV["DERIVED_DATA_PATH"].to_s.empty?
+
     run_id = ENV["GITHUB_RUN_ID"] || "local"
     xcode = ENV["XCODE_VERSION"] || "default-xcode"
     destination_key = destination.to_s.gsub(/[^A-Za-z0-9_.-]/, "_")


### PR DESCRIPTION
## Summary

- Move CI jobs from self-hosted runners to GitHub-hosted `macos-15` and `macos-26` runners.
- Bind Xcode 16 jobs to `macos-15` and Xcode 26 jobs to `macos-26`.
- Add Bundler, SwiftPM, and Xcode build-support caches while keeping compiled build products isolated by Xcode and platform.
- Allow CI to pass a stable `DERIVED_DATA_PATH` into Fastlane.

## Notes

Build jobs use generic simulator destinations so compatibility coverage does not depend on every older runtime being installed on GitHub-hosted images. Test jobs keep explicit simulator runtimes for the current Xcode 16.4 and 26.4.1 lanes.

## Validation

- Parsed both workflow YAML files.
- Checked matrix entries and unique cache keys.
- Ran `git diff --check`.
- Ran `bundle exec fastlane build destination:"generic/platform=iOS Simulator"`.
- Ran `bundle exec fastlane build destination:"generic/platform=watchOS Simulator"`.
- Ran `DESTINATION=platform=macOS bundle exec fastlane test_ci`.
