### PR TITLE
Update CI matrix to Xcode 26 only

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,65 +23,65 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - xcode: '26.2'
-            runner: macos-26-arm64
+          - xcode: '26.0.1'
+            runner: macos-26
             destination: 'platform=macOS'
             label: 'macOS'
-            cache-key: xcode-26.2-macos
-          - xcode: '26.2'
-            runner: macos-26-arm64
+            cache-key: xcode-26.0.1-macos
+          - xcode: '26.0.1'
+            runner: macos-26
             sdk: iphonesimulator
             label: 'iOS Simulator'
-            cache-key: xcode-26.2-ios
-          - xcode: '26.2'
-            runner: macos-26-arm64
+            cache-key: xcode-26.0.1-ios
+          - xcode: '26.0.1'
+            runner: macos-26
             sdk: appletvsimulator
             label: 'tvOS Simulator'
-            cache-key: xcode-26.2-tvos
-          - xcode: '26.2'
-            runner: macos-26-arm64
+            cache-key: xcode-26.0.1-tvos
+          - xcode: '26.0.1'
+            runner: macos-26
             sdk: watchsimulator
             label: 'watchOS Simulator'
-            cache-key: xcode-26.2-watchos
+            cache-key: xcode-26.0.1-watchos
 
           - xcode: '26.3'
-            runner: macos-26-arm64
+            runner: macos-26
             destination: 'platform=macOS'
             label: 'macOS'
             cache-key: xcode-26.3-macos
           - xcode: '26.3'
-            runner: macos-26-arm64
+            runner: macos-26
             sdk: iphonesimulator
             label: 'iOS Simulator'
             cache-key: xcode-26.3-ios
           - xcode: '26.3'
-            runner: macos-26-arm64
+            runner: macos-26
             sdk: appletvsimulator
             label: 'tvOS Simulator'
             cache-key: xcode-26.3-tvos
           - xcode: '26.3'
-            runner: macos-26-arm64
+            runner: macos-26
             sdk: watchsimulator
             label: 'watchOS Simulator'
             cache-key: xcode-26.3-watchos
 
           - xcode: '26.4.1'
-            runner: macos-26-arm64
+            runner: macos-26
             destination: 'platform=macOS'
             label: 'macOS'
             cache-key: xcode-26.4.1-macos
           - xcode: '26.4.1'
-            runner: macos-26-arm64
+            runner: macos-26
             sdk: iphonesimulator
             label: 'iOS Simulator'
             cache-key: xcode-26.4.1-ios
           - xcode: '26.4.1'
-            runner: macos-26-arm64
+            runner: macos-26
             sdk: appletvsimulator
             label: 'tvOS Simulator'
             cache-key: xcode-26.4.1-tvos
           - xcode: '26.4.1'
-            runner: macos-26-arm64
+            runner: macos-26
             sdk: watchsimulator
             label: 'watchOS Simulator'
             cache-key: xcode-26.4.1-watchos

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,69 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - xcode: '16.2'
-            runner: macos-15
-            destination: 'platform=macOS'
-            label: 'macOS'
-            cache-key: xcode-16.2-macos
-          - xcode: '16.2'
-            runner: macos-15
-            sdk: iphonesimulator
-            label: 'iOS Simulator'
-            cache-key: xcode-16.2-ios
-          - xcode: '16.2'
-            runner: macos-15
-            sdk: appletvsimulator
-            label: 'tvOS Simulator'
-            cache-key: xcode-16.2-tvos
-          - xcode: '16.2'
-            runner: macos-15
-            sdk: watchsimulator
-            label: 'watchOS Simulator'
-            cache-key: xcode-16.2-watchos
-
-          - xcode: '16.3'
-            runner: macos-15
-            destination: 'platform=macOS'
-            label: 'macOS'
-            cache-key: xcode-16.3-macos
-          - xcode: '16.3'
-            runner: macos-15
-            sdk: iphonesimulator
-            label: 'iOS Simulator'
-            cache-key: xcode-16.3-ios
-          - xcode: '16.3'
-            runner: macos-15
-            sdk: appletvsimulator
-            label: 'tvOS Simulator'
-            cache-key: xcode-16.3-tvos
-          - xcode: '16.3'
-            runner: macos-15
-            sdk: watchsimulator
-            label: 'watchOS Simulator'
-            cache-key: xcode-16.3-watchos
-
-          - xcode: '26.0.1'
-            runner: macos-26
-            destination: 'platform=macOS'
-            label: 'macOS'
-            cache-key: xcode-26.0.1-macos
-          - xcode: '26.0.1'
-            runner: macos-26
-            sdk: iphonesimulator
-            label: 'iOS Simulator'
-            cache-key: xcode-26.0.1-ios
-          - xcode: '26.0.1'
-            runner: macos-26
-            sdk: appletvsimulator
-            label: 'tvOS Simulator'
-            cache-key: xcode-26.0.1-tvos
-          - xcode: '26.0.1'
-            runner: macos-26
-            sdk: watchsimulator
-            label: 'watchOS Simulator'
-            cache-key: xcode-26.0.1-watchos
-
           - xcode: '26.2'
             runner: macos-26
             destination: 'platform=macOS'
