### PR TITLE
Fix disk cache lookup during initial scan

### DIFF
--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -64,6 +64,8 @@ public enum DiskStorage {
 
         // A shortcut (which contains false-positive) to improve matching performance.
         var maybeCached : Set<String>?
+        var maybeCachedSetupCompleted = false
+        var maybeCachedFilesStoredDuringSetup = Set<String>()
         let maybeCachedCheckingQueue = DispatchQueue(label: "com.onevcat.Kingfisher.maybeCachedCheckingQueue")
 
         // `false` if the storage initialized with an error.
@@ -105,13 +107,17 @@ public enum DiskStorage {
                     let allFiles = try self.config.fileManager.contentsOfDirectory(atPath: self.directoryURL.path)
                     let maybeCached = Set(allFiles)
                     self.maybeCachedCheckingQueue.async {
-                        self.maybeCached = maybeCached
+                        self.maybeCached = maybeCached.union(self.maybeCachedFilesStoredDuringSetup)
+                        self.maybeCachedFilesStoredDuringSetup.removeAll()
+                        self.maybeCachedSetupCompleted = true
                     }
                 } catch {
                     self.maybeCachedCheckingQueue.async {
                         // Just disable the functionality if we fail to initialize it properly. This will just revert to
                         // the behavior which is to check file existence on disk directly.
                         self.maybeCached = nil
+                        self.maybeCachedFilesStoredDuringSetup.removeAll()
+                        self.maybeCachedSetupCompleted = true
                     }
                 }
             }
@@ -209,8 +215,11 @@ public enum DiskStorage {
                 )
             }
 
-            maybeCachedCheckingQueue.async {
-                self.maybeCached?.insert(fileURL.lastPathComponent)
+            maybeCachedCheckingQueue.sync {
+                if !maybeCachedSetupCompleted {
+                    maybeCachedFilesStoredDuringSetup.insert(fileURL.lastPathComponent)
+                }
+                maybeCached?.insert(fileURL.lastPathComponent)
             }
         }
 
@@ -252,7 +261,7 @@ public enum DiskStorage {
             let filePath = fileURL.path
 
             let fileMaybeCached = maybeCachedCheckingQueue.sync {
-                return maybeCached?.contains(fileURL.lastPathComponent) ?? true
+                return !maybeCachedSetupCompleted || (maybeCached?.contains(fileURL.lastPathComponent) ?? true)
             }
             guard fileMaybeCached else {
                 return nil

--- a/Tests/KingfisherTests/DiskStorageTests.swift
+++ b/Tests/KingfisherTests/DiskStorageTests.swift
@@ -42,6 +42,47 @@ extension String {
     public static var empty: String { return "" }
 }
 
+private final class DelayedDirectoryScanFileManager: FileManager, @unchecked Sendable {
+    private let scanStarted = DispatchSemaphore(value: 0)
+    private let releaseScan = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+
+    private var shouldDelayNextScan = true
+    private var delayedResult: [String] = []
+
+    override func contentsOfDirectory(atPath path: String) throws -> [String] {
+        lock.lock()
+        let shouldDelay = shouldDelayNextScan
+        if shouldDelay {
+            shouldDelayNextScan = false
+        }
+        lock.unlock()
+
+        guard shouldDelay else {
+            return try super.contentsOfDirectory(atPath: path)
+        }
+
+        scanStarted.signal()
+        releaseScan.wait()
+
+        lock.lock()
+        let result = delayedResult
+        lock.unlock()
+        return result
+    }
+
+    func waitUntilScanStarts(timeout: TimeInterval = 2) -> Bool {
+        scanStarted.wait(timeout: .now() + timeout) == .success
+    }
+
+    func finishDelayedScan(returning result: [String]) {
+        lock.lock()
+        delayedResult = result
+        lock.unlock()
+        releaseScan.signal()
+    }
+}
+
 class DiskStorageTests: XCTestCase {
 
     var storage: DiskStorage.Backend<String>!
@@ -65,6 +106,33 @@ class DiskStorageTests: XCTestCase {
         XCTAssertTrue(storage.isCached(forKey: "1"))
         let value = try! storage.value(forKey: "1")
         XCTAssertEqual(value, "1")
+    }
+
+    func testStoreAndGetWhenInitialCacheScanFinishesAfterStore() {
+        let fileManager = DelayedDirectoryScanFileManager()
+        let config = DiskStorage.Config(name: "test-\(UUID().uuidString)", sizeLimit: 5, fileManager: fileManager)
+        let storage = try! DiskStorage.Backend<String>(config: config)
+        defer { try? storage.removeAll(skipCreatingDirectory: true) }
+
+        XCTAssertTrue(fileManager.waitUntilScanStarts())
+
+        try! storage.store(value: "1", forKey: "1")
+        fileManager.finishDelayedScan(returning: [])
+
+        let deadline = Date().addingTimeInterval(2)
+        var initialScanApplied = false
+        repeat {
+            initialScanApplied = storage.maybeCachedCheckingQueue.sync {
+                storage.maybeCached != nil
+            }
+            if !initialScanApplied {
+                Thread.sleep(forTimeInterval: 0.001)
+            }
+        } while !initialScanApplied && Date() < deadline
+
+        XCTAssertTrue(initialScanApplied)
+        XCTAssertTrue(storage.isCached(forKey: "1"))
+        XCTAssertEqual(try! storage.value(forKey: "1"), "1")
     }
 
     func testRemove() {


### PR DESCRIPTION
## Summary

- keep disk cache bookkeeping ordered with store completion
- preserve files stored while the initial disk directory scan is still pending
- add a deterministic regression test for a late initial scan snapshot

## Verification

- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=macOS' -only-testing:KingfisherTests/DiskStorageTests`
- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=macOS' -only-testing:KingfisherTests/ImageCacheStaleDiskRetrievalTests`
- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -only-testing:KingfisherTests/DiskStorageTests`
