### PR TITLE
Avoid full-size Data copies on internal download data reads

### DIFF
--- a/Sources/Image/ImageProgressive.swift
+++ b/Sources/Image/ImageProgressive.swift
@@ -124,7 +124,7 @@ final class ImageProgressiveProvider: DataReceivingSideEffect, @unchecked Sendab
 
         DispatchQueue.main.async {
             guard self.onShouldApply() else { return }
-            self.update(data: task.mutableData, with: task.callbacks)
+            self.update(data: task.sharedData, with: task.callbacks)
         }
     }
 

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -342,7 +342,7 @@ open class ImageDownloader: @unchecked Sendable {
             }
         }
         sessionDelegate.onDidDownloadData.delegate(on: self) { (self, task) in
-            (self.delegate ?? self).imageDownloader(self, didDownload: task.mutableData, with: task)
+            (self.delegate ?? self).imageDownloader(self, didDownload: task.sharedData, with: task)
         }
     }
 

--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -54,6 +54,17 @@ public class SessionDataTask: @unchecked Sendable {
         return _mutableData.count
     }
 
+    // Zero-copy access to the accumulated data for internal use. Unlike `mutableData`, this shares
+    // the storage of `_mutableData` through copy-on-write instead of allocating a full-size copy.
+    // That allocation can trap (`EXC_BREAKPOINT` in `__DataStorage`) on memory-constrained devices
+    // when the downloaded data is large (#2543). Sharing is safe: a later `didReceiveData` append
+    // copies on write and never mutates the storage a previously returned value sees.
+    var sharedData: Data {
+        lock.lock()
+        defer { lock.unlock() }
+        return _mutableData
+    }
+
     // This is a copy of `task.originalRequest?.url`. It is for obtaining race-safe behavior for a pitfall on iOS 13.
     // Ref: https://github.com/onevcat/Kingfisher/issues/1511
     public let originalURL: URL?

--- a/Tests/KingfisherTests/DataReceivingSideEffectTests.swift
+++ b/Tests/KingfisherTests/DataReceivingSideEffectTests.swift
@@ -50,6 +50,29 @@ class DataReceivingSideEffectTests: XCTestCase {
         )
     }
 
+    func testSessionDataTaskSharedDataIsZeroCopyAndUnaffectedByLaterAppends() {
+        let url = URL(string: "https://example.com/image.png")!
+        let urlTask = URLSession(configuration: .ephemeral).dataTask(with: url)
+        let task = SessionDataTask(task: urlTask)
+
+        let received = Data(repeating: 0x22, count: 1024 * 1024)
+        task.didReceiveData(received)
+
+        // Zero-copy: repeated reads share the internal COW storage instead of allocating copies.
+        let first = task.sharedData
+        let second = task.sharedData
+        XCTAssertEqual(
+            storageAddress(of: first),
+            storageAddress(of: second),
+            "sharedData should share the internal COW storage without allocating a copy."
+        )
+
+        // COW safety: a later append must not mutate a previously returned value.
+        task.didReceiveData(Data([0x33]))
+        XCTAssertEqual(first, received)
+        XCTAssertEqual(task.sharedData.count, received.count + 1)
+    }
+
     private func storageAddress(of data: Data) -> UInt {
         data.withUnsafeBytes { buffer in
             UInt(bitPattern: buffer.baseAddress!)


### PR DESCRIPTION
## Summary

- Add an internal zero-copy accessor `SessionDataTask.sharedData` that returns the accumulated download data as a COW share instead of allocating a full-size copy.
- Use it on the two internal read paths: the download completion handler in `ImageDownloader.setupSessionHandler()`, and progressive decoding in `ImageProgressiveProvider.onDataReceived`.
- The public `mutableData` getter keeps the independent-snapshot semantics introduced in #2524. No public API change.

Fixes #2543.

## Root cause of #2543

The crash is an allocation failure (OOM-class), not a data race and not an iOS 26 bug in the generic `Data` initializer:

- `Data(_mutableData)` (introduced in #2524) allocates a buffer as large as the downloaded data on every completed download, momentarily doubling the memory held for that download. On the progressive decoding path it did so once per received chunk.
- When such an allocation fails on a memory-constrained device, Foundation does not report an error — it traps: `EXC_BREAKPOINT` in `__DataStorage`.

This was reproduced deterministically on macOS 26.5 (same-generation Foundation as iOS 26.5) by fault-injecting the allocator (a DYLD-interposed `malloc` failing requests >= 100 MB) while downloading a 120 MB blob through `ImageDownloader`:

- Trap on thread queue `com.apple.NSURLSession-delegate`, frame 0 `__DataStorage.init(bytes:length:) + 300` — identical to the report in #2543, including the symbol offset.
- The append-side crash (issue A in the report, observed since #1811 in 2021) is the same failure family on the buffer-growth path; under the same injection it produces `Foundation/Data.swift:353: Fatal error: unable to allocate memory for length (N)`.

Sharing the buffer on the internal paths is safe: completion happens after the last `didReceiveData` for the task, and `Data`'s copy-on-write guarantees a later append can never mutate storage seen by a previously returned value. This removes the avoidable full-size allocation at completion and restores zero-copy reads for progressive decoding.

Note: if a device genuinely cannot allocate buffers of the image's size while data accumulates, the append-side trap can still occur — no library change can prevent that. This change removes the extra copies Kingfisher itself added on top of the baseline requirement.

## Tests

- New: `DataReceivingSideEffectTests.testSessionDataTaskSharedDataIsZeroCopyAndUnaffectedByLaterAppends` pins the zero-copy behavior (identical storage address across reads) and COW safety (later appends do not affect a previously returned value).
- Existing `testSessionDataTaskMutableDataGetterDoesNotShareStorage` continues to pin the public getter's snapshot semantics.
- Full macOS suite passes (664 tests).
- End-to-end fault-injection harness: on `master`, the process traps exactly as reported in #2543; with this change, the download completes and the non-image payload fails decoding gracefully with a `KingfisherError`.