@@ -127,6 +64,27 @@ jobs:
             sdk: watchsimulator
             label: 'watchOS Simulator'
             cache-key: xcode-26.3-watchos
+
+          - xcode: '26.4.1'
+            runner: macos-26
+            destination: 'platform=macOS'
+            label: 'macOS'
+            cache-key: xcode-26.4.1-macos
+          - xcode: '26.4.1'
+            runner: macos-26
+            sdk: iphonesimulator
+            label: 'iOS Simulator'
+            cache-key: xcode-26.4.1-ios
+          - xcode: '26.4.1'
+            runner: macos-26
+            sdk: appletvsimulator
+            label: 'tvOS Simulator'
+            cache-key: xcode-26.4.1-tvos
+          - xcode: '26.4.1'
+            runner: macos-26
+            sdk: watchsimulator
+            label: 'watchOS Simulator'
+            cache-key: xcode-26.4.1-watchos
     steps:
       - uses: actions/checkout@v6
       - name: Setup Ruby

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,64 +24,64 @@ jobs:
       matrix:
         include:
           - xcode: '26.2'
-            runner: macos-26
+            runner: macos-26-arm64
             destination: 'platform=macOS'
             label: 'macOS'
             cache-key: xcode-26.2-macos
           - xcode: '26.2'
-            runner: macos-26
+            runner: macos-26-arm64
             sdk: iphonesimulator
             label: 'iOS Simulator'
             cache-key: xcode-26.2-ios
           - xcode: '26.2'
-            runner: macos-26
+            runner: macos-26-arm64
             sdk: appletvsimulator
             label: 'tvOS Simulator'
             cache-key: xcode-26.2-tvos
           - xcode: '26.2'
-            runner: macos-26
+            runner: macos-26-arm64
             sdk: watchsimulator
             label: 'watchOS Simulator'
             cache-key: xcode-26.2-watchos
 
           - xcode: '26.3'
-            runner: macos-26
+            runner: macos-26-arm64
             destination: 'platform=macOS'
             label: 'macOS'
             cache-key: xcode-26.3-macos
           - xcode: '26.3'
-            runner: macos-26
+            runner: macos-26-arm64
             sdk: iphonesimulator
             label: 'iOS Simulator'
             cache-key: xcode-26.3-ios
           - xcode: '26.3'
-            runner: macos-26
+            runner: macos-26-arm64
             sdk: appletvsimulator
             label: 'tvOS Simulator'
             cache-key: xcode-26.3-tvos
           - xcode: '26.3'
-            runner: macos-26
+            runner: macos-26-arm64
             sdk: watchsimulator
             label: 'watchOS Simulator'
             cache-key: xcode-26.3-watchos
 
           - xcode: '26.4.1'
-            runner: macos-26
+            runner: macos-26-arm64
             destination: 'platform=macOS'
             label: 'macOS'
             cache-key: xcode-26.4.1-macos
           - xcode: '26.4.1'
-            runner: macos-26
+            runner: macos-26-arm64
             sdk: iphonesimulator
             label: 'iOS Simulator'
             cache-key: xcode-26.4.1-ios
           - xcode: '26.4.1'
-            runner: macos-26
+            runner: macos-26-arm64
             sdk: appletvsimulator
             label: 'tvOS Simulator'
             cache-key: xcode-26.4.1-tvos
           - xcode: '26.4.1'
-            runner: macos-26
+            runner: macos-26-arm64
             sdk: watchsimulator
             label: 'watchOS Simulator'
             cache-key: xcode-26.4.1-watchos

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,47 +23,47 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - xcode: '16.4'
-            runner: macos-15
+          - xcode: '26.0.1'
+            runner: macos-26
             destination: 'platform=macOS'
             label: 'macOS'
