### PR TITLE
Avoid generic Data initializer when copying mutableData (iOS 26 crash, #2543)

### DIFF
--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -45,7 +45,19 @@ public class SessionDataTask: @unchecked Sendable {
     public var mutableData: Data {
         lock.lock()
         defer { lock.unlock() }
-        return Data(_mutableData)
+        // Return a standalone copy that does not share copy-on-write storage with `_mutableData`
+        // (the intent of #2524) — but build it WITHOUT `Data(_mutableData)`. Because `Data` is a
+        // `Sequence<UInt8>`, `Data(_mutableData)` resolves to the generic `Data.init<S: Sequence>(_:)`,
+        // which on iOS 26.x can trap inside `__DataStorage.init(bytes:length:)` while copying data that
+        // was accumulated through many `append`s (issue #2543). Allocating the destination up front and
+        // copying the bytes in goes through a different, stable path.
+        let count = _mutableData.count
+        guard count > 0 else { return Data() }
+        var copy = Data(count: count)
+        copy.withUnsafeMutableBytes { destination in
+            _ = _mutableData.copyBytes(to: destination)
+        }
+        return copy
     }
 
     var mutableDataCount: Int {

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -125,6 +125,30 @@ class ImageDownloaderTests: XCTestCase {
         waitForExpectations(timeout: 5, handler: nil)
     }
     
+    // Verifies the `mutableData` getter (issue #2543): it returns the accumulated bytes correctly and
+    // as an independent copy — appending more data afterward must not mutate a previously returned
+    // value (the copy-on-write isolation introduced by #2524) — without using the generic `Data(_:)`
+    // sequence initializer that traps on iOS 26.x.
+    func testSessionDataTaskMutableDataIsCorrectIndependentCopy() {
+        let url = URL(string: "https://example.com/mutable-data")!
+        let task = SessionDataTask(task: URLSession.shared.dataTask(with: url))
+
+        XCTAssertEqual(task.mutableData, Data())
+        XCTAssertEqual(task.mutableDataCount, 0)
+
+        task.didReceiveData(Data([1, 2, 3]))
+        task.didReceiveData(Data([4, 5, 6, 7]))
+
+        let snapshot = task.mutableData
+        XCTAssertEqual(snapshot, Data([1, 2, 3, 4, 5, 6, 7]))
+        XCTAssertEqual(task.mutableDataCount, 7)
+
+        // Appending after reading must not mutate the previously returned copy.
+        task.didReceiveData(Data([8, 9]))
+        XCTAssertEqual(snapshot, Data([1, 2, 3, 4, 5, 6, 7]), "previously returned data must be an independent copy")
+        XCTAssertEqual(task.mutableData, Data([1, 2, 3, 4, 5, 6, 7, 8, 9]))
+    }
+
     func testDownloadWithModifyingRequest() {
         let exp = expectation(description: #function)
 


### PR DESCRIPTION
Candidate fix for #2543.

## Root cause

`SessionDataTask.mutableData` (after #2524) returns a defensive copy via `Data(_mutableData)`:

```swift
public var mutableData: Data {
    lock.lock()
    defer { lock.unlock() }
    return Data(_mutableData)   // SessionDataTask.swift
}
```

Because `Data` is a `Sequence<UInt8>`, `Data(_mutableData)` resolves to the **generic** `Data.init<S: Sequence>(_:)` initializer — visible in the crash stack from #2543:

```
0  Foundation  __DataStorage.init(bytes:length:) + 300
2  App         closure #1 in Data.init<A>(_:)            ← generic Sequence init
3  App         SessionDataTask.swift:48                  ← mutableData getter
...
6  App         SessionDelegate.urlSession(_:task:didCompleteWithError:)
```

On iOS 26.x that generic initializer can trap (`EXC_BREAKPOINT`) inside `__DataStorage.init(bytes:length:)` while copying a `Data` that was accumulated through many `append`s. This is the new crash #2524 introduced (the report distinguishes it from the older append-side crash, which is untouched here).

## Fix

Build the standalone copy without the generic sequence initializer: allocate the destination up front with `Data(count:)` and copy the bytes in with `copyBytes(to:)`.

```swift
let count = _mutableData.count
guard count > 0 else { return Data() }
var copy = Data(count: count)
copy.withUnsafeMutableBytes { destination in
    _ = _mutableData.copyBytes(to: destination)
}
return copy
```

This goes through a different, stable path (`Data(count:)` zero-fill allocation + `memcpy`) and keeps the copy independent of `_mutableData`, preserving the copy-on-write isolation #2524 intended.

## Tests

`testSessionDataTaskMutableDataIsCorrectIndependentCopy` asserts `mutableData` returns the correct accumulated bytes and that a previously returned value is unaffected by later appends. The existing `testDownloadedDataCouldBeModified[WithTask]` (which read `mutableData` through the delegate path) still pass.

## ⚠️ Verification status — please read

I could **not reproduce the crash** — it is iOS 26.5-only and I don't have that environment. This change is a *reasoned route-around* of the generic initializer that appears in the report's stack trace; it is verified only for **functional correctness and copy-independence on macOS**, not against the actual iOS-26.5 trap.

The reporter offered to validate a candidate fix against production traffic — that confirmation should gate merge. To test, point the dependency at this branch:

```swift
.package(url: "https://github.com/devzahirul/Kingfisher.git", branch: "fix/mutabledata-ios26-copy")
```

Scoped to crash **B** (the copy site) from the report; the pre-existing append-side crash **A** is a separate issue and not addressed here.
