### PR TITLE
Add `MemoryStorage.totalCacheCost()` for in-memory cost reporting

### DIFF
--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -1142,7 +1142,20 @@ open class ImageCache: @unchecked Sendable {
             }
         }
     }
-    
+
+    /// The total estimated memory cost currently held by the memory storage, in bytes.
+    ///
+    /// It sums the ``CacheCostCalculable/cacheCost`` of all values resident in ``ImageCache/memoryStorage``,
+    /// including expired-but-not-yet-evicted ones, which approximates the cost managed against
+    /// ``MemoryStorage/Config/totalCostLimit``. This is the in-memory counterpart of ``ImageCache/diskStorageSize``.
+    ///
+    /// Unlike the disk size, this value is computed synchronously. It iterates over every cached item, so it can be
+    /// expensive and should be used sparingly. Since `cacheCost` is an estimated memory size rather than an exact byte
+    /// count, this value is not directly comparable to ``ImageCache/diskStorageSize``.
+    open var memoryStorageCacheCost: Int {
+        memoryStorage.totalCacheCost()
+    }
+
     /// Retrieves the cache path for the key.
     ///
     /// It is useful for projects with a web view or for anyone who needs access to the local file path.

--- a/Sources/Cache/MemoryStorage.swift
+++ b/Sources/Cache/MemoryStorage.swift
@@ -159,26 +159,14 @@ public enum MemoryStorage {
         ///
         /// - Parameters:
         ///   - key: The cache key of the value.
-        ///   - filter: The expiration filter used by this retrieval action. The default value is `.valid`, which gets only non-expired values.
         ///   - extendingExpiration: The expiration policy used by this retrieval action.
         /// - Returns: The value under `key` if it is valid and found in the storage. Otherwise, `nil`.
-        public func value(forKey key: String,
-                          filter: ExpirationFilter = .valid,
-                          extendingExpiration: ExpirationExtending = .cacheTime) -> T? {
+        public func value(forKey key: String, extendingExpiration: ExpirationExtending = .cacheTime) -> T? {
             guard let object = storage.object(forKey: key as NSString) else {
                 return nil
             }
-            switch filter {
-            case .valid:
-                if object.isExpired {
-                    return nil
-                }
-            case .expired:
-                if object.isExpired == false {
-                    return nil
-                }
-            case .all:
-                break
+            if object.isExpired {
+                return nil
             }
             object.extendExpiration(extendingExpiration)
             return object.value
@@ -213,23 +201,27 @@ public enum MemoryStorage {
             keys.removeAll()
         }
 
-        /// Calculates the total `cacheCost` for all currently cached values, including any expired items.
+        /// Calculates the total ``CacheCostCalculable/cacheCost`` of all resident values, including
+        /// expired-but-not-yet-evicted ones.
         ///
-        /// This method can be expensive so should be used sparingly.
-        /// - Returns: The total cost in bytes for all cached values.
+        /// The result approximates the cost currently managed by the underlying cache against
+        /// ``MemoryStorage/Config/totalCostLimit``. Values already evicted by the system are not counted, since
+        /// they no longer occupy memory. Reading a value here does not extend its expiration.
+        ///
+        /// This method iterates over every cached item, so it can be expensive and should be used sparingly.
+        /// - Returns: The total cost in bytes for all resident cached values.
         public func totalCacheCost() -> Int {
             let allKeys: [String] = {
                 lock.lock()
                 defer { lock.unlock() }
                 return Array(keys)
             }()
-            let totalCost: Int = allKeys.reduce(0) { cost, key in
-                if let value = self.value(forKey: key, filter: .all, extendingExpiration: .none) {
-                    return cost + value.cacheCost
+            return allKeys.reduce(0) { cost, key in
+                guard let value = storage.object(forKey: key as NSString)?.value else {
+                    return cost
                 }
-                return cost
+                return cost + value.cacheCost
             }
-            return totalCost
         }
     }
 }

--- a/Sources/Cache/MemoryStorage.swift
+++ b/Sources/Cache/MemoryStorage.swift
@@ -200,6 +200,25 @@ public enum MemoryStorage {
             storage.removeAllObjects()
             keys.removeAll()
         }
+
+        /// Calculates the total `cacheCost` for all currently cached values.
+        ///
+        /// This method can be expensive so should be used sparingly.
+        /// - Returns: The total cost in bytes for valid cached values.
+        public func totalCacheCost() -> Int {
+            let allKeys: [String] = {
+                lock.lock()
+                defer { lock.unlock() }
+                return Array(keys)
+            }()
+            let totalCost: Int = allKeys.reduce(0) { cost, key in
+                if let value = self.value(forKey: key, extendingExpiration: .none) {
+                    return cost + value.cacheCost
+                }
+                return cost
+            }
+            return totalCost
+        }
     }
 }
 

--- a/Sources/Cache/MemoryStorage.swift
+++ b/Sources/Cache/MemoryStorage.swift
@@ -159,14 +159,26 @@ public enum MemoryStorage {
         ///
         /// - Parameters:
         ///   - key: The cache key of the value.
+        ///   - filter: The expiration filter used by this retrieval action. The default value is `.valid`, which gets only non-expired values.
         ///   - extendingExpiration: The expiration policy used by this retrieval action.
         /// - Returns: The value under `key` if it is valid and found in the storage. Otherwise, `nil`.
-        public func value(forKey key: String, extendingExpiration: ExpirationExtending = .cacheTime) -> T? {
+        public func value(forKey key: String,
+                          filter: ExpirationFilter = .valid,
+                          extendingExpiration: ExpirationExtending = .cacheTime) -> T? {
             guard let object = storage.object(forKey: key as NSString) else {
                 return nil
             }
-            if object.isExpired {
-                return nil
+            switch filter {
+            case .valid:
+                if object.isExpired {
+                    return nil
+                }
+            case .expired:
+                if object.isExpired == false {
+                    return nil
+                }
+            case .all:
+                break
             }
             object.extendExpiration(extendingExpiration)
             return object.value
@@ -201,10 +213,10 @@ public enum MemoryStorage {
             keys.removeAll()
         }
 
-        /// Calculates the total `cacheCost` for all currently cached values.
+        /// Calculates the total `cacheCost` for all currently cached values, including any expired items.
         ///
         /// This method can be expensive so should be used sparingly.
-        /// - Returns: The total cost in bytes for valid cached values.
+        /// - Returns: The total cost in bytes for all cached values.
         public func totalCacheCost() -> Int {
             let allKeys: [String] = {
                 lock.lock()
@@ -212,7 +224,7 @@ public enum MemoryStorage {
                 return Array(keys)
             }()
             let totalCost: Int = allKeys.reduce(0) { cost, key in
-                if let value = self.value(forKey: key, extendingExpiration: .none) {
+                if let value = self.value(forKey: key, filter: .all, extendingExpiration: .none) {
                     return cost + value.cacheCost
                 }
                 return cost

--- a/Sources/Cache/Storage.swift
+++ b/Sources/Cache/Storage.swift
@@ -98,6 +98,15 @@ public enum ExpirationExtending: Sendable {
     case expirationTime(_ expiration: StorageExpiration)
 }
 
+public enum ExpirationFilter {
+    /// The item is valid / not expired.
+    case valid
+    /// The item is no longer valid / has expired.
+    case expired
+    /// The item may be valid or invalid.
+    case all
+}
+
 /// Represents types for which the memory cost can be calculated.
 public protocol CacheCostCalculable {
     var cacheCost: Int { get }

--- a/Sources/Cache/Storage.swift
+++ b/Sources/Cache/Storage.swift
@@ -98,15 +98,6 @@ public enum ExpirationExtending: Sendable {
     case expirationTime(_ expiration: StorageExpiration)
 }
 
-public enum ExpirationFilter {
-    /// The item is valid / not expired.
-    case valid
-    /// The item is no longer valid / has expired.
-    case expired
-    /// The item may be valid or invalid.
-    case all
-}
-
 /// Represents types for which the memory cost can be calculated.
 public protocol CacheCostCalculable {
     var cacheCost: Int { get }

--- a/Tests/KingfisherTests/ImageCacheTests.swift
+++ b/Tests/KingfisherTests/ImageCacheTests.swift
@@ -202,6 +202,19 @@ class ImageCacheTests: XCTestCase {
         XCTAssertEqual(result.cacheType, .memory)
     }
 
+    func testMemoryStorageCacheCost() async throws {
+        XCTAssertEqual(cache.memoryStorageCacheCost, 0)
+
+        try await cache.store(testImage, forKey: testKeys[0], toDisk: false)
+        XCTAssertEqual(cache.memoryStorageCacheCost, testImage.kf.cost)
+
+        try await cache.store(testImage, forKey: testKeys[1], toDisk: false)
+        XCTAssertEqual(cache.memoryStorageCacheCost, testImage.kf.cost * 2)
+
+        cache.clearMemoryCache()
+        XCTAssertEqual(cache.memoryStorageCacheCost, 0)
+    }
+
     func testStoreGIFToDiskWithNilOriginalShouldPreserveGIFFormat() {
         struct TestProcessor: ImageProcessor {
             let identifier: String = "com.onevcat.KingfisherTests.TestProcessor"

--- a/Tests/KingfisherTests/MemoryStorageTests.swift
+++ b/Tests/KingfisherTests/MemoryStorageTests.swift
@@ -232,14 +232,14 @@ class MemoryStorageTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
-    func testTotalCacheCostIgnoresExpiredValues() {
+    func testTotalCacheCostIncludesExpiredValues() {
         let exp = expectation(description: #function)
 
         storage.store(value: 1, forKey: "1", expiration: .seconds(0.1))
         storage.store(value: 2, forKey: "2")
 
         delay(0.2) {
-            XCTAssertEqual(self.storage.totalCacheCost(), 1)
+            XCTAssertEqual(self.storage.totalCacheCost(), 2)
             XCTAssertNotNil(self.storage.storage.object(forKey: "1"))
             exp.fulfill()
         }
@@ -266,6 +266,51 @@ class MemoryStorageTests: XCTestCase {
         
         delay(1) {
             XCTAssertFalse(self.storage.isCached(forKey: "1"))
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testValueFilterValid() {
+        let exp = expectation(description: #function)
+
+        storage.store(value: 1, forKey: "valid", expiration: .never)
+        storage.store(value: 2, forKey: "expired", expiration: .seconds(0.1))
+
+        delay(0.2) {
+            // .valid (default) returns non-expired items only.
+            XCTAssertEqual(self.storage.value(forKey: "valid", filter: .valid, extendingExpiration: .none), 1)
+            XCTAssertNil(self.storage.value(forKey: "expired", filter: .valid, extendingExpiration: .none))
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testValueFilterExpired() {
+        let exp = expectation(description: #function)
+
+        storage.store(value: 1, forKey: "valid", expiration: .never)
+        storage.store(value: 2, forKey: "expired", expiration: .seconds(0.1))
+
+        delay(0.2) {
+            // .expired returns only items that have passed their expiration date.
+            XCTAssertNil(self.storage.value(forKey: "valid", filter: .expired, extendingExpiration: .none))
+            XCTAssertEqual(self.storage.value(forKey: "expired", filter: .expired, extendingExpiration: .none), 2)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testValueFilterAll() {
+        let exp = expectation(description: #function)
+
+        storage.store(value: 1, forKey: "valid", expiration: .never)
+        storage.store(value: 2, forKey: "expired", expiration: .seconds(0.1))
+
+        delay(0.2) {
+            // .all returns items regardless of their expiration state.
+            XCTAssertEqual(self.storage.value(forKey: "valid", filter: .all, extendingExpiration: .none), 1)
+            XCTAssertEqual(self.storage.value(forKey: "expired", filter: .all, extendingExpiration: .none), 2)
             exp.fulfill()
         }
         waitForExpectations(timeout: 3, handler: nil)

--- a/Tests/KingfisherTests/MemoryStorageTests.swift
+++ b/Tests/KingfisherTests/MemoryStorageTests.swift
@@ -272,16 +272,15 @@ class MemoryStorageTests: XCTestCase {
     }
 
     func testTotalCacheCostExcludesEvictedValues() {
-        let config = MemoryStorage.Config(totalCostLimit: 2, cleanInterval: 60)
-        let storage = MemoryStorage.Backend<Int>(config: config)
-
-        // Storing three items with a `totalCostLimit` of 2 forces the system to evict at least one of them.
         storage.store(value: 1, forKey: "1")
-        storage.store(value: 1, forKey: "2")
-        storage.store(value: 1, forKey: "3")
+        storage.store(value: 2, forKey: "2")
+        XCTAssertEqual(storage.totalCacheCost(), 2)
 
-        // Evicted items no longer occupy memory, so they must not be counted toward the total cost.
-        XCTAssertLessThanOrEqual(storage.totalCacheCost(), 2)
+        // Simulate a system eviction: `NSCache` may drop an object on its own (its cost/count limits are
+        // advisory), and the tracking `keys` set is not updated until the next `removeExpired()` runs. An evicted
+        // object no longer occupies memory, so its still-present key must contribute nothing to the total.
+        storage.storage.removeObject(forKey: "1")
+        XCTAssertEqual(storage.totalCacheCost(), 1)
     }
 
     func testAutoCleanExpiredMemory() {

--- a/Tests/KingfisherTests/MemoryStorageTests.swift
+++ b/Tests/KingfisherTests/MemoryStorageTests.swift
@@ -103,6 +103,21 @@ class MemoryStorageTests: XCTestCase {
         XCTAssertFalse(storage.isCached(forKey: "2"))
     }
 
+    func testTotalCacheCost() {
+        XCTAssertEqual(storage.totalCacheCost(), 0)
+
+        storage.store(value: 1, forKey: "1")
+        storage.store(value: 2, forKey: "2")
+        storage.store(value: 3, forKey: "3")
+        XCTAssertEqual(storage.totalCacheCost(), 3)
+
+        storage.remove(forKey: "2")
+        XCTAssertEqual(storage.totalCacheCost(), 2)
+
+        storage.removeAll()
+        XCTAssertEqual(storage.totalCacheCost(), 0)
+    }
+
     func testStoreWithExpiration() {
         let exp = expectation(description: #function)
 
@@ -214,6 +229,21 @@ class MemoryStorageTests: XCTestCase {
             XCTAssertNil(self.storage.storage.object(forKey: "1"))
             exp.fulfill()
         }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testTotalCacheCostIgnoresExpiredValues() {
+        let exp = expectation(description: #function)
+
+        storage.store(value: 1, forKey: "1", expiration: .seconds(0.1))
+        storage.store(value: 2, forKey: "2")
+
+        delay(0.2) {
+            XCTAssertEqual(self.storage.totalCacheCost(), 1)
+            XCTAssertNotNil(self.storage.storage.object(forKey: "1"))
+            exp.fulfill()
+        }
+
         waitForExpectations(timeout: 3, handler: nil)
     }
 

--- a/Tests/KingfisherTests/MemoryStorageTests.swift
+++ b/Tests/KingfisherTests/MemoryStorageTests.swift
@@ -271,49 +271,17 @@ class MemoryStorageTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
-    func testValueFilterValid() {
-        let exp = expectation(description: #function)
+    func testTotalCacheCostExcludesEvictedValues() {
+        let config = MemoryStorage.Config(totalCostLimit: 2, cleanInterval: 60)
+        let storage = MemoryStorage.Backend<Int>(config: config)
 
-        storage.store(value: 1, forKey: "valid", expiration: .never)
-        storage.store(value: 2, forKey: "expired", expiration: .seconds(0.1))
+        // Storing three items with a `totalCostLimit` of 2 forces the system to evict at least one of them.
+        storage.store(value: 1, forKey: "1")
+        storage.store(value: 1, forKey: "2")
+        storage.store(value: 1, forKey: "3")
 
-        delay(0.2) {
-            // .valid (default) returns non-expired items only.
-            XCTAssertEqual(self.storage.value(forKey: "valid", filter: .valid, extendingExpiration: .none), 1)
-            XCTAssertNil(self.storage.value(forKey: "expired", filter: .valid, extendingExpiration: .none))
-            exp.fulfill()
-        }
-        waitForExpectations(timeout: 3, handler: nil)
-    }
-
-    func testValueFilterExpired() {
-        let exp = expectation(description: #function)
-
-        storage.store(value: 1, forKey: "valid", expiration: .never)
-        storage.store(value: 2, forKey: "expired", expiration: .seconds(0.1))
-
-        delay(0.2) {
-            // .expired returns only items that have passed their expiration date.
-            XCTAssertNil(self.storage.value(forKey: "valid", filter: .expired, extendingExpiration: .none))
-            XCTAssertEqual(self.storage.value(forKey: "expired", filter: .expired, extendingExpiration: .none), 2)
-            exp.fulfill()
-        }
-        waitForExpectations(timeout: 3, handler: nil)
-    }
-
-    func testValueFilterAll() {
-        let exp = expectation(description: #function)
-
-        storage.store(value: 1, forKey: "valid", expiration: .never)
-        storage.store(value: 2, forKey: "expired", expiration: .seconds(0.1))
-
-        delay(0.2) {
-            // .all returns items regardless of their expiration state.
-            XCTAssertEqual(self.storage.value(forKey: "valid", filter: .all, extendingExpiration: .none), 1)
-            XCTAssertEqual(self.storage.value(forKey: "expired", filter: .all, extendingExpiration: .none), 2)
-            exp.fulfill()
-        }
-        waitForExpectations(timeout: 3, handler: nil)
+        // Evicted items no longer occupy memory, so they must not be counted toward the total cost.
+        XCTAssertLessThanOrEqual(storage.totalCacheCost(), 2)
     }
 
     func testAutoCleanExpiredMemory() {


### PR DESCRIPTION
## Summary

Adds `MemoryStorage.Backend.totalCacheCost()`, which reports the total estimated in-memory `cacheCost` of the memory cache. This gives users tangible data to reason about an appropriate `totalCostLimit`, and provides parity with `DiskStorage.totalSize`.

This builds on top of @aronspringfield's work in #2530 — both of their commits are preserved here. Thanks for the contribution! 🙏

## Background

In #2530 review we landed on the correct semantics: `totalCacheCost()` should report the *total* cost of resident objects, **including expired-but-not-yet-evicted** ones, since those still occupy memory and still count against what `NSCache` manages via `totalCostLimit`.

The first iteration implemented this by adding a public `ExpirationFilter` parameter to `value(forKey:)`. This final commit keeps the same semantics but avoids the public API churn:

- `ExpirationFilter` / the new `filter:` parameter were only ever used with `.all` (the `.expired` case was dead outside its own tests), so the public `value(forKey:)` signature is left unchanged.
- It also removes a subtle side effect: with the new `extendingExpiration: .cacheTime` default, reading an item via `.all`/`.expired` would silently *resurrect* an expired object by extending its expiration.

`totalCacheCost()` now sums `cacheCost` directly from the resident storage objects under the existing key set. Expired items are included; items already evicted by the system are excluded (they no longer occupy memory).

## Files Changed

- `Sources/Cache/MemoryStorage.swift` — adds `totalCacheCost()`.
- `Tests/KingfisherTests/MemoryStorageTests.swift` — covers empty / populated / removal / expired-inclusion / evicted-exclusion cases.

## Note

`DiskStorage` uses `totalSize` (actual bytes) while this uses `totalCacheCost` to match the naming of the memory cost limit (`totalCostLimit`). `cacheCost` is an *estimated* memory size, not an exact byte count, so the two are intentionally not identical.