-            cache-key: xcode-16.4-macos
-          - xcode: '16.4'
-            runner: macos-15
-            destination: 'platform=iOS Simulator,name=iPhone 16,OS=18.5'
-            label: 'iOS 18.5'
-            cache-key: xcode-16.4-ios
-          - xcode: '16.4'
-            runner: macos-15
-            destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5'
-            label: 'tvOS 18.5'
-            cache-key: xcode-16.4-tvos
-          - xcode: '16.4'
-            runner: macos-15
+            cache-key: xcode-26.0.1-macos
+          - xcode: '26.0.1'
+            runner: macos-26
+            destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.0'
+            label: 'iOS 26.0'
+            cache-key: xcode-26.0.1-ios
+          - xcode: '26.0.1'
+            runner: macos-26
+            destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.0'
+            label: 'tvOS 26.0'
+            cache-key: xcode-26.0.1-tvos
+          - xcode: '26.0.1'
+            runner: macos-26
             sdk: watchsimulator
-            label: 'watchOS 11.5'
-            cache-key: xcode-16.4-watchos
+            label: 'watchOS 26.0'
+            cache-key: xcode-26.0.1-watchos
 
-          - xcode: '26.4.1'
+          - xcode: '26.5'
             runner: macos-26
             destination: 'platform=macOS'
             label: 'macOS'
-            cache-key: xcode-26.4.1-macos
-          - xcode: '26.4.1'
+            cache-key: xcode-26.5-macos
+          - xcode: '26.5'
             runner: macos-26
-            destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1'
-            label: 'iOS 26.4.1'
-            cache-key: xcode-26.4.1-ios
-          - xcode: '26.4.1'
+            destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.5'
+            label: 'iOS 26.5'
+            cache-key: xcode-26.5-ios
+          - xcode: '26.5'
             runner: macos-26
-            destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.4'
-            label: 'tvOS 26.4'
-            cache-key: xcode-26.4.1-tvos
-          - xcode: '26.4.1'
+            destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.5'
+            label: 'tvOS 26.5'
+            cache-key: xcode-26.5-tvos
+          - xcode: '26.5'
             runner: macos-26
             sdk: watchsimulator
-            label: 'watchOS 26.4'
-            cache-key: xcode-26.4.1-watchos
+            label: 'watchOS 26.5'
+            cache-key: xcode-26.5-watchos
     steps:
       - uses: actions/checkout@v6
       - name: Setup Ruby

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,43 +24,45 @@ jobs:
       matrix:
         include:
           - xcode: '26.0.1'
-            runner: macos-26
+            runner: macos-26-arm64
             destination: 'platform=macOS'
             label: 'macOS'
             cache-key: xcode-26.0.1-macos
           - xcode: '26.0.1'
-            runner: macos-26
+            runner: macos-26-arm64
             destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.2'
             label: 'iOS 26.2'
             cache-key: xcode-26.0.1-ios
+            download-platform: iOS
           - xcode: '26.0.1'
-            runner: macos-26
+            runner: macos-26-arm64
             destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.2'
             label: 'tvOS 26.2'
+            download-platform: tvOS
             cache-key: xcode-26.0.1-tvos
           - xcode: '26.0.1'
-            runner: macos-26
+            runner: macos-26-arm64
             sdk: watchsimulator
             label: 'watchOS 26.0'
             cache-key: xcode-26.0.1-watchos
 
           - xcode: '26.5'
-            runner: macos-26
+            runner: macos-26-arm64
             destination: 'platform=macOS'
             label: 'macOS'
             cache-key: xcode-26.5-macos
           - xcode: '26.5'
-            runner: macos-26
+            runner: macos-26-arm64
             destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.5'
             label: 'iOS 26.5'
             cache-key: xcode-26.5-ios
           - xcode: '26.5'
-            runner: macos-26
+            runner: macos-26-arm64
             destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.5'
             label: 'tvOS 26.5'
             cache-key: xcode-26.5-tvos
           - xcode: '26.5'
-            runner: macos-26
+            runner: macos-26-arm64
             sdk: watchsimulator
             label: 'watchOS 26.5'
             cache-key: xcode-26.5-watchos
