### PR TITLE
Fix data race in SessionDataTask.forceCancel()

### DIFF
--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -156,7 +156,20 @@ public class SessionDataTask: @unchecked Sendable {
     }
 
     func forceCancel() {
-        for token in callbacksStore.keys {
+        // `callbacksStore` is protected by `lock` for every other access. Snapshot the
+        // tokens under the lock before cancelling, for two reasons:
+        // 1. `forceCancel()` is reachable from the public `ImageDownloader.cancelAll()` and
+        //    `cancel(url:)` on arbitrary caller threads, while the session delegate queue may
+        //    concurrently mutate the store via `addCallback`/`completeAndRemoveAllCallbacks`.
+        //    Reading the live `keys` view here would be a data race on the dictionary.
+        // 2. `cancel(token:)` removes the token via `removeCallback`, so iterating the live
+        //    `keys` view would mutate the dictionary mid-iteration.
+        // Iterating an immutable snapshot avoids both. The lock is released before calling
+        // `cancel(token:)`, which re-acquires it (the non-recursive `lock` would otherwise deadlock).
+        lock.lock()
+        let tokens = Array(callbacksStore.keys)
+        lock.unlock()
+        for token in tokens {
             cancel(token: token)
         }
     }

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -386,6 +386,46 @@ class ImageDownloaderTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
     
+    // Regression test for a data race in `SessionDataTask.forceCancel()`.
+    //
+    // `forceCancel()` — reachable from the public `ImageDownloader.cancelAll()` / `cancel(url:)`
+    // on arbitrary caller threads — used to iterate `callbacksStore.keys` without holding `lock`,
+    // while the session delegate queue mutates the store through `addCallback`. That is a
+    // read/write data race on a Swift `Dictionary` (reported by Thread Sanitizer and able to
+    // crash on rehash). This test hammers both paths concurrently; with the snapshot-under-lock
+    // fix it completes without crashing and stays clean under TSan.
+    func testForceCancelConcurrentWithAddCallbackIsThreadSafe() {
+        let url = URL(string: "https://example.com/forceCancelRace.png")!
+        let options = KingfisherParsedOptionsInfo(nil)
+        let urlTask = URLSession.shared.dataTask(with: url)
+        let queue = DispatchQueue(label: "test.forceCancel.race", attributes: .concurrent)
+
+        for _ in 0..<500 {
+            let sessionTask = SessionDataTask(task: urlTask)
+            // Pre-load callbacks so `forceCancel` always has tokens to iterate.
+            for _ in 0..<8 {
+                _ = sessionTask.addCallback(.init(onCompleted: nil, options: options))
+            }
+
+            let group = DispatchGroup()
+            // Writer: keep inserting into `callbacksStore`.
+            group.enter()
+            queue.async {
+                for _ in 0..<16 {
+                    _ = sessionTask.addCallback(.init(onCompleted: nil, options: options))
+                }
+                group.leave()
+            }
+            // Reader under test: iterate + cancel concurrently with the writer.
+            group.enter()
+            queue.async {
+                sessionTask.forceCancel()
+                group.leave()
+            }
+            group.wait()
+        }
+    }
+
     // Issue 532 https://github.com/onevcat/Kingfisher/issues/532#issuecomment-305644311
     func testCancelThenRestartSameDownload() {
         let exp = expectation(description: #function)


### PR DESCRIPTION
## What

Fix a data race in `SessionDataTask.forceCancel()`.

`forceCancel()` iterated `callbacksStore.keys` **without holding `lock`**, even though every other access to `callbacksStore` in the file is lock-guarded:

```swift
func forceCancel() {
    for token in callbacksStore.keys {   // unlocked read of shared state
        cancel(token: token)             // cancel(token:) -> removeCallback mutates the store
    }
}
```

Two distinct problems:

1. **Data race.** `forceCancel()` is reachable from the public `ImageDownloader.cancelAll()` and `ImageDownloader.cancel(url:)` (via `SessionDelegate.cancelAll()` / `cancel(url:)`), which run on whatever thread the caller uses. Meanwhile the `URLSession` delegate queue mutates the same dictionary through `addCallback` / `completeAndRemoveAllCallbacks`. A concurrent iterate‑vs‑insert on a Swift `Dictionary` is undefined behavior — Thread Sanitizer flags it, and an insert that triggers a re‑hash can crash with `EXC_BAD_ACCESS`.
2. **Mutation during iteration.** `cancel(token:)` removes the entry via `removeCallback`, mutating the dictionary while its `keys` view is being iterated.

## Fix

Snapshot the tokens under the lock, then cancel outside it. The lock is released before calling `cancel(token:)`, which re‑acquires the non‑recursive `NSLock` (holding it across the call would deadlock). This mirrors the existing snapshot‑under‑lock pattern already used in `SessionDelegate.cancelAll()` / `cancel(url:)` a few lines away.

```swift
lock.lock()
let tokens = Array(callbacksStore.keys)
lock.unlock()
for token in tokens { cancel(token: token) }
```

## Tests

Adds `ImageDownloaderTests.testForceCancelConcurrentWithAddCallbackIsThreadSafe`, which drives `SessionDataTask` internals (via `@testable import`) and hammers `addCallback` against `forceCancel` concurrently over many iterations — a tight, low‑flake reproduction of the exact raced paths.

## How to verify

Run the new test under Thread Sanitizer:

```bash
xcodebuild test -project Kingfisher.xcodeproj -scheme Kingfisher \
  -destination 'platform=macOS' \
  -only-testing:KingfisherTests/ImageDownloaderTests/testForceCancelConcurrentWithAddCallbackIsThreadSafe \
  -enableThreadSanitizer YES
```

- **Before the fix:** `WARNING: ThreadSanitizer: Swift access race` (Read of size 8 on `callbacksStore`) → crash (Signal 6: Aborted) → `** TEST FAILED **`.
- **After the fix:** passes with no sanitizer report → `** TEST SUCCEEDED **` (~0.15s).

`swift build` and the full macOS `build-for-testing` also succeed.

## Why it matters

This is the same class of concurrency bug as the recent `fix-network-observer-cancel-race` and `fix-disk-storage-maybe-cached-race` work, but on a hotter, user‑facing path: cancellation. Apps that call `cancelAll()` / `cancel(url:)` while downloads are in flight can hit a data race that trips Thread Sanitizer and can crash in release builds. The fix is minimal, allocation‑light, and follows the file's existing locking conventions.


## Related issue

This is the data race behind the production crash reported in #2441 — `[__NSTaggedDate countByEnumeratingWithState:objects:count:]: unrecognized selector sent to instance`. That report's stack traces through `ImageDownloader.cancel(url:)` → `SessionDelegate.cancel(url:)` → `SessionDataTask.forceCancel()`, and an "unrecognized selector during fast enumeration" is the classic symptom of a Swift `Dictionary` corrupted by the unsynchronized `for token in callbacksStore.keys` enumeration that this PR removes.

Fixes #2441

## CI

The full test + build matrix passes on my fork across **iOS, macOS, tvOS, and watchOS** (Xcode 26.2 and 26.5).