### PR TITLE
Absorb cancellation token lifecycle into TaskPropertyAccessor

### DIFF
--- a/Sources/Extensions/CPListItem+Kingfisher.swift
+++ b/Sources/Extensions/CPListItem+Kingfisher.swift
@@ -110,7 +110,6 @@ extension KingfisherWrapper where Base: CPListItem {
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
     {
         var mutatingSelf = self
-        let previousToken = mutatingSelf.cancellationToken
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
@@ -137,10 +136,10 @@ extension KingfisherWrapper where Base: CPListItem {
             taskAccessor: TaskPropertyAccessor(
                 setTaskIdentifier: { mutatingSelf.taskIdentifier = $0 },
                 getTaskIdentifier: { mutatingSelf.taskIdentifier },
-                setTask: { mutatingSelf.imageTask = $0 }
+                setTask: { mutatingSelf.imageTask = $0 },
+                getCancellationToken: { mutatingSelf.cancellationToken },
+                setCancellationToken: { mutatingSelf.cancellationToken = $0 }
             ),
-            previousCancellationToken: previousToken,
-            setCancellationToken: { mutatingSelf.cancellationToken = $0 },
             placeholder: placeholder,
             parsedOptions: parsedOptions,
             progressBlock: progressBlock,

--- a/Sources/Extensions/HasImageComponent+Kingfisher.swift
+++ b/Sources/Extensions/HasImageComponent+Kingfisher.swift
@@ -96,6 +96,8 @@ struct TaskPropertyAccessor: Sendable {
     let setTaskIdentifier: @Sendable @MainActor (Source.Identifier.Value?) -> Void
     let getTaskIdentifier: @Sendable @MainActor () -> Source.Identifier.Value?
     let setTask: @Sendable @MainActor (DownloadTask?) -> Void
+    let getCancellationToken: @Sendable @MainActor () -> CancellationToken?
+    let setCancellationToken: @Sendable @MainActor (CancellationToken) -> Void
 }
 
 @MainActor
@@ -361,7 +363,6 @@ extension KingfisherWrapper where Base: KingfisherImageSettable {
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
     ) -> DownloadTask? {
         var mutatingSelf = self
-        let previousToken = mutatingSelf.cancellationToken
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
@@ -375,10 +376,10 @@ extension KingfisherWrapper where Base: KingfisherImageSettable {
                 getTaskIdentifier: { self.taskIdentifier },
                 setTask: { task in
                     mutatingSelf.imageTask = task
-                }
+                },
+                getCancellationToken: { self.cancellationToken },
+                setCancellationToken: { mutatingSelf.cancellationToken = $0 }
             ),
-            previousCancellationToken: previousToken,
-            setCancellationToken: { mutatingSelf.cancellationToken = $0 },
             placeholder: placeholder,
             parsedOptions: parsedOptions,
             progressBlock: progressBlock,
@@ -393,8 +394,6 @@ extension KingfisherWrapper {
         with source: Source?,
         imageAccessor: ImagePropertyAccessor<KFCrossPlatformImage>,
         taskAccessor: TaskPropertyAccessor,
-        previousCancellationToken: CancellationToken? = nil,
-        setCancellationToken: (@MainActor (CancellationToken) -> Void)? = nil,
         placeholder: KFCrossPlatformImage? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
@@ -424,8 +423,8 @@ extension KingfisherWrapper {
         taskAccessor.setTaskIdentifier(issuedIdentifier)
 
         let token = CancellationToken()
-        previousCancellationToken?.cancel()
-        setCancellationToken?(token)
+        taskAccessor.getCancellationToken()?.cancel()
+        taskAccessor.setCancellationToken(token)
 
         if let block = progressBlock {
             options.onDataReceived = (options.onDataReceived ?? []) + [ImageLoadingProgressSideEffect(block)]

--- a/Sources/Extensions/NSButton+Kingfisher.swift
+++ b/Sources/Extensions/NSButton+Kingfisher.swift
@@ -108,7 +108,6 @@ extension KingfisherWrapper where Base: NSButton {
     ) -> DownloadTask?
     {
         var mutatingSelf = self
-        let previousToken = mutatingSelf.imageCancellationToken
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
@@ -119,10 +118,10 @@ extension KingfisherWrapper where Base: NSButton {
                 }),
             taskAccessor: TaskPropertyAccessor(
                 setTaskIdentifier: { mutatingSelf.taskIdentifier = $0 },
-                getTaskIdentifier: { mutatingSelf.taskIdentifier }, 
-                setTask: { mutatingSelf.imageTask = $0 }),
-            previousCancellationToken: previousToken,
-            setCancellationToken: { mutatingSelf.imageCancellationToken = $0 },
+                getTaskIdentifier: { mutatingSelf.taskIdentifier },
+                setTask: { mutatingSelf.imageTask = $0 },
+                getCancellationToken: { mutatingSelf.imageCancellationToken },
+                setCancellationToken: { mutatingSelf.imageCancellationToken = $0 }),
             placeholder: placeholder,
             parsedOptions: parsedOptions,
             progressBlock: progressBlock,
@@ -201,7 +200,6 @@ extension KingfisherWrapper where Base: NSButton {
     ) -> DownloadTask?
     {
         var mutatingSelf = self
-        let previousToken = mutatingSelf.alternateImageCancellationToken
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
@@ -213,10 +211,10 @@ extension KingfisherWrapper where Base: NSButton {
             taskAccessor: TaskPropertyAccessor(
                 setTaskIdentifier: { mutatingSelf.alternateTaskIdentifier = $0 },
                 getTaskIdentifier: { mutatingSelf.alternateTaskIdentifier },
-                setTask: { mutatingSelf.alternateImageTask = $0 }
+                setTask: { mutatingSelf.alternateImageTask = $0 },
+                getCancellationToken: { mutatingSelf.alternateImageCancellationToken },
+                setCancellationToken: { mutatingSelf.alternateImageCancellationToken = $0 }
             ),
-            previousCancellationToken: previousToken,
-            setCancellationToken: { mutatingSelf.alternateImageCancellationToken = $0 },
             placeholder: placeholder,
             parsedOptions: parsedOptions,
             progressBlock: progressBlock,

--- a/Sources/Extensions/UIButton+Kingfisher.swift
+++ b/Sources/Extensions/UIButton+Kingfisher.swift
@@ -115,7 +115,6 @@ extension KingfisherWrapper where Base: UIButton {
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
     {
         var mutatingSelf = self
-        let previousToken = mutatingSelf.imageCancellationToken
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
@@ -125,10 +124,10 @@ extension KingfisherWrapper where Base: UIButton {
             taskAccessor: TaskPropertyAccessor(
                 setTaskIdentifier: { setTaskIdentifier($0, for: state) },
                 getTaskIdentifier: { taskIdentifier(for: state) },
-                setTask: { mutatingSelf.imageTask = $0 }
+                setTask: { mutatingSelf.imageTask = $0 },
+                getCancellationToken: { imageCancellationToken },
+                setCancellationToken: { mutatingSelf.imageCancellationToken = $0 }
             ),
-            previousCancellationToken: previousToken,
-            setCancellationToken: { mutatingSelf.imageCancellationToken = $0 },
             placeholder: placeholder,
             parsedOptions: parsedOptions,
             progressBlock: progressBlock,
@@ -228,7 +227,6 @@ extension KingfisherWrapper where Base: UIButton {
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
     {
         var mutatingSelf = self
-        let previousToken = mutatingSelf.backgroundImageCancellationToken
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
@@ -242,10 +240,10 @@ extension KingfisherWrapper where Base: UIButton {
             taskAccessor: TaskPropertyAccessor(
                 setTaskIdentifier: { setBackgroundTaskIdentifier($0, for: state) },
                 getTaskIdentifier: { backgroundTaskIdentifier(for: state) },
-                setTask: { mutatingSelf.backgroundImageTask = $0 }
+                setTask: { mutatingSelf.backgroundImageTask = $0 },
+                getCancellationToken: { backgroundImageCancellationToken },
+                setCancellationToken: { mutatingSelf.backgroundImageCancellationToken = $0 }
             ),
-            previousCancellationToken: previousToken,
-            setCancellationToken: { mutatingSelf.backgroundImageCancellationToken = $0 },
             placeholder: placeholder,
             parsedOptions: parsedOptions,
             progressBlock: progressBlock,


### PR DESCRIPTION
## What

Fixes #2496.

The shared `setImage` helper received `previousCancellationToken` and `setCancellationToken` as standalone parameters next to `TaskPropertyAccessor`, although they belong to the same task lifecycle concern as `setTaskIdentifier` / `getTaskIdentifier` / `setTask`.

This PR folds them into `TaskPropertyAccessor`:

- `getCancellationToken: @Sendable @MainActor () -> CancellationToken?`
- `setCancellationToken: @Sendable @MainActor (CancellationToken) -> Void`

The helper now cancels the previous token and stores the new one through the accessor. The six call sites (`HasImageComponent`, `UIButton` ×2, `NSButton` ×2, `CPListItem`) are updated accordingly — each site's accessor reads/writes the same property it previously captured.

Per the issue's non-goals, `ImageView+Kingfisher.swift` and `NSTextAttachment+Kingfisher.swift` are untouched: they keep their own inline implementations and never passed tokens to the shared helper.

## Behavior

No public API change, no behavior change. The only theoretical difference: the previous token is now read at cancellation time instead of being captured at the start of the call — equivalent on all paths, since the code in between is synchronous on the `MainActor`.

## Tests

Full suite run before and after, same results:

| Destination | Before (master) | After |
|---|---|---|
| macOS | 323 passed, 0 failed | 323 passed, 0 failed |
| iOS Simulator (iPhone 17) | 342 passed, 0 failed | 342 passed, 0 failed |

Stale cache tests included, per the acceptance criteria. Diff: 4 files, +23/−29.