@@ -71,6 +73,9 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
+      - name: Install platform support
+        if: matrix.download-platform != ''
+        run: xcodebuild -downloadPlatform ${{ matrix.download-platform }}
       - name: Run tests
         env:
           DESTINATION: ${{ matrix.destination }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,46 +23,44 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - xcode: '26.0.1'
-            runner: macos-26-arm64
+          - xcode: '26.2'
+            runner: macos-26
             destination: 'platform=macOS'
             label: 'macOS'
-            cache-key: xcode-26.0.1-macos
-          - xcode: '26.0.1'
-            runner: macos-26-arm64
+            cache-key: xcode-26.2-macos
+          - xcode: '26.2'
+            runner: macos-26
             destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.2'
             label: 'iOS 26.2'
-            cache-key: xcode-26.0.1-ios
-            download-platform: iOS
-          - xcode: '26.0.1'
-            runner: macos-26-arm64
+            cache-key: xcode-26.2-ios
+          - xcode: '26.2'
+            runner: macos-26
             destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.2'
             label: 'tvOS 26.2'
-            download-platform: tvOS
-            cache-key: xcode-26.0.1-tvos
-          - xcode: '26.0.1'
-            runner: macos-26-arm64
+            cache-key: xcode-26.2-tvos
+          - xcode: '26.2'
+            runner: macos-26
             sdk: watchsimulator
-            label: 'watchOS 26.0'
-            cache-key: xcode-26.0.1-watchos
+            label: 'watchOS 26.2'
+            cache-key: xcode-26.2-watchos
 
           - xcode: '26.5'
-            runner: macos-26-arm64
+            runner: macos-26
             destination: 'platform=macOS'
             label: 'macOS'
             cache-key: xcode-26.5-macos
           - xcode: '26.5'
-            runner: macos-26-arm64
+            runner: macos-26
             destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.5'
             label: 'iOS 26.5'
             cache-key: xcode-26.5-ios
           - xcode: '26.5'
-            runner: macos-26-arm64
+            runner: macos-26
             destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.5'
             label: 'tvOS 26.5'
             cache-key: xcode-26.5-tvos
           - xcode: '26.5'
-            runner: macos-26-arm64
+            runner: macos-26
             sdk: watchsimulator
             label: 'watchOS 26.5'
             cache-key: xcode-26.5-watchos
@@ -73,9 +71,6 @@ jobs:
         with:
           ruby-version: .ruby-version
           bundler-cache: true
-      - name: Install platform support
-        if: matrix.download-platform != ''
-        run: xcodebuild -downloadPlatform ${{ matrix.download-platform }}
       - name: Run tests
         env:
           DESTINATION: ${{ matrix.destination }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,13 +30,13 @@ jobs:
             cache-key: xcode-26.0.1-macos
           - xcode: '26.0.1'
             runner: macos-26
-            destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.0'
-            label: 'iOS 26.0'
+            destination: 'platform=iOS Simulator,name=iPhone 17,OS=26.2'
+            label: 'iOS 26.2'
             cache-key: xcode-26.0.1-ios
           - xcode: '26.0.1'
             runner: macos-26
-            destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.0'
-            label: 'tvOS 26.0'
+            destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=26.2'
+            label: 'tvOS 26.2'
             cache-key: xcode-26.0.1-tvos
           - xcode: '26.0.1'
             runner: macos-26

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -121,7 +121,7 @@ platform :ios do
   lane :xcframework do |options|
     version = options[:version]
     swift_version = options[:swift_version] || "5.0"
-    xcode_version = options[:xcode_version] || "26.4.1"
+    xcode_version = options[:xcode_version] || "26.5"
 
     xcodes(version: xcode_version, select_for_current_build_only: true)
     FileUtils.rm_rf '../build'
@@ -194,7 +194,7 @@ platform :ios do
   end
 
   before_all do |lane|
-    xcode_version = ENV["XCODE_VERSION"] || "26.4.1"
+    xcode_version = ENV["XCODE_VERSION"] || "26.5"
     xcodes(version: xcode_version, select_for_current_build_only: true)
   end
 


### PR DESCRIPTION
## Summary
- Drop all Xcode 16.x CI entries (App Store Connect now requires Xcode 26+)
- **test**: Xcode 26.0.1, 26.5
- **build**: Xcode 26.2, 26.3, 26.4.1

## Test plan
- [x] CI passes on all matrix entries
