### PR TITLE
Prevent cancelled network observers from notifying

### DIFF
--- a/Sources/Networking/NetworkMonitor.swift
+++ b/Sources/Networking/NetworkMonitor.swift
@@ -138,6 +138,7 @@ internal final class NetworkObserverImpl: @unchecked Sendable, NetworkObserver {
     let callback: @Sendable (Bool) -> Void
     private weak var monitor: NetworkMonitor?
     private var timeoutWorkItem: DispatchWorkItem?
+    private var isCancelled = false
     private let queue = DispatchQueue(label: "com.onevcat.Kingfisher.NetworkObserver", qos: .utility)
 
     init(timeoutInterval: TimeInterval?, callback: @escaping @Sendable (Bool) -> Void, monitor: NetworkMonitor) {
@@ -157,7 +158,7 @@ internal final class NetworkObserverImpl: @unchecked Sendable, NetworkObserver {
 
     func notify(isConnected: Bool) {
         queue.async { [weak self] in
-            guard let self else { return }
+            guard let self, !isCancelled else { return }
 
             // Cancel timeout if we're notifying
             timeoutWorkItem?.cancel()
@@ -176,6 +177,8 @@ internal final class NetworkObserverImpl: @unchecked Sendable, NetworkObserver {
     func cancel() {
         queue.async { [weak self] in
             guard let self else { return }
+
+            isCancelled = true
 
             // Cancel timeout
             timeoutWorkItem?.cancel()

--- a/Sources/Networking/NetworkMonitor.swift
+++ b/Sources/Networking/NetworkMonitor.swift
@@ -138,7 +138,7 @@ internal final class NetworkObserverImpl: @unchecked Sendable, NetworkObserver {
     let callback: @Sendable (Bool) -> Void
     private weak var monitor: NetworkMonitor?
     private var timeoutWorkItem: DispatchWorkItem?
-    private var isCancelled = false
+    private var isFinished = false
     private let queue = DispatchQueue(label: "com.onevcat.Kingfisher.NetworkObserver", qos: .utility)
 
     init(timeoutInterval: TimeInterval?, callback: @escaping @Sendable (Bool) -> Void, monitor: NetworkMonitor) {
@@ -158,7 +158,8 @@ internal final class NetworkObserverImpl: @unchecked Sendable, NetworkObserver {
 
     func notify(isConnected: Bool) {
         queue.async { [weak self] in
-            guard let self, !isCancelled else { return }
+            guard let self, !isFinished else { return }
+            isFinished = true
 
             // Cancel timeout if we're notifying
             timeoutWorkItem?.cancel()
@@ -176,9 +177,8 @@ internal final class NetworkObserverImpl: @unchecked Sendable, NetworkObserver {
 
     func cancel() {
         queue.async { [weak self] in
-            guard let self else { return }
-
-            isCancelled = true
+            guard let self, !isFinished else { return }
+            isFinished = true
 
             // Cancel timeout
             timeoutWorkItem?.cancel()

--- a/Tests/KingfisherTests/RetryStrategyTests.swift
+++ b/Tests/KingfisherTests/RetryStrategyTests.swift
@@ -469,6 +469,22 @@ class RetryStrategyTests: XCTestCase {
 
         waitForExpectations(timeout: 1, handler: nil)
     }
+
+    func testNetworkObserverNotifiesOnlyOnce() {
+        let exp = expectation(description: #function)
+        exp.assertForOverFulfill = true
+
+        let observer = NetworkObserverImpl(
+            timeoutInterval: nil,
+            callback: { _ in exp.fulfill() },
+            monitor: .default
+        )
+
+        observer.notify(isConnected: true)
+        observer.notify(isConnected: false)
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
 }
 
 private struct E: Error {}
@@ -574,7 +590,7 @@ final class TestNetworkObserver: @unchecked Sendable, NetworkObserver {
     let callback: @Sendable (Bool) -> Void
     private weak var monitor: TestNetworkMonitor?
     private var timeoutWorkItem: DispatchWorkItem?
-    private var isCancelled = false
+    private var isFinished = false
     private let queue = DispatchQueue(label: "com.onevcat.KingfisherTests.TestNetworkObserver", qos: .utility)
 
     init(timeoutInterval: TimeInterval?, callback: @escaping @Sendable (Bool) -> Void, monitor: TestNetworkMonitor) {
@@ -594,7 +610,8 @@ final class TestNetworkObserver: @unchecked Sendable, NetworkObserver {
 
     func notify(isConnected: Bool) {
         queue.async { [weak self] in
-            guard let self, !isCancelled else { return }
+            guard let self, !isFinished else { return }
+            isFinished = true
 
             // Cancel timeout if we're notifying
             timeoutWorkItem?.cancel()
@@ -612,9 +629,8 @@ final class TestNetworkObserver: @unchecked Sendable, NetworkObserver {
 
     func cancel() {
         queue.async { [weak self] in
-            guard let self else { return }
-
-            isCancelled = true
+            guard let self, !isFinished else { return }
+            isFinished = true
 
             // Cancel timeout
             timeoutWorkItem?.cancel()

--- a/Tests/KingfisherTests/RetryStrategyTests.swift
+++ b/Tests/KingfisherTests/RetryStrategyTests.swift
@@ -453,6 +453,22 @@ class RetryStrategyTests: XCTestCase {
 
         waitForExpectations(timeout: 10, handler: nil)
     }
+
+    func testNetworkObserverDoesNotNotifyAfterCancel() {
+        let exp = expectation(description: #function)
+        exp.isInverted = true
+
+        let observer = NetworkObserverImpl(
+            timeoutInterval: nil,
+            callback: { _ in exp.fulfill() },
+            monitor: .default
+        )
+
+        observer.cancel()
+        observer.notify(isConnected: true)
+
+        waitForExpectations(timeout: 1, handler: nil)
+    }
 }
 
 private struct E: Error {}
@@ -558,6 +574,7 @@ final class TestNetworkObserver: @unchecked Sendable, NetworkObserver {
     let callback: @Sendable (Bool) -> Void
     private weak var monitor: TestNetworkMonitor?
     private var timeoutWorkItem: DispatchWorkItem?
+    private var isCancelled = false
     private let queue = DispatchQueue(label: "com.onevcat.KingfisherTests.TestNetworkObserver", qos: .utility)
 
     init(timeoutInterval: TimeInterval?, callback: @escaping @Sendable (Bool) -> Void, monitor: TestNetworkMonitor) {
@@ -577,7 +594,7 @@ final class TestNetworkObserver: @unchecked Sendable, NetworkObserver {
 
     func notify(isConnected: Bool) {
         queue.async { [weak self] in
-            guard let self else { return }
+            guard let self, !isCancelled else { return }
 
             // Cancel timeout if we're notifying
             timeoutWorkItem?.cancel()
@@ -596,6 +613,8 @@ final class TestNetworkObserver: @unchecked Sendable, NetworkObserver {
     func cancel() {
         queue.async { [weak self] in
             guard let self else { return }
+
+            isCancelled = true
 
             // Cancel timeout
             timeoutWorkItem?.cancel()


### PR DESCRIPTION
## Summary

- make network observers one-shot after the first notification or cancellation
- skip notification callbacks after an observer has been cancelled
- prevent duplicate callbacks when multiple `notify` events race, such as timeout and reconnect
- mirror the production observer semantics in the retry strategy test double
- add deterministic regression tests for cancel-before-notify and duplicate notify ordering

## Verification

- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=macOS' -only-testing:KingfisherTests/RetryStrategyTests/testNetworkObserverDoesNotNotifyAfterCancel -only-testing:KingfisherTests/RetryStrategyTests/testNetworkObserverNotifiesOnlyOnce`
- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=macOS' -only-testing:KingfisherTests/RetryStrategyTests`
- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -only-testing:KingfisherTests/RetryStrategyTests`
- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -only-testing:KingfisherTests/RetryStrategyTests/testNetworkRetryStrategyWaitsForReconnection -test-iterations 20`
