### PR TITLE
Fix CacheCallbackCoordinator race and out-of-order cache actions

### DIFF
--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -1279,38 +1279,54 @@ class CacheCallbackCoordinator: @unchecked Sendable {
     }
 
     func apply(_ action: Action, trigger: () -> Void) {
-        switch (state, action) {
-        case (.done, _):
-            break
+        // Resolve the whole transition atomically. The previous version read `state` (in the
+        // `switch`) and wrote it back through separate `stateQueue.sync` calls, so two concurrent
+        // `apply` calls could interleave between the read and the write — corrupting the state
+        // machine and either firing `trigger` twice or dropping it (a stuck `waitForCache`
+        // completion). `trigger()` is invoked after the queue is released so user code never runs
+        // while the queue is held.
+        let shouldTrigger = stateQueue.sync { () -> Bool in
+            switch (threadSafeState, action) {
+            case (.done, _):
+                return false
 
-        // From .idle
-        case (.idle, .cacheInitiated):
-            if !shouldWaitForCache {
-                state = .done
-                trigger()
+            // From .idle
+            case (.idle, .cacheInitiated):
+                guard !shouldWaitForCache else { return false }
+                threadSafeState = .done
+                return true
+            case (.idle, .cachingImage):
+                if shouldCacheOriginal {
+                    threadSafeState = .imageCached
+                    return false
+                } else {
+                    threadSafeState = .done
+                    return true
+                }
+            case (.idle, .cachingOriginalImage):
+                threadSafeState = .originalImageCached
+                return false
+
+            // One half is cached; the matching half completes the work.
+            case (.imageCached, .cachingOriginalImage), (.originalImageCached, .cachingImage):
+                threadSafeState = .done
+                return true
+
+            // A cache write can finish before the synchronous `.cacheInitiated` signal is applied,
+            // so `.cacheInitiated` may arrive in `.imageCached` / `.originalImageCached` rather than
+            // `.idle`. Treat it exactly like `(.idle, .cacheInitiated)` instead of trapping.
+            case (.imageCached, .cacheInitiated), (.originalImageCached, .cacheInitiated):
+                guard !shouldWaitForCache else { return false }
+                threadSafeState = .done
+                return true
+
+            default:
+                assertionFailure("This case should not happen in CacheCallbackCoordinator: \(threadSafeState) - \(action)")
+                return false
             }
-        case (.idle, .cachingImage):
-            if shouldCacheOriginal {
-                state = .imageCached
-            } else {
-                state = .done
-                trigger()
-            }
-        case (.idle, .cachingOriginalImage):
-            state = .originalImageCached
-
-        // From .imageCached
-        case (.imageCached, .cachingOriginalImage):
-            state = .done
+        }
+        if shouldTrigger {
             trigger()
-
-        // From .originalImageCached
-        case (.originalImageCached, .cachingImage):
-            state = .done
-            trigger()
-
-        default:
-            assertionFailure("This case should not happen in CacheCallbackCoordinator: \(state) - \(action)")
         }
     }
 }

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -1059,6 +1059,71 @@ class KingfisherManagerTests: XCTestCase {
         XCTAssertNil(context.popAlternativeSource())
     }
 
+    // MARK: - CacheCallbackCoordinator
+
+    // A cache write can complete before the synchronous `.cacheInitiated` action is applied (the
+    // store callbacks run on a different queue). The coordinator must tolerate `.cacheInitiated`
+    // arriving after `.cachingImage` / `.cachingOriginalImage` instead of trapping with the
+    // assertion "This case should not happen in CacheCallbackCoordinator: originalImageCached -
+    // cacheInitiated" that intermittently failed CI.
+    func testCacheCoordinatorToleratesLateCacheInitiated() {
+        for waitForCache in [true, false] {
+            let afterOriginal = CacheCallbackCoordinator(shouldWaitForCache: waitForCache, shouldCacheOriginal: true)
+            afterOriginal.apply(.cachingOriginalImage) {}
+            afterOriginal.apply(.cacheInitiated) {}   // must not trap
+
+            let afterImage = CacheCallbackCoordinator(shouldWaitForCache: waitForCache, shouldCacheOriginal: true)
+            afterImage.apply(.cachingImage) {}
+            afterImage.apply(.cacheInitiated) {}      // must not trap
+        }
+    }
+
+    // The completion (`trigger`) must fire exactly once, regardless of the order in which the three
+    // cache actions arrive.
+    func testCacheCoordinatorTriggersExactlyOnceForEveryOrdering() {
+        let orderings: [[CacheCallbackCoordinator.Action]] = [
+            [.cacheInitiated, .cachingImage, .cachingOriginalImage],
+            [.cacheInitiated, .cachingOriginalImage, .cachingImage],
+            [.cachingImage, .cacheInitiated, .cachingOriginalImage],
+            [.cachingImage, .cachingOriginalImage, .cacheInitiated],
+            [.cachingOriginalImage, .cacheInitiated, .cachingImage],
+            [.cachingOriginalImage, .cachingImage, .cacheInitiated],
+        ]
+        for waitForCache in [true, false] {
+            for order in orderings {
+                let coordinator = CacheCallbackCoordinator(shouldWaitForCache: waitForCache, shouldCacheOriginal: true)
+                var triggers = 0
+                for action in order {
+                    coordinator.apply(action) { triggers += 1 }
+                }
+                XCTAssertEqual(triggers, 1, "waitForCache=\(waitForCache), order=\(order)")
+            }
+        }
+    }
+
+    // Applying the actions concurrently must stay race-free and still fire the completion exactly
+    // once (the previous non-atomic read-then-write could double-fire or drop it).
+    func testCacheCoordinatorConcurrentActionsTriggerOnce() {
+        let lock = NSLock()
+        for _ in 0..<1000 {
+            let coordinator = CacheCallbackCoordinator(shouldWaitForCache: true, shouldCacheOriginal: true)
+            var triggers = 0
+            let group = DispatchGroup()
+            let actions: [CacheCallbackCoordinator.Action] = [.cacheInitiated, .cachingImage, .cachingOriginalImage]
+            for action in actions {
+                group.enter()
+                DispatchQueue.global().async {
+                    coordinator.apply(action) {
+                        lock.lock(); triggers += 1; lock.unlock()
+                    }
+                    group.leave()
+                }
+            }
+            group.wait()
+            XCTAssertEqual(triggers, 1)
+        }
+    }
+
     func testRetrievingWithAlternativeSource() {
         let exp = expectation(description: #function)
         let url = testURLs[0]


### PR DESCRIPTION
## What

Fixes a race and an intermittent assertion crash in `CacheCallbackCoordinator` — the cache-completion coordinator used by `KingfisherManager` when storing image + original image.

## Symptom

A flaky CI crash (Debug-only `assertionFailure`):

```
Fatal error: This case should not happen in CacheCallbackCoordinator:
originalImageCached - cacheInitiated   (KingfisherManager.swift)
```

## Two root causes

**1. Non-atomic transition.** `apply()` read `state` (in the `switch` tuple) and wrote it back via *separate* `stateQueue.sync` calls:

```swift
func apply(_ action: Action, trigger: () -> Void) {
    switch (state, action) {                 // sync read
    …
    case (.imageCached, .cachingOriginalImage):
        state = .done                        // sync write — different critical section
        trigger()
    …
    }
}
```

Two `apply` calls (the `.cachingImage` and `.cachingOriginalImage` store callbacks run on different threads) can interleave *between* the read and the write — corrupting the state machine and either firing `trigger` twice (double completion) or never (a stuck `waitForCache` completion).

**2. Out-of-order actions.** The three actions are produced from different queues:

```swift
targetCache.store(…)      { coordinator.apply(.cachingImage)         { … } }  // async callback
originalCache.storeToDisk { coordinator.apply(.cachingOriginalImage) { … } }  // async callback
coordinator.apply(.cacheInitiated) { … }                                      // synchronous
```

If a store finishes before the synchronous `.cacheInitiated` is applied, `.cacheInitiated` arrives in `.imageCached` / `.originalImageCached` instead of `.idle`. The state machine had no case for that and hit `default → assertionFailure` (the CI crash). It's intermittent because it depends on store-vs-`cacheInitiated` timing.

## Fix

- Resolve the entire transition inside **one** `stateQueue.sync`, returning whether to fire, and call `trigger()` **after** the queue is released (so user code never runs while the queue is held). This makes each transition atomic and guarantees `trigger` fires exactly once.
- Handle `(.imageCached, .cacheInitiated)` / `(.originalImageCached, .cacheInitiated)` identically to `(.idle, .cacheInitiated)` instead of trapping. The `default → assertionFailure` is kept as a safety net for genuinely-unreachable duplicate actions.

No public API or behavior change for the in-order path; the completion semantics are unchanged.

## Tests (`KingfisherManagerTests`)

- `testCacheCoordinatorToleratesLateCacheInitiated` — deterministic reproduction of the CI crash (`.cachingOriginalImage` / `.cachingImage` then `.cacheInitiated`).
- `testCacheCoordinatorTriggersExactlyOnceForEveryOrdering` — all 6 action orderings × `waitForCache`, completion must fire exactly once.
- `testCacheCoordinatorConcurrentActionsTriggerOnce` — applies the actions concurrently 1000×, asserts exactly one trigger and stays clean under TSan.

## Verification (macOS, Thread Sanitizer)

```bash
xcodebuild test -project Kingfisher.xcodeproj -scheme Kingfisher \
  -destination 'platform=macOS' \
  -only-testing:KingfisherTests/KingfisherManagerTests/testCacheCoordinatorToleratesLateCacheInitiated \
  -only-testing:KingfisherTests/KingfisherManagerTests/testCacheCoordinatorTriggersExactlyOnceForEveryOrdering \
  -only-testing:KingfisherTests/KingfisherManagerTests/testCacheCoordinatorConcurrentActionsTriggerOnce \
  -enableThreadSanitizer YES
```

- **Before the fix:** `testCacheCoordinatorToleratesLateCacheInitiated` crashes with `Fatal error: … originalImageCached - cacheInitiated` → `** TEST FAILED **` (the exact CI failure).
- **After the fix:** all three pass, no sanitizer report → `** TEST SUCCEEDED **`.

## Why it matters

This is the intermittent failure behind the "originalImageCached - cacheInitiated" crash that flakes CI. Beyond the Debug assertion, the non-atomic transition can drop a `waitForCache` completion in Release builds — a silently never-firing callback — which is a plausible contributor to hard-to-reproduce hang reports.


## CI

The full test + build matrix passes on my fork across **iOS, macOS, tvOS, and watchOS** (Xcode 26.2 and 26.5).