### PR TITLE
Fix alternative source task update ordering

### DIFF
--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -340,14 +340,20 @@ public class KingfisherManager: @unchecked Sendable {
             retryContext: RetryContext?,
             downloadTaskUpdated: DownloadTaskUpdatedBlock?
         ) {
+            let reporter = DownloadTaskUpdatedReporter(downloadTaskUpdated)
+            let updateGate = DownloadTaskUpdatedCallbackGate()
             let newTask = self.retrieveImage(
                 with: source,
                 context: retrievingContext,
-                downloadTaskUpdated: downloadTaskUpdated
+                downloadTaskUpdated: reporter.report,
+                notifyStartedDownloadTask: true
             ) { result in
-                handler(currentSource: source, retryContext: retryContext, result: result)
+                updateGate.execute {
+                    handler(currentSource: source, retryContext: retryContext, result: result)
+                }
             }
-            downloadTaskUpdated?(newTask)
+            reporter.report(newTask)
+            updateGate.open()
         }
 
         @Sendable func failCurrentSource(_ source: Source, retryContext: RetryContext?, with error: KingfisherError) {
@@ -433,6 +439,7 @@ public class KingfisherManager: @unchecked Sendable {
         with source: Source,
         context: RetrievingContext<Source>,
         downloadTaskUpdated: DownloadTaskUpdatedBlock?,
+        notifyStartedDownloadTask: Bool = false,
         completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?) -> DownloadTask?
     {
         let options = context.options
@@ -440,7 +447,8 @@ public class KingfisherManager: @unchecked Sendable {
             return loadAndCacheImage(
                 source: source,
                 context: context,
-                completionHandler: completionHandler)?.value
+                completionHandler: completionHandler,
+                downloadTaskCreated: notifyStartedDownloadTask ? downloadTaskUpdated : nil)?.value
 
         }
 
@@ -473,7 +481,8 @@ public class KingfisherManager: @unchecked Sendable {
         return loadAndCacheImage(
             source: source,
             context: context,
-            completionHandler: completionHandler)?.value
+            completionHandler: completionHandler,
+            downloadTaskCreated: notifyStartedDownloadTask ? downloadTaskUpdated : nil)?.value
     }
 
     /// Opt-in async cache-type probe path.
