### PR TITLE
Fix data race on RetrievingContext.propagationErrors

### DIFF
--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -364,8 +364,7 @@ public class KingfisherManager: @unchecked Sendable {
             }
             // When low data mode constrained error, retry with the low data mode source instead of use alternative on fly.
             guard !error.isLowDataModeConstrained else {
-                if let source = retrievingContext.options.lowDataModeSource {
-                    retrievingContext.options.lowDataModeSource = nil
+                if let source = retrievingContext.takeLowDataModeSource() {
                     startNewRetrieveTask(with: source, retryContext: retryContext, downloadTaskUpdated: downloadTaskUpdated)
                 } else {
                     // This should not happen.
@@ -1240,6 +1239,18 @@ class RetrievingContext<SourceType>: @unchecked Sendable {
             let nextSource = alternativeSources.removeFirst()
             _options.alternativeSources = alternativeSources
             return nextSource
+        }
+    }
+
+    func takeLowDataModeSource() -> Source? {
+        // Read and clear `lowDataModeSource` in a single critical section. Clearing it through the
+        // `options` accessor would be a get-modify-set of the whole options value, which can write
+        // back a stale snapshot and restore an alternative source that a concurrent
+        // `popAlternativeSource()` already consumed.
+        propertyQueue.sync {
+            guard let source = _options.lowDataModeSource else { return nil }
+            _options.lowDataModeSource = nil
+            return source
         }
     }
 

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -1218,7 +1218,11 @@ class RetrievingContext<SourceType>: @unchecked Sendable {
     }
 
     let originalSource: SourceType
-    var propagationErrors: [PropagationError] = []
+
+    private var _propagationErrors: [PropagationError] = []
+    var propagationErrors: [PropagationError] {
+        propertyQueue.sync { _propagationErrors }
+    }
 
     init(options: KingfisherParsedOptionsInfo, originalSource: SourceType) {
         self.originalSource = originalSource
@@ -1226,23 +1230,29 @@ class RetrievingContext<SourceType>: @unchecked Sendable {
     }
 
     func popAlternativeSource() -> Source? {
-        var localOptions = options
-        guard var alternativeSources = localOptions.alternativeSources, !alternativeSources.isEmpty else {
-            return nil
+        // Perform the read-modify-write atomically. Accessing `_options` directly (instead of the
+        // `options` accessor) keeps it within a single `propertyQueue.sync`, which both avoids a
+        // re-entrant deadlock and prevents two concurrent failovers from popping the same source.
+        propertyQueue.sync {
+            guard var alternativeSources = _options.alternativeSources, !alternativeSources.isEmpty else {
+                return nil
+            }
+            let nextSource = alternativeSources.removeFirst()
+            _options.alternativeSources = alternativeSources
+            return nextSource
         }
-        let nextSource = alternativeSources.removeFirst()
-        
-        localOptions.alternativeSources = alternativeSources
-        options = localOptions
-        
-        return nextSource
     }
 
     @discardableResult
     func appendError(_ error: KingfisherError, to source: Source) -> [PropagationError] {
+        // `appendError` is called from `@Sendable` download completion handlers, which may run on
+        // different threads across alternative-source failovers. Mutate the backing store under
+        // `propertyQueue`, matching how `_options` is protected on this `@unchecked Sendable` type.
         let item = PropagationError(source: source, error: error)
-        propagationErrors.append(item)
-        return propagationErrors
+        return propertyQueue.sync {
+            _propagationErrors.append(item)
+            return _propagationErrors
+        }
     }
 }
 

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1059,6 +1059,35 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertNil(context.popAlternativeSource())
     }
 
+    // Regression test for a data race on `RetrievingContext`. The type is `@unchecked Sendable`
+    // and protects `_options` with `propertyQueue`, but `propagationErrors` used to be an
+    // unsynchronized `var` that is appended from `@Sendable` download completion handlers across
+    // alternative-source failovers. Hammering `appendError` concurrently must record every append
+    // (and stay clean under Thread Sanitizer); the unsynchronized version loses updates and races.
+    func testContextAppendErrorIsThreadSafe() {
+        let info = KingfisherParsedOptionsInfo(nil)
+        let source = Source.network(URL(string: "https://example.com/a.png")!)
+        let context = RetrievingContext<Source>(options: info, originalSource: source)
+        let error = KingfisherError.requestError(reason: .emptyRequest)
+
+        let workers = 8
+        let perWorker = 250
+        let queue = DispatchQueue(label: "test.context.append", attributes: .concurrent)
+        let group = DispatchGroup()
+        for _ in 0..<workers {
+            group.enter()
+            queue.async {
+                for _ in 0..<perWorker {
+                    context.appendError(error, to: source)
+                    _ = context.propagationErrors
+                }
+                group.leave()
+            }
+        }
+        group.wait()
+        XCTAssertEqual(context.propagationErrors.count, workers * perWorker)
+    }
+
     func testRetrievingWithAlternativeSource() {
         let exp = expectation(description: #function)
         let url = testURLs[0]

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1088,6 +1088,104 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertEqual(context.propagationErrors.count, workers * perWorker)
     }
 
+    // Regression test for the atomicity of `popAlternativeSource()`. The pop is a read-modify-write
+    // of `_options.alternativeSources`; if it were only synchronized per access instead of as one
+    // critical section, two concurrent failovers could pop the same source. Concurrent pops must
+    // hand out every alternative exactly once and then run dry.
+    func testContextPopAlternativeSourceIsThreadSafe() {
+        let sourceCount = 1000
+        let allSources: [Source] = (0..<sourceCount).map {
+            .network(URL(string: "https://example.com/alt-\($0).png")!)
+        }
+        let info = KingfisherParsedOptionsInfo([.alternativeSources(allSources)])
+        let context = RetrievingContext<Source>(
+            options: info, originalSource: .network(URL(string: "https://example.com/original.png")!))
+
+        let workers = 8
+        let queue = DispatchQueue(label: "test.context.pop", attributes: .concurrent)
+        let resultQueue = DispatchQueue(label: "test.context.pop.results")
+        let group = DispatchGroup()
+        var popped: [String] = []
+        for _ in 0..<workers {
+            group.enter()
+            queue.async {
+                var local: [String] = []
+                while let source = context.popAlternativeSource() {
+                    local.append(source.url!.absoluteString)
+                }
+                resultQueue.sync { popped.append(contentsOf: local) }
+                group.leave()
+            }
+        }
+        group.wait()
+
+        XCTAssertEqual(popped.count, sourceCount)
+        XCTAssertEqual(Set(popped).count, sourceCount, "Each alternative source must be popped exactly once")
+        XCTAssertNil(context.popAlternativeSource())
+    }
+
+    // Regression test for the low-data-mode fallback racing with alternative-source failover.
+    // Clearing `lowDataModeSource` through the `options` accessor is a get-modify-set of the whole
+    // options value: it can write back a stale snapshot and restore an alternative source that a
+    // concurrent `popAlternativeSource()` already consumed, letting the same source be selected
+    // twice. `takeLowDataModeSource()` must read and clear within one critical section, so racing
+    // takes and pops still hand out the low data source and every alternative exactly once.
+    func testContextTakeLowDataModeSourceIsThreadSafe() {
+        let sourceCount = 500
+        let allSources: [Source] = (0..<sourceCount).map {
+            .network(URL(string: "https://example.com/alt-\($0).png")!)
+        }
+        let lowDataURL = URL(string: "https://example.com/low-data.png")!
+        let info = KingfisherParsedOptionsInfo([
+            .alternativeSources(allSources),
+            .lowDataMode(.network(lowDataURL))
+        ])
+        let context = RetrievingContext<Source>(
+            options: info, originalSource: .network(URL(string: "https://example.com/original.png")!))
+
+        let popWorkers = 4
+        let takeWorkers = 4
+        let takesPerWorker = 250
+        let queue = DispatchQueue(label: "test.context.take", attributes: .concurrent)
+        let resultQueue = DispatchQueue(label: "test.context.take.results")
+        let group = DispatchGroup()
+        var popped: [String] = []
+        var taken: [String] = []
+
+        for _ in 0..<popWorkers {
+            group.enter()
+            queue.async {
+                var local: [String] = []
+                while let source = context.popAlternativeSource() {
+                    local.append(source.url!.absoluteString)
+                }
+                resultQueue.sync { popped.append(contentsOf: local) }
+                group.leave()
+            }
+        }
+        for _ in 0..<takeWorkers {
+            group.enter()
+            queue.async {
+                var local: [String] = []
+                for _ in 0..<takesPerWorker {
+                    if let source = context.takeLowDataModeSource() {
+                        local.append(source.url!.absoluteString)
+                    }
+                }
+                resultQueue.sync { taken.append(contentsOf: local) }
+                group.leave()
+            }
+        }
+        group.wait()
+
+        XCTAssertEqual(popped.count, sourceCount)
+        XCTAssertEqual(Set(popped).count, sourceCount, "A popped alternative source must not be reintroduced")
+        XCTAssertEqual(taken, [lowDataURL.absoluteString], "The low data mode source must be taken exactly once")
+        XCTAssertNil(context.popAlternativeSource())
+        XCTAssertNil(context.takeLowDataModeSource())
+        XCTAssertNil(context.options.lowDataModeSource)
+    }
+
     func testRetrievingWithAlternativeSource() {
         let exp = expectation(description: #function)
         let url = testURLs[0]


### PR DESCRIPTION
## What

Fixes a data race on `RetrievingContext` (the per-request retrieval state in `KingfisherManager`).

`RetrievingContext` is `@unchecked Sendable` and deliberately guards its mutable `_options` with a serial `propertyQueue`:

```swift
private var _options: KingfisherParsedOptionsInfo
var options: KingfisherParsedOptionsInfo {
    get { propertyQueue.sync { _options } }
    set { propertyQueue.sync { _options = newValue } }
}
```

But `propagationErrors` was left as a plain, unsynchronized `var`:

```swift
var propagationErrors: [PropagationError] = []

@discardableResult
func appendError(_ error: KingfisherError, to source: Source) -> [PropagationError] {
    let item = PropagationError(source: source, error: error)
    propagationErrors.append(item)   // ← no synchronization
    return propagationErrors
}
```

`appendError(_:to:)` is called from `failCurrentSource` (`KingfisherManager.swift:359-390`), which runs inside `@Sendable` download completion handlers — i.e. on the downloader's callback queues. Across alternative-source failovers, successive handlers can run on different threads, and `failCurrentSource` also *reads* `propagationErrors`. Concurrent append/read on a Swift `Array` with no synchronization is a data race: Thread Sanitizer reports a **`Swift access race`**, and appends can be lost or crash.

## Fix

Route `propagationErrors` through the existing `propertyQueue`, exactly as `_options` already is. Also make `popAlternativeSource()` a single atomic read-modify-write under the queue — its previous "get via `options`, mutate, set via `options`" was synchronized per access but **not atomic**, so two concurrent failovers could pop the same alternative source.

```swift
private var _propagationErrors: [PropagationError] = []
var propagationErrors: [PropagationError] { propertyQueue.sync { _propagationErrors } }

func popAlternativeSource() -> Source? {
    propertyQueue.sync {
        guard var alternativeSources = _options.alternativeSources, !alternativeSources.isEmpty else { return nil }
        let nextSource = alternativeSources.removeFirst()
        _options.alternativeSources = alternativeSources
        return nextSource
    }
}

@discardableResult
func appendError(_ error: KingfisherError, to source: Source) -> [PropagationError] {
    let item = PropagationError(source: source, error: error)
    return propertyQueue.sync {
        _propagationErrors.append(item)
        return _propagationErrors
    }
}
```

No public API or behavior change — only synchronization. (Accessing `_options` directly inside `popAlternativeSource` keeps the whole RMW in one `propertyQueue.sync` and avoids a re-entrant deadlock.)

## Tests

`KingfisherManagerTests.testContextAppendErrorIsThreadSafe` hammers `appendError` from 8 concurrent workers (250 each) while reading `propagationErrors`, then asserts all 2000 appends were recorded.

## Verification (macOS, Thread Sanitizer)

```bash
xcodebuild test -project Kingfisher.xcodeproj -scheme Kingfisher \
  -destination 'platform=macOS' \
  -only-testing:KingfisherTests/KingfisherManagerTests/testContextAppendErrorIsThreadSafe \
  -enableThreadSanitizer YES
```

- **Before the fix:** `WARNING: ThreadSanitizer: Swift access race` → `** TEST FAILED **`.
- **After the fix:** passes with no sanitizer report; the existing `testContextRemovingAlternativeSource` still passes too.

## Why it matters

This is the same class of `@unchecked Sendable` hardening as the recent `fix-network-observer-cancel-race` / `fix-alternative-source-task-update-order` work, on the alternative-source failover path. The class already declares thread-safety intent via `propertyQueue`; this closes the two spots that were left out.


## CI

The full test + build matrix passes on my fork across **iOS, macOS, tvOS, and watchOS** (Xcode 26.2 and 26.5).