### PR TITLE
Add `MemoryStorage.swift` method `totalCacheCost`

### DIFF
--- a/Sources/Cache/MemoryStorage.swift
+++ b/Sources/Cache/MemoryStorage.swift
@@ -200,6 +200,25 @@ public enum MemoryStorage {
             storage.removeAllObjects()
             keys.removeAll()
         }
+
+        /// Calculates the total `cacheCost` for all currently cached values.
+        ///
+        /// This method can be expensive so should be used sparingly.
+        /// - Returns: The total cost in bytes for valid cached values.
+        public func totalCacheCost() -> Int {
+            let allKeys: [String] = {
+                lock.lock()
+                defer { lock.unlock() }
+                return Array(keys)
+            }()
+            let totalCost: Int = allKeys.reduce(0) { cost, key in
+                if let value = self.value(forKey: key, extendingExpiration: .none) {
+                    return cost + value.cacheCost
+                }
+                return cost
+            }
+            return totalCost
+        }
     }
 }
 

--- a/Sources/Cache/MemoryStorage.swift
+++ b/Sources/Cache/MemoryStorage.swift
@@ -159,14 +159,26 @@ public enum MemoryStorage {
         ///
         /// - Parameters:
         ///   - key: The cache key of the value.
+        ///   - filter: The expiration filter used by this retrieval action. The default value is `.valid`, which gets only non-expired values.
         ///   - extendingExpiration: The expiration policy used by this retrieval action.
         /// - Returns: The value under `key` if it is valid and found in the storage. Otherwise, `nil`.
-        public func value(forKey key: String, extendingExpiration: ExpirationExtending = .cacheTime) -> T? {
+        public func value(forKey key: String,
+                          filter: ExpirationFilter = .valid,
+                          extendingExpiration: ExpirationExtending = .cacheTime) -> T? {
             guard let object = storage.object(forKey: key as NSString) else {
                 return nil
             }
-            if object.isExpired {
-                return nil
+            switch filter {
+            case .valid:
+                if object.isExpired {
+                    return nil
+                }
+            case .expired:
+                if object.isExpired == false {
+                    return nil
+                }
+            case .all:
+                break
             }
             object.extendExpiration(extendingExpiration)
             return object.value
@@ -201,10 +213,10 @@ public enum MemoryStorage {
             keys.removeAll()
         }
 
-        /// Calculates the total `cacheCost` for all currently cached values.
+        /// Calculates the total `cacheCost` for all currently cached values, including any expired items.
         ///
         /// This method can be expensive so should be used sparingly.
-        /// - Returns: The total cost in bytes for valid cached values.
+        /// - Returns: The total cost in bytes for all cached values.
         public func totalCacheCost() -> Int {
             let allKeys: [String] = {
                 lock.lock()
@@ -212,7 +224,7 @@ public enum MemoryStorage {
                 return Array(keys)
             }()
             let totalCost: Int = allKeys.reduce(0) { cost, key in
-                if let value = self.value(forKey: key, extendingExpiration: .none) {
+                if let value = self.value(forKey: key, filter: .all, extendingExpiration: .none) {
                     return cost + value.cacheCost
                 }
                 return cost

--- a/Sources/Cache/Storage.swift
+++ b/Sources/Cache/Storage.swift
@@ -98,6 +98,15 @@ public enum ExpirationExtending: Sendable {
     case expirationTime(_ expiration: StorageExpiration)
 }
 
+public enum ExpirationFilter {
+    /// The item is valid / not expired.
+    case valid
+    /// The item is no longer valid / has expired.
+    case expired
+    /// The item may be valid or invalid.
+    case all
+}
+
 /// Represents types for which the memory cost can be calculated.
 public protocol CacheCostCalculable {
     var cacheCost: Int { get }

--- a/Tests/KingfisherTests/MemoryStorageTests.swift
+++ b/Tests/KingfisherTests/MemoryStorageTests.swift
@@ -232,14 +232,14 @@ class MemoryStorageTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
-    func testTotalCacheCostIgnoresExpiredValues() {
+    func testTotalCacheCostIncludesExpiredValues() {
         let exp = expectation(description: #function)
 
         storage.store(value: 1, forKey: "1", expiration: .seconds(0.1))
         storage.store(value: 2, forKey: "2")
 
         delay(0.2) {
-            XCTAssertEqual(self.storage.totalCacheCost(), 1)
+            XCTAssertEqual(self.storage.totalCacheCost(), 2)
             XCTAssertNotNil(self.storage.storage.object(forKey: "1"))
             exp.fulfill()
         }
@@ -266,6 +266,51 @@ class MemoryStorageTests: XCTestCase {
         
         delay(1) {
             XCTAssertFalse(self.storage.isCached(forKey: "1"))
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testValueFilterValid() {
+        let exp = expectation(description: #function)
+
+        storage.store(value: 1, forKey: "valid", expiration: .never)
+        storage.store(value: 2, forKey: "expired", expiration: .seconds(0.1))
+
+        delay(0.2) {
+            // .valid (default) returns non-expired items only.
+            XCTAssertEqual(self.storage.value(forKey: "valid", filter: .valid, extendingExpiration: .none), 1)
+            XCTAssertNil(self.storage.value(forKey: "expired", filter: .valid, extendingExpiration: .none))
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testValueFilterExpired() {
+        let exp = expectation(description: #function)
+
+        storage.store(value: 1, forKey: "valid", expiration: .never)
+        storage.store(value: 2, forKey: "expired", expiration: .seconds(0.1))
+
+        delay(0.2) {
+            // .expired returns only items that have passed their expiration date.
+            XCTAssertNil(self.storage.value(forKey: "valid", filter: .expired, extendingExpiration: .none))
+            XCTAssertEqual(self.storage.value(forKey: "expired", filter: .expired, extendingExpiration: .none), 2)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testValueFilterAll() {
+        let exp = expectation(description: #function)
+
+        storage.store(value: 1, forKey: "valid", expiration: .never)
+        storage.store(value: 2, forKey: "expired", expiration: .seconds(0.1))
+
+        delay(0.2) {
+            // .all returns items regardless of their expiration state.
+            XCTAssertEqual(self.storage.value(forKey: "valid", filter: .all, extendingExpiration: .none), 1)
+            XCTAssertEqual(self.storage.value(forKey: "expired", filter: .all, extendingExpiration: .none), 2)
             exp.fulfill()
         }
         waitForExpectations(timeout: 3, handler: nil)

--- a/Tests/KingfisherTests/MemoryStorageTests.swift
+++ b/Tests/KingfisherTests/MemoryStorageTests.swift
@@ -103,6 +103,21 @@ class MemoryStorageTests: XCTestCase {
         XCTAssertFalse(storage.isCached(forKey: "2"))
     }
 
+    func testTotalCacheCost() {
+        XCTAssertEqual(storage.totalCacheCost(), 0)
+
+        storage.store(value: 1, forKey: "1")
+        storage.store(value: 2, forKey: "2")
+        storage.store(value: 3, forKey: "3")
+        XCTAssertEqual(storage.totalCacheCost(), 3)
+
+        storage.remove(forKey: "2")
+        XCTAssertEqual(storage.totalCacheCost(), 2)
+
+        storage.removeAll()
+        XCTAssertEqual(storage.totalCacheCost(), 0)
+    }
+
     func testStoreWithExpiration() {
         let exp = expectation(description: #function)
 
@@ -214,6 +229,21 @@ class MemoryStorageTests: XCTestCase {
             XCTAssertNil(self.storage.storage.object(forKey: "1"))
             exp.fulfill()
         }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testTotalCacheCostIgnoresExpiredValues() {
+        let exp = expectation(description: #function)
+
+        storage.store(value: 1, forKey: "1", expiration: .seconds(0.1))
+        storage.store(value: 2, forKey: "2")
+
+        delay(0.2) {
+            XCTAssertEqual(self.storage.totalCacheCost(), 1)
+            XCTAssertNotNil(self.storage.storage.object(forKey: "1"))
+            exp.fulfill()
+        }
+
         waitForExpectations(timeout: 3, handler: nil)
     }
 


### PR DESCRIPTION
## Summary

Added a new function to `MemoryStorage` to get `totalCacheCost`, which adds up the `cacheCost` of all objects, valid and expired, that exist in `MemoryStorage`.

This also provides parity with `DiskStorage`, where it is able to give us the `totalSize` of the cache.

## Problem

When setting `totalCostLimit` on `MemoryStorage`, it feels like a bit of a 'finger in the air' type approach to guessing what an appropriate limit may be. So to give us some tangible data and reference points, being able to determine what our `totalCacheCost` is, can allow us to make better-informed decisions. It's also quite helpful to be able to show the User this information. 

## Solution

`totalCacheCost` adds up the `cacheCost` of all objects that exist in the `MemoryStorage` cache, without triggering `estimatedExpiration` to be extended. 

## Files Changes

- `Sources/Cache/MemoryStorage.swift` - Added the new `totalCacheCost` function here to provide an estimate of our in-memory footprint. 
-  `Sources/Cache/Storage.swift` - Added a new type `ExpirationFilter` to define how to filter object validity. 
- `Tests/KingfisherTests/MemoryStorageTests.swift` - Added two additional tests to support this new `totalCacheCost` function. 

### Note

I'm aware `DiskStorage` uses the name `totalSize` and this function is using the term `totaCacheCost`. This aligns with the naming convention used when applying cache limits. It's also worth being aware that there is a small distinction in that `cacheCost` is an estimated memory size, not an actual size. So they're strictly not the same. 