@@ -687,10 +696,12 @@ public class KingfisherManager: @unchecked Sendable {
         switch source {
         case .network(let resource):
             let downloader = options.downloader ?? self.downloader
+            let taskCreatedReporter = DownloadTaskCreatedReporter(downloadTaskCreated)
+            let downloadOptions = options.appendingDownloadTaskStartedHandler(taskCreatedReporter.report)
             let task = downloader.downloadImage(
-                with: resource.downloadURL, options: options, completionHandler: _cacheImage
+                with: resource.downloadURL, options: downloadOptions, completionHandler: _cacheImage
             )
-            downloadTaskCreated?(task)
+            taskCreatedReporter.report(task)
 
 
             // The code below is neat, but it fails the Swift 5.2 compiler with a runtime crash when 
@@ -1301,5 +1312,146 @@ class CacheCallbackCoordinator: @unchecked Sendable {
         default:
             assertionFailure("This case should not happen in CacheCallbackCoordinator: \(state) - \(action)")
         }
+    }
+}
+
+private final class DownloadTaskUpdatedReporter: @unchecked Sendable {
+    private let lock = NSLock()
+    private let block: DownloadTaskUpdatedBlock?
+    private var reportedTaskIdentifiers = Set<ObjectIdentifier>()
+    private var reportedNil = false
+
+    init(_ block: DownloadTaskUpdatedBlock?) {
+        self.block = block
+    }
+
+    func report(_ task: DownloadTask?) {
+        guard let block else { return }
+
+        lock.lock()
+        let shouldReport: Bool
+        if let task {
+            shouldReport = reportedTaskIdentifiers.insert(ObjectIdentifier(task)).inserted
+        } else {
+            shouldReport = !reportedNil
+            reportedNil = true
+        }
+        lock.unlock()
+
+        if shouldReport {
+            block(task)
+        }
+    }
+}
+
+private final class DownloadTaskCreatedReporter: @unchecked Sendable {
+    private let lock = NSLock()
+    private let block: (@Sendable (DownloadTask) -> Void)?
+    private var reportedTaskIdentifiers = Set<ObjectIdentifier>()
+
+    init(_ block: (@Sendable (DownloadTask) -> Void)?) {
+        self.block = block
+    }
+
+    func report(_ task: DownloadTask) {
+        guard let block else { return }
+
+        lock.lock()
+        let shouldReport = reportedTaskIdentifiers.insert(ObjectIdentifier(task)).inserted
+        lock.unlock()
+
+        if shouldReport {
+            block(task)
+        }
+    }
+}
+
+private final class DownloadTaskUpdatedCallbackGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isOpen = false
+    private var pendingBlocks: [@Sendable () -> Void] = []
+
+    func execute(_ block: @escaping @Sendable () -> Void) {
+        lock.lock()
+        if isOpen {
+            lock.unlock()
+            block()
+        } else {
+            pendingBlocks.append(block)
+            lock.unlock()
+        }
+    }
+
+    func open() {
+        lock.lock()
+        guard !isOpen else {
+            lock.unlock()
+            return
+        }
+
+        isOpen = true
+        let blocks = pendingBlocks
+        pendingBlocks.removeAll()
+        lock.unlock()
+
+        blocks.forEach { $0() }
+    }
+}
+
+private extension KingfisherParsedOptionsInfo {
+    func appendingDownloadTaskStartedHandler(
+        _ handler: (@Sendable (DownloadTask) -> Void)?
+    ) -> KingfisherParsedOptionsInfo {
+        guard let handler else { return self }
+
+        var options = self
+        if let modifier = requestModifier {
+            if let syncModifier = modifier as? any ImageDownloadRequestModifier {
+                options.requestModifier = DownloadTaskReportingModifier(base: syncModifier, handler: handler)
+            } else {
+                options.requestModifier = AsyncDownloadTaskReportingModifier(base: modifier, handler: handler)
+            }
+        } else {
+            options.requestModifier = DownloadTaskReportingModifier(base: nil, handler: handler)
+        }
+        return options
+    }
+}
+
+private struct DownloadTaskReportingModifier: ImageDownloadRequestModifier {
+    let base: (any ImageDownloadRequestModifier)?
+    let onDownloadTaskStarted: (@Sendable (DownloadTask?) -> Void)?
+
+    init(base: (any ImageDownloadRequestModifier)?, handler: @escaping @Sendable (DownloadTask) -> Void) {
+        self.base = base
+        self.onDownloadTaskStarted = { task in
+            if let task {
+                handler(task)
+            }
+            base?.onDownloadTaskStarted?(task)
+        }
+    }
+
+    func modified(for request: URLRequest) -> URLRequest? {
+        base?.modified(for: request) ?? request
+    }
+}
+
+private struct AsyncDownloadTaskReportingModifier: AsyncImageDownloadRequestModifier {
+    let base: any AsyncImageDownloadRequestModifier
+    let onDownloadTaskStarted: (@Sendable (DownloadTask?) -> Void)?
+
+    init(base: any AsyncImageDownloadRequestModifier, handler: @escaping @Sendable (DownloadTask) -> Void) {
+        self.base = base
+        self.onDownloadTaskStarted = { task in
+            if let task {
+                handler(task)
+            }
+            base.onDownloadTaskStarted?(task)
+        }
+    }
+
+    func modified(for request: URLRequest) async -> URLRequest? {
+        await base.modified(for: request)
     }
 }

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1151,6 +1151,31 @@ class KingfisherManagerTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testRetrievingAlternativeSourceTaskUpdateBlockCalledBeforeCompletion() {
+        let exp = expectation(description: #function)
+        let brokenURL = URL(string: "https://kingfisher.test/manager-alternative-sync-primary")!
+        let alternativeURL = URL(string: "https://kingfisher.test/manager-alternative-sync-fallback")!
+        let downloader = ImmediateFailureImageDownloader(name: "test.manager.immediate")
+        let manager = KingfisherManager(downloader: downloader, cache: manager.cache)
+        let downloadTaskUpdated = LockIsolated(false)
+
+        _ = manager.retrieveImage(
+            with: .network(brokenURL),
+            options: [.alternativeSources([.network(alternativeURL)])],
+            downloadTaskUpdated: { newTask in
+                XCTAssertEqual(newTask?.sessionTask?.task.originalRequest?.url, alternativeURL)
+                downloadTaskUpdated.setValue(true)
+            })
+        {
+            result in
+            XCTAssertNotNil(result.error)
+            XCTAssertTrue(downloadTaskUpdated.value)
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
     func testRetrievingAlternativeSourceCancelled() {
         let exp = expectation(description: #function)
         let url = testURLs[0]
@@ -1176,11 +1201,17 @@ class KingfisherManagerTests: XCTestCase {
     }
 
     func testRetrievingAlternativeSourceCanCancelUpdatedTask() {
-        let exp = expectation(description: #function)
+        let updatedExp = expectation(description: "\(#function) updated")
+        let completionExp = expectation(description: "\(#function) completion")
+        let extraCompletionExp = expectation(description: "\(#function) extra completion")
+        extraCompletionExp.isInverted = true
         let url = testURLs[0]
         let dataStub = delayedStub(url, data: testImageData)
         
         let called = LockIsolated(false)
+        let completionCount = LockIsolated(0)
+        let isActive = LockIsolated(true)
+        defer { isActive.setValue(false) }
 
         let brokenURL = URL(string: "https://kingfisher.test/manager-alternative-cancel-updated-task")!
         stub(brokenURL, data: Data())
@@ -1192,24 +1223,34 @@ class KingfisherManagerTests: XCTestCase {
                 XCTAssertNotNil(newTask)
                 newTask?.cancel()
                 called.setValue(true)
+                updatedExp.fulfill()
             }
         )
         {
             result in
+            guard isActive.value else { return }
+            let callCount = completionCount.withValue {
+                $0 += 1
+                return $0
+            }
+            guard callCount == 1 else {
+                extraCompletionExp.fulfill()
+                return
+            }
+
             XCTAssertNotNil(result.error)
             XCTAssertTrue(result.error?.isTaskCancelled ?? false)
-
-            delay(0.3) {
-                _ = dataStub.go()
-                XCTAssertTrue(called.value)
-                exp.fulfill()
-            }
+            completionExp.fulfill()
         }
         
         XCTAssertNotNil(task)
         XCTAssertTrue(task!.isInitialized)
 
-        waitForExpectations(timeout: 3, handler: nil)
+        wait(for: [updatedExp], timeout: 3)
+        XCTAssertTrue(called.value)
+        _ = dataStub.go()
+        wait(for: [completionExp], timeout: 3)
+        wait(for: [extraCompletionExp], timeout: 0.3)
     }
     
     func testDownsamplingHandleScale2x() {
@@ -2098,6 +2139,25 @@ private final class AsyncCacheTypeCheckProvider: ImageDataProvider, @unchecked S
         onStart()
         try await Task.sleep(nanoseconds: 1_000_000_000)
         return payload
+    }
+}
+
+private final class ImmediateFailureImageDownloader: ImageDownloader, @unchecked Sendable {
+    private var sessions = [URLSession]()
+
+    override func downloadImage(
+        with url: URL,
+        options: KingfisherParsedOptionsInfo,
+        completionHandler: (@Sendable (Result<ImageLoadingResult, KingfisherError>) -> Void)? = nil
+    ) -> DownloadTask {
+        let session = URLSession(configuration: .ephemeral)
+        sessions.append(session)
+        let sessionTask = SessionDataTask(task: session.dataTask(with: url))
+        let task = DownloadTask(sessionTask: sessionTask, cancelToken: 0)
+        completionHandler?(.failure(.processorError(
+            reason: .processingFailed(processor: DefaultImageProcessor.default, item: .data(Data()))
+        )))
+        return task
     }
 }
 


### PR DESCRIPTION
## Summary

- ensure retry / low-data / alternative-source download completions cannot run before the replacement task is reported through `downloadTaskUpdated`
- report manager-mediated fallback download tasks before `resume()` by wrapping request modifiers and chaining any user-provided task-started hook
- make `testRetrievingAlternativeSourceCanCancelUpdatedTask` event-driven so late delayed assertions cannot spill into the next test

## Verification

- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=macOS' -only-testing:KingfisherTests/KingfisherManagerTests/testRetrievingAlternativeSourceTaskUpdateBlockCalledBeforeCompletion -only-testing:KingfisherTests/KingfisherManagerTests/testRetrievingAlternativeSourceCanCancelUpdatedTask -only-testing:KingfisherTests/KingfisherManagerTests/testRetrievingAlternativeSourceTaskUpdateBlockCalled 2>&1 | xcsift -f toon`
- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=macOS' -only-testing:KingfisherTests/KingfisherManagerTests 2>&1 | xcsift -f toon`
- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -only-testing:KingfisherTests/KingfisherManagerTests 2>&1 | xcsift -f toon`
- `xcodebuild test -workspace Kingfisher.xcworkspace -scheme Kingfisher -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.5' -only-testing:KingfisherTests/KingfisherManagerTests/testRetrievingAlternativeSourceCanCancelUpdatedTask -test-iterations 20 2>&1 | xcsift -f toon`
