### PR TITLE
Fix broken disk caching when the image URL path contains '@'

### DIFF
--- a/Sources/Utility/String+SHA256.swift
+++ b/Sources/Utility/String+SHA256.swift
@@ -54,6 +54,22 @@ extension KingfisherWrapper where Base == String {
             let extRange = firstSeg.index(index, offsetBy: 1)..<firstSeg.endIndex
             ext = String(firstSeg[extRange])
         }
-        return ext.count > 0 ? ext : nil
+
+        // The result is appended to the hashed cache file name as a file extension
+        // (e.g. `<hash>.png`). The text after the last `.` is not guaranteed to be a valid
+        // extension: when the original URL path itself contains `@` (such as
+        // `.../57373197@300-1720981878.jpg`), the `@`-split above yields `.../57373197`, and
+        // this extracts `net/57373197`. A value containing a path separator turns the cache
+        // file name into a nonexistent sub-directory path, so the file can never be written
+        // and disk caching silently breaks. See https://github.com/onevcat/Kingfisher/issues/2301
+        //
+        // Only accept a plausible file extension: non-empty, short, and alphanumeric.
+        guard !ext.isEmpty,
+              ext.count <= 20,
+              ext.allSatisfy({ $0.isLetter || $0.isNumber })
+        else {
+            return nil
+        }
+        return ext
     }
 }

--- a/Tests/KingfisherTests/StringExtensionTests.swift
+++ b/Tests/KingfisherTests/StringExtensionTests.swift
@@ -14,4 +14,31 @@ class StringExtensionTests: XCTestCase {
         let s = "hello"
         XCTAssertEqual(s.kf.sha256, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
     }
+
+    func testStringExt() {
+        // Basic extension extraction from a key.
+        XCTAssertEqual("https://example.com/image.png".kf.ext, "png")
+        XCTAssertEqual("https://example.com/image.JPG".kf.ext, "JPG")
+        XCTAssertEqual("https://example.com/a.b/photo.gif".kf.ext, "gif")
+        // The processor identifier is appended as `@identifier`; it is stripped before extraction.
+        XCTAssertEqual("https://example.com/image.png@round-corner".kf.ext, "png")
+        // No extension present.
+        XCTAssertNil("https://example.com/image".kf.ext)
+        XCTAssertNil("plain-key-without-dot".kf.ext)
+    }
+
+    // Regression test for https://github.com/onevcat/Kingfisher/issues/2301
+    //
+    // When the URL path itself contains `@`, the `@`-split used to strip the processor
+    // identifier extracted a bogus "extension" that contained a path separator
+    // (`net/57373197`). Appended to the hashed file name, that produces a nonexistent
+    // sub-directory path, the cache file can never be written, and disk caching breaks.
+    func testStringExtRejectsValueWithPathSeparator() {
+        let key = "https://t.furaffinity.net/57373197@300-1720981878.jpg"
+        let ext = key.kf.ext
+        XCTAssertNil(ext, "Expected no extension instead of the broken `net/57373197` value")
+        if let ext {
+            XCTAssertFalse(ext.contains("/"), "A file extension must never contain a path separator")
+        }
+    }
 }


### PR DESCRIPTION
## What

Fixes #2301 — with `DiskStorage.config.autoExtAfterHashedFileName = true`, disk caching silently breaks for image URLs whose path contains an `@`.

## Root cause

When `autoExtAfterHashedFileName` is on, the cache file name is `<sha256>.<ext>`, where `<ext>` comes from `String.kf.ext` (`String+SHA256.swift`):

```swift
var ext: String? {
    guard let firstSeg = base.split(separator: "@").first else { return nil }
    var ext = ""
    if let index = firstSeg.lastIndex(of: ".") {
        let extRange = firstSeg.index(index, offsetBy: 1)..<firstSeg.endIndex
        ext = String(firstSeg[extRange])
    }
    return ext.count > 0 ? ext : nil
}
```

The `@` split exists to drop the processor identifier — processed cache keys are formed as `originalKey@processorIdentifier` (`ImageCache.swift:1470`). But when the **URL path itself contains `@`** — e.g. `https://t.furaffinity.net/57373197@300-1720981878.jpg` — `split(separator: "@").first` returns `https://t.furaffinity.net/57373197`, and the last `.` is the one in `.net`, so the extracted extension becomes **`net/57373197`**.

That value contains a path separator. `cacheFileName` then returns `<hash>.net/57373197`, and `cacheFileURL` (`DiskStorage.swift:378-380`) resolves it into a nonexistent `<hash>.net/` sub-directory. `FileManager` cannot create the file there, so the write fails, every subsequent lookup misses, and `result.cacheType` is always `.none` (the reporter's `precondition(result.cacheType != .none)` trips).

## Fix

Validate the extracted extension before using it: accept only a non-empty, short, alphanumeric string; otherwise return `nil` (no extension), which restores correct caching. Behavior for normal and processed keys is unchanged.

```swift
guard !ext.isEmpty,
      ext.count <= 20,
      ext.allSatisfy({ $0.isLetter || $0.isNumber })
else { return nil }
return ext
```

## Tests

`StringExtensionTests`:
- `testStringExt` — basic extraction, processor-identifier stripping (`image.png@round-corner` → `png`), and the no-extension cases.
- `testStringExtRejectsValueWithPathSeparator` — regression for #2301: `…/57373197@300-1720981878.jpg` must not yield an extension containing `/`.

## Verification (macOS)

```bash
xcodebuild test -project Kingfisher.xcodeproj -scheme Kingfisher \
  -destination 'platform=macOS' -only-testing:KingfisherTests/StringExtensionTests
```

- **Before the fix:** `testStringExtRejectsValueWithPathSeparator` fails — `XCTAssertNil failed: "net/57373197"`.
- **After the fix:** all `StringExtensionTests` pass.

## Note / scope

Fully *recovering* the real extension for URLs whose path contains `@` is ambiguous (the same `@` also separates the appended processor identifier), so this change deliberately scopes to the actual defect: never emit an extension that corrupts the cache path. For such URLs the cache file simply has no extension (the same outcome as `autoExtAfterHashedFileName = false`), and caching works again.


## CI

The full test + build matrix passes on my fork across **iOS, macOS, tvOS, and watchOS** (Xcode 26.2 and 26.5).