### PR TITLE
Avoid empty KFImage layout before image loads

### DIFF
--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		38D5D4A12C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D5D4A22C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift */; };
 		3ADE9AF92A73CD69009A86CA /* String+SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADE9AF82A73CD69009A86CA /* String+SHA256.swift */; };
 		4B0C35B22FFF5F4C00BBDEA1 /* KFImageRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B0C35B12FFF5F4C00BBDEA1 /* KFImageRendererTests.swift */; };
+		4B0C57F03008A31100BBDEA1 /* ImageBinderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B0C57EF3008A30A00BBDEA1 /* ImageBinderTests.swift */; };
 		4B10480D216F157000300C61 /* ImageDataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B10480C216F157000300C61 /* ImageDataProcessor.swift */; };
 		4B46CC5F217449C600D90C4A /* MemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B46CC5E217449C600D90C4A /* MemoryStorage.swift */; };
 		4B46CC64217449E000D90C4A /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B46CC63217449E000D90C4A /* Storage.swift */; };
@@ -192,6 +193,7 @@
 		38D5D4A22C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDataProviderCancellationTests.swift; sourceTree = "<group>"; };
 		3ADE9AF82A73CD69009A86CA /* String+SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SHA256.swift"; sourceTree = "<group>"; };
 		4B0C35B12FFF5F4C00BBDEA1 /* KFImageRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KFImageRendererTests.swift; sourceTree = "<group>"; };
+		4B0C57EF3008A30A00BBDEA1 /* ImageBinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageBinderTests.swift; sourceTree = "<group>"; };
 		4B10480C216F157000300C61 /* ImageDataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDataProcessor.swift; sourceTree = "<group>"; };
 		4B164ACE1B8D554200768EC6 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		4B3E714D1B01FEB200F5AAED /* WatchKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchKit.framework; path = System/Library/Frameworks/WatchKit.framework; sourceTree = SDKROOT; };
@@ -535,6 +537,7 @@
 				D12E0C491C47F23500AC98AD /* Info.plist */,
 				D12E0C441C47F23500AC98AD /* dancing-banana.gif */,
 				D1D2C3291C70A3230018F2F9 /* single-frame.gif */,
+				4B0C57EF3008A30A00BBDEA1 /* ImageBinderTests.swift */,
 				D12E0C451C47F23500AC98AD /* ImageCacheTests.swift */,
 				D1DC4B401D60996D00DFDFAA /* StringExtensionTests.swift */,
 				D12E0C461C47F23500AC98AD /* ImageDownloaderTests.swift */,
@@ -1022,6 +1025,7 @@
 				D16FEA4D23078C63006E67D5 /* LSMatcher.m in Sources */,
 				4B8351C8217066580081EED8 /* StubHelpers.swift in Sources */,
 				D1F1F6FF24625EC600910725 /* RetryStrategyTests.swift in Sources */,
+				4B0C57F03008A31100BBDEA1 /* ImageBinderTests.swift in Sources */,
 				D1DC4B411D60996D00DFDFAA /* StringExtensionTests.swift in Sources */,
 				D1BFED95222ACC6B009330C8 /* ImageProcessorTests.swift in Sources */,
 				D16FEA5223078C63006E67D5 /* LSHTTPRequestDSLRepresentation.m in Sources */,

--- a/Kingfisher.xcodeproj/project.pbxproj
+++ b/Kingfisher.xcodeproj/project.pbxproj
@@ -17,18 +17,18 @@
 		2F6023D252BE169414B01D8B /* CancellationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FAE088D96F2BF3FACCBD355 /* CancellationToken.swift */; };
 		388F37382B4D9CDB0089705C /* DisplayLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388F37372B4D9CDB0089705C /* DisplayLink.swift */; };
 		38D5D3A32C5C757E00BF1D01 /* PixelFormatDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D5D3A42C5C757E00BF1D01 /* PixelFormatDecodingTests.swift */; };
-		38D5D4A12C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D5D4A22C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift */; };
 		38D5D3C12C5C7A1800BF1D01 /* gradient-8b-srgb-opaque.png in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3AC2C5C784700BF1D01 /* gradient-8b-srgb-opaque.png */; };
 		38D5D3C22C5C7A1800BF1D01 /* gradient-8b-srgb-alpha.png in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3AD2C5C784700BF1D01 /* gradient-8b-srgb-alpha.png */; };
 		38D5D3C32C5C7A1800BF1D01 /* gradient-8b-displayp3-alpha.png in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3AE2C5C784700BF1D01 /* gradient-8b-displayp3-alpha.png */; };
 		38D5D3C42C5C7A1800BF1D01 /* gradient-8b-gray.png in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3AF2C5C784700BF1D01 /* gradient-8b-gray.png */; };
-		6F62C780F5433101ADA3A9E4 /* gradient-8b-indexed.png in Resources */ = {isa = PBXBuildFile; fileRef = 5B961EF75D5B87CED8EF5951 /* gradient-8b-indexed.png */; };
 		38D5D3C52C5C7A1800BF1D01 /* gradient-10b-srgb-opaque.heic in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3B02C5C784700BF1D01 /* gradient-10b-srgb-opaque.heic */; };
 		38D5D3C62C5C7A1800BF1D01 /* gradient-10b-srgb-alpha.heic in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3B12C5C784700BF1D01 /* gradient-10b-srgb-alpha.heic */; };
 		38D5D3C72C5C7A1800BF1D01 /* gradient-10b-displayp3-alpha.heic in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3B22C5C784700BF1D01 /* gradient-10b-displayp3-alpha.heic */; };
 		38D5D3C82C5C7A1800BF1D01 /* gradient-16b-srgb-alpha.png in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3B32C5C784700BF1D01 /* gradient-16b-srgb-alpha.png */; };
 		38D5D3C92C5C7A1800BF1D01 /* gradient-16b-gray.png in Resources */ = {isa = PBXBuildFile; fileRef = 38D5D3B42C5C784700BF1D01 /* gradient-16b-gray.png */; };
+		38D5D4A12C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D5D4A22C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift */; };
 		3ADE9AF92A73CD69009A86CA /* String+SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ADE9AF82A73CD69009A86CA /* String+SHA256.swift */; };
+		4B0C35B22FFF5F4C00BBDEA1 /* KFImageRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B0C35B12FFF5F4C00BBDEA1 /* KFImageRendererTests.swift */; };
 		4B10480D216F157000300C61 /* ImageDataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B10480C216F157000300C61 /* ImageDataProcessor.swift */; };
 		4B46CC5F217449C600D90C4A /* MemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B46CC5E217449C600D90C4A /* MemoryStorage.swift */; };
 		4B46CC64217449E000D90C4A /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B46CC63217449E000D90C4A /* Storage.swift */; };
@@ -46,6 +46,7 @@
 		4BD821622189FC0C0084CC21 /* SessionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD821612189FC0C0084CC21 /* SessionDelegate.swift */; };
 		4BD821672189FD330084CC21 /* SessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BD821662189FD330084CC21 /* SessionDataTask.swift */; };
 		4BE688F722FD513100B11168 /* NSButton+Kingfisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12AB6AD215D2BB50013BA68 /* NSButton+Kingfisher.swift */; };
+		6F62C780F5433101ADA3A9E4 /* gradient-8b-indexed.png in Resources */ = {isa = PBXBuildFile; fileRef = 5B961EF75D5B87CED8EF5951 /* gradient-8b-indexed.png */; };
 		76FB4FD2262D773E006D15F8 /* GraphicsContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76FB4FD1262D773E006D15F8 /* GraphicsContext.swift */; };
 		C9286407228584EB00257182 /* ImageProgressive.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9286406228584EB00257182 /* ImageProgressive.swift */; };
 		D1132C9725919F69003E528D /* KFOptionsSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1132C9625919F69003E528D /* KFOptionsSetter.swift */; };
@@ -179,18 +180,18 @@
 		22FDCE0D2700078B0044D11E /* CPListItem+Kingfisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CPListItem+Kingfisher.swift"; sourceTree = "<group>"; };
 		388F37372B4D9CDB0089705C /* DisplayLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayLink.swift; sourceTree = "<group>"; };
 		38D5D3A42C5C757E00BF1D01 /* PixelFormatDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PixelFormatDecodingTests.swift; sourceTree = "<group>"; };
-		38D5D4A22C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDataProviderCancellationTests.swift; sourceTree = "<group>"; };
 		38D5D3AC2C5C784700BF1D01 /* gradient-8b-srgb-opaque.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gradient-8b-srgb-opaque.png"; sourceTree = "<group>"; };
 		38D5D3AD2C5C784700BF1D01 /* gradient-8b-srgb-alpha.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gradient-8b-srgb-alpha.png"; sourceTree = "<group>"; };
 		38D5D3AE2C5C784700BF1D01 /* gradient-8b-displayp3-alpha.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gradient-8b-displayp3-alpha.png"; sourceTree = "<group>"; };
 		38D5D3AF2C5C784700BF1D01 /* gradient-8b-gray.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gradient-8b-gray.png"; sourceTree = "<group>"; };
-		5B961EF75D5B87CED8EF5951 /* gradient-8b-indexed.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gradient-8b-indexed.png"; sourceTree = "<group>"; };
 		38D5D3B02C5C784700BF1D01 /* gradient-10b-srgb-opaque.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = "gradient-10b-srgb-opaque.heic"; sourceTree = "<group>"; };
 		38D5D3B12C5C784700BF1D01 /* gradient-10b-srgb-alpha.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = "gradient-10b-srgb-alpha.heic"; sourceTree = "<group>"; };
 		38D5D3B22C5C784700BF1D01 /* gradient-10b-displayp3-alpha.heic */ = {isa = PBXFileReference; lastKnownFileType = file; path = "gradient-10b-displayp3-alpha.heic"; sourceTree = "<group>"; };
 		38D5D3B32C5C784700BF1D01 /* gradient-16b-srgb-alpha.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gradient-16b-srgb-alpha.png"; sourceTree = "<group>"; };
 		38D5D3B42C5C784700BF1D01 /* gradient-16b-gray.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gradient-16b-gray.png"; sourceTree = "<group>"; };
+		38D5D4A22C5C757E00BF1D01 /* ImageDataProviderCancellationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDataProviderCancellationTests.swift; sourceTree = "<group>"; };
 		3ADE9AF82A73CD69009A86CA /* String+SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+SHA256.swift"; sourceTree = "<group>"; };
+		4B0C35B12FFF5F4C00BBDEA1 /* KFImageRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KFImageRendererTests.swift; sourceTree = "<group>"; };
 		4B10480C216F157000300C61 /* ImageDataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDataProcessor.swift; sourceTree = "<group>"; };
 		4B164ACE1B8D554200768EC6 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
 		4B3E714D1B01FEB200F5AAED /* WatchKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WatchKit.framework; path = System/Library/Frameworks/WatchKit.framework; sourceTree = SDKROOT; };
@@ -210,6 +211,7 @@
 		4BD821612189FC0C0084CC21 /* SessionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDelegate.swift; sourceTree = "<group>"; };
 		4BD821662189FD330084CC21 /* SessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDataTask.swift; sourceTree = "<group>"; };
 		4DA09A43E8598D4EE9ED451C /* StaleCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StaleCacheTests.swift; sourceTree = "<group>"; };
+		5B961EF75D5B87CED8EF5951 /* gradient-8b-indexed.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "gradient-8b-indexed.png"; sourceTree = "<group>"; };
 		71F41758E54372A0704BA440 /* StaleCacheTestHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StaleCacheTestHelpers.swift; sourceTree = "<group>"; };
 		76FB4FD1262D773E006D15F8 /* GraphicsContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphicsContext.swift; sourceTree = "<group>"; };
 		C9286406228584EB00257182 /* ImageProgressive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProgressive.swift; sourceTree = "<group>"; };
@@ -542,6 +544,7 @@
 				D186696C21834261002B502E /* ImageDrawingTests.swift */,
 				D9638BA41C7DC71F0046523D /* ImagePrefetcherTests.swift */,
 				D12E0C481C47F23500AC98AD /* ImageViewExtensionTests.swift */,
+				4B0C35B12FFF5F4C00BBDEA1 /* KFImageRendererTests.swift */,
 				D12E0C4A1C47F23500AC98AD /* KingfisherManagerTests.swift */,
 				D12E0C4B1C47F23500AC98AD /* KingfisherOptionsInfoTests.swift */,
 				D12E0C4C1C47F23500AC98AD /* KingfisherTestHelper.swift */,
@@ -1000,6 +1003,7 @@
 				D16FEA5023078C63006E67D5 /* NSString+Nocilla.m in Sources */,
 				D16FEA4E23078C63006E67D5 /* LSRegexMatcher.m in Sources */,
 				F72CE9CE1FCF17ED00CC522A /* ImageModifierTests.swift in Sources */,
+				4B0C35B22FFF5F4C00BBDEA1 /* KFImageRendererTests.swift in Sources */,
 				D1F66CC12CB2CF2E004959F3 /* LivePhotoSourceTests.swift in Sources */,
 				D12E0C531C47F23500AC98AD /* ImageViewExtensionTests.swift in Sources */,
 				D16FEA4023078C63006E67D5 /* LSHTTPClientHook.m in Sources */,

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -122,6 +122,7 @@ extension KFImage {
                                             self.markLoaded(sendChangeEvent: true)
                                         }
                                         self.animating = false
+                                        context.onSuccessDelegate.call(value)
                                     }
                                 } else if let fadeDuration = context.fadeTransitionDuration(cacheType: value.cacheType) {
                                     self.animating = true
@@ -134,15 +135,16 @@ extension KFImage {
                                             self.markLoaded(sendChangeEvent: true)
                                         }
                                         self.animating = false
+                                        context.onSuccessDelegate.call(value)
                                     }
                                 } else {
                                     self.markLoaded(sendChangeEvent: false)
                                     self.loadedImage = value.image
-                                }
-                            }
 
-                            CallbackQueueMain.async {
-                                context.onSuccessDelegate.call(value)
+                                    CallbackQueueMain.async {
+                                        context.onSuccessDelegate.call(value)
+                                    }
+                                }
                             }
                         case .failure(let error):
                             CallbackQueueMain.currentOrAsync {

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -114,22 +114,31 @@ extension KFImage {
                                    context.shouldApplyFade(cacheType: value.cacheType) {
                                     // Apply SwiftUI loadTransition with custom animation (higher priority than fade)
                                     self.animating = true
+                                    self.loadedImage = value.image
+
                                     let animation = context.swiftUIAnimation ?? .default
-                                    withAnimation(animation) {
-                                        self.markLoaded(sendChangeEvent: true)
+                                    CallbackQueueMain.async {
+                                        withAnimation(animation) {
+                                            self.markLoaded(sendChangeEvent: true)
+                                        }
+                                        self.animating = false
                                     }
                                 } else if let fadeDuration = context.fadeTransitionDuration(cacheType: value.cacheType) {
                                     self.animating = true
+                                    self.loadedImage = value.image
+
                                     let animation = Animation.linear(duration: fadeDuration)
-                                    withAnimation(animation) {
-                                        // Trigger the view render to apply the animation.
-                                        self.markLoaded(sendChangeEvent: true)
+                                    CallbackQueueMain.async {
+                                        withAnimation(animation) {
+                                            // Trigger the view render to apply the animation.
+                                            self.markLoaded(sendChangeEvent: true)
+                                        }
+                                        self.animating = false
                                     }
                                 } else {
                                     self.markLoaded(sendChangeEvent: false)
+                                    self.loadedImage = value.image
                                 }
-                                self.loadedImage = value.image
-                                self.animating = false
                             }
 
                             CallbackQueueMain.async {

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -36,6 +36,15 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
     @StateObject var binder: KFImage.ImageBinder = .init()
     let context: KFImage.Context<HoldingView>
     
+    init(context: KFImage.Context<HoldingView>) {
+        self.init(context: context, binder: .init())
+    }
+
+    init(context: KFImage.Context<HoldingView>, binder: KFImage.ImageBinder) {
+        _binder = StateObject(wrappedValue: binder)
+        self.context = context
+    }
+
     var body: some View {
         if context.startLoadingBeforeViewAppear && !binder.loadingOrSucceeded && !binder.animating {
             binder.markLoading()
@@ -54,7 +63,7 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
                     .opacity(binder.loaded ? 1.0 : 0.0)
                     .frame(width: binder.loadedImage == nil ? 0 : nil, height: binder.loadedImage == nil ? 0 : nil)
             }
-            if binder.loadedImage == nil {
+            if binder.loadedImage == nil || !binder.loaded {
                 ZStack {
                     // Priority: failureView > placeholder > Color.clear
                     // failureView is only set when image loading fails

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -43,18 +43,18 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
         }
         
         return ZStack {
-            if binder.loadedImage != nil {
-                if context.swiftUITransition != nil {
-                    // SwiftUI loadTransition: insert/remove view for proper transition behavior
-                    if binder.loaded {
-                        renderedImage()
-                    }
-                } else {
-                    // Fade transition or no transition: use opacity control
+            if context.swiftUITransition != nil {
+                // SwiftUI loadTransition: insert/remove view for proper transition behavior
+                if binder.loaded {
                     renderedImage()
-                        .opacity(binder.loaded ? 1.0 : 0.0)
                 }
             } else {
+                // Fade transition or no transition: use opacity control
+                renderedImage()
+                    .opacity(binder.loaded ? 1.0 : 0.0)
+                    .frame(width: binder.loadedImage == nil ? 0 : nil, height: binder.loadedImage == nil ? 0 : nil)
+            }
+            if binder.loadedImage == nil {
                 ZStack {
                     // Priority: failureView > placeholder > Color.clear
                     // failureView is only set when image loading fails

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -43,17 +43,18 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
         }
         
         return ZStack {
-            if context.swiftUITransition != nil {
-                // SwiftUI loadTransition: insert/remove view for proper transition behavior
-                if binder.loaded {
+            if binder.loadedImage != nil {
+                if context.swiftUITransition != nil {
+                    // SwiftUI loadTransition: insert/remove view for proper transition behavior
+                    if binder.loaded {
+                        renderedImage()
+                    }
+                } else {
+                    // Fade transition or no transition: use opacity control
                     renderedImage()
+                        .opacity(binder.loaded ? 1.0 : 0.0)
                 }
             } else {
-                // Fade transition or no transition: use opacity control
-                renderedImage()
-                    .opacity(binder.loaded ? 1.0 : 0.0)
-            }
-            if binder.loadedImage == nil {
                 ZStack {
                     // Priority: failureView > placeholder > Color.clear
                     // failureView is only set when image loading fails

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -52,18 +52,20 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
         }
         
         return ZStack {
-            if context.swiftUITransition != nil {
-                // SwiftUI loadTransition: insert/remove view for proper transition behavior
-                if binder.loaded {
-                    renderedImage()
-                }
-            } else {
+            let isImageRenderable = binder.loadedImage != nil && binder.loaded
+
+            if context.swiftUITransition == nil {
                 // Fade transition or no transition: use opacity control
+                // Keep the image branch for external transitions without affecting layout until it is renderable.
                 renderedImage()
-                    .opacity(binder.loaded ? 1.0 : 0.0)
-                    .frame(width: binder.loadedImage == nil ? 0 : nil, height: binder.loadedImage == nil ? 0 : nil)
+                    .opacity(isImageRenderable ? 1.0 : 0.0)
+                    .frame(width: isImageRenderable ? nil : 0, height: isImageRenderable ? nil : 0)
+            } else if isImageRenderable {
+                // SwiftUI loadTransition: insert/remove view for proper transition behavior
+                renderedImage()
             }
-            if binder.loadedImage == nil || !binder.loaded {
+
+            if !isImageRenderable {
                 ZStack {
                     // Priority: failureView > placeholder > Color.clear
                     // failureView is only set when image loading fails

--- a/Tests/KingfisherTests/ImageBinderTests.swift
+++ b/Tests/KingfisherTests/ImageBinderTests.swift
@@ -1,0 +1,95 @@
+//
+//  ImageBinderTests.swift
+//  Kingfisher
+//
+//  Created by kjy on 7/16/26.
+//
+//  Copyright (c) 2026 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+#if canImport(SwiftUI) && canImport(UIKit) && (os(iOS) || os(tvOS))
+
+import SwiftUI
+import UIKit
+import XCTest
+@testable import Kingfisher
+
+@available(iOS 14.0, tvOS 14.0, *)
+class ImageBinderTests: XCTestCase {
+    @MainActor
+    func testFadeCallsSuccessAfterMarkingLoadedOnCustomCallbackQueue() async {
+        let callbackQueue = DispatchQueue(
+            label: "com.onevcat.KingfisherTests.ImageBinder.callback"
+        )
+        let provider = RawImageDataProvider(
+            data: testImagePNGData,
+            cacheKey: "com.onevcat.KingfisherTests.ImageBinder.\(UUID().uuidString)"
+        )
+        let context = KFImage.Context<Image>(source: .provider(provider))
+        var options = context.options
+        options.callbackQueue = .dispatch(callbackQueue)
+        options.transition = .fade(0.2)
+        context.options = options
+
+        let binder = KFImage.ImageBinder()
+        let success = expectation(description: "Success is called after loading")
+
+        context.onSuccessDelegate.delegate(on: self) { _, _ in
+            XCTAssertTrue(binder.loaded)
+            XCTAssertNotNil(binder.loadedImage)
+            success.fulfill()
+        }
+
+        binder.start(context: context)
+
+        await fulfillment(of: [success], timeout: 1)
+    }
+
+    @MainActor
+    func testLoadTransitionCallsSuccessAfterMarkingLoadedOnCustomCallbackQueue() async {
+        let callbackQueue = DispatchQueue(
+            label: "com.onevcat.KingfisherTests.ImageBinder.callback"
+        )
+        let provider = RawImageDataProvider(
+            data: testImagePNGData,
+            cacheKey: "com.onevcat.KingfisherTests.ImageBinder.\(UUID().uuidString)"
+        )
+        let context = KFImage.Context<Image>(source: .provider(provider))
+        var options = context.options
+        options.callbackQueue = .dispatch(callbackQueue)
+        context.options = options
+        context.swiftUITransition = .opacity
+
+        let binder = KFImage.ImageBinder()
+        let success = expectation(description: "Success is called after loading")
+
+        context.onSuccessDelegate.delegate(on: self) { _, _ in
+            XCTAssertTrue(binder.loaded)
+            XCTAssertNotNil(binder.loadedImage)
+            success.fulfill()
+        }
+
+        binder.start(context: context)
+
+        await fulfillment(of: [success], timeout: 1)
+    }
+}
+
+#endif

--- a/Tests/KingfisherTests/KFImageRendererTests.swift
+++ b/Tests/KingfisherTests/KFImageRendererTests.swift
@@ -313,6 +313,9 @@ class KFImageRendererTests: XCTestCase {
 
         let state = ExternalTransitionState()
         let loaded = expectation(description: "Cached image loads")
+        // A branch inserted after the cache hit would not receive the parent's animation transaction.
+        let animatedInsertion = expectation(description: "Image branch receives the external animation transaction")
+        animatedInsertion.assertForOverFulfill = false
 
         let view = ExternalTransitionHost(
             state: state,
@@ -321,6 +324,9 @@ class KFImageRendererTests: XCTestCase {
             onSuccess: { result in
                 XCTAssertEqual(result.cacheType, .memory)
                 loaded.fulfill()
+            },
+            onImageBranchReceivesAnimationTransaction: {
+                animatedInsertion.fulfill()
             }
         )
 
@@ -339,8 +345,24 @@ class KFImageRendererTests: XCTestCase {
             state.showImage = true
         }
 
-        await fulfillment(of: [loaded], timeout: 1)
+        await fulfillment(of: [loaded, animatedInsertion], timeout: 1)
         window.isHidden = true
+    }
+}
+
+private struct AnimatedTransactionProbe: View {
+    let onAnimatedTransaction: () -> Void
+
+    var body: some View {
+        Color.clear
+            .transaction { transaction in
+                if transaction.animation != nil {
+                    // Avoid fulfilling the expectation while SwiftUI is updating the view hierarchy.
+                    DispatchQueue.main.async {
+                        onAnimatedTransaction()
+                    }
+                }
+            }
     }
 }
 
@@ -355,6 +377,7 @@ private struct ExternalTransitionHost: View {
     let url: URL
     let cache: ImageCache
     let onSuccess: (RetrieveImageResult) -> Void
+    let onImageBranchReceivesAnimationTransaction: () -> Void
 
     var body: some View {
         ZStack {
@@ -363,6 +386,13 @@ private struct ExternalTransitionHost: View {
                     .targetCache(cache)
                     .onSuccess { result in
                         onSuccess(result)
+                    }
+                    .contentConfigure { image in
+                        image.background(
+                            AnimatedTransactionProbe(
+                                onAnimatedTransaction: onImageBranchReceivesAnimationTransaction
+                            )
+                        )
                     }
                     .resizable()
                     .frame(width: 100, height: 100)

--- a/Tests/KingfisherTests/KFImageRendererTests.swift
+++ b/Tests/KingfisherTests/KFImageRendererTests.swift
@@ -1,0 +1,133 @@
+//
+//  KFImageRendererTests.swift
+//  Kingfisher
+//
+//  Created by kjy on 7/9/26.
+//
+//  Copyright (c) 2026 Wei Wang <onevcat@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#if canImport(SwiftUI) && canImport(UIKit) && (os(iOS) || os(tvOS))
+
+import SwiftUI
+import UIKit
+import XCTest
+@testable import Kingfisher
+
+@available(iOS 14.0, tvOS 14.0, *)
+class KFImageRendererTests: XCTestCase {
+    @MainActor
+    func testPlaceholderDefinesLayoutWhenLoadedImageIsNil() async {
+        let maxHeight: CGFloat = 200
+
+        let view = KFImage.dataProvider(nil)
+            .resizable()
+            .placeholder {
+                Color.gray
+                    .frame(maxHeight: maxHeight)
+            }
+            .aspectRatio(contentMode: .fit)
+
+        let measuredSize = await measureLayout(view)
+
+        XCTAssertLessThanOrEqual(
+            measuredSize.height,
+            maxHeight + 0.5,
+            "The placeholder should define the KFImage layout while loadedImage is nil. Before the fix, the empty image branch still participated in layout and made KFImage taller than the placeholder."
+        )
+        XCTAssertGreaterThan(measuredSize.height, 0)
+    }
+
+    @MainActor
+    func testFailureViewDefinesLayoutWhenLoadedImageIsNil() async {
+        let maxHeight: CGFloat = 200
+
+        let view = KFImage.dataProvider(FailingImageDataProvider())
+            .resizable()
+            .onFailureView {
+                Color.red
+                    .frame(maxHeight: maxHeight)
+            }
+            .aspectRatio(contentMode: .fit)
+
+        let measuredSize = await measureLayout(view)
+
+        XCTAssertLessThanOrEqual(
+            measuredSize.height,
+            maxHeight + 0.5,
+            "The failure view should define the KFImage layout while loadedImage is nil. Before the fix, the empty image branch still participated in layout and made KFImage taller than the failure view."
+        )
+        XCTAssertGreaterThan(measuredSize.height, 0)
+    }
+
+    @MainActor
+    private func measureLayout<V: View>(_ view: V) async -> CGSize {
+        let width: CGFloat = 390
+        let height: CGFloat = 800
+
+        var measuredSize = CGSize.zero
+
+        let rootView = VStack(spacing: 0) {
+            view
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear
+                            .onAppear {
+                                measuredSize = proxy.size
+                            }
+                            .onChange(of: proxy.size) { newSize in
+                                measuredSize = newSize
+                            }
+                    }
+                )
+
+            Spacer()
+        }
+        .frame(width: width, height: height)
+
+        let controller = UIHostingController(rootView: rootView)
+
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: width, height: height))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+
+        for _ in 0..<5 {
+            await Task.yield()
+            controller.view.setNeedsLayout()
+            controller.view.layoutIfNeeded()
+        }
+
+        window.isHidden = true
+        return measuredSize
+    }
+}
+
+private struct FailingImageDataProvider: ImageDataProvider {
+    let cacheKey = "com.onevcat.KingfisherTests.FailingImageDataProvider"
+
+    func data() async throws -> Data {
+        throw Error()
+    }
+
+    struct Error: Swift.Error {}
+}
+
+#endif

--- a/Tests/KingfisherTests/KFImageRendererTests.swift
+++ b/Tests/KingfisherTests/KFImageRendererTests.swift
@@ -84,6 +84,33 @@ class KFImageRendererTests: XCTestCase {
     }
 
     @MainActor
+    func testFailureViewDefinesLayoutWithLoadTransitionWhenLoadedImageIsNil() async {
+        let maxHeight: CGFloat = 200
+        let failureExpectation = expectation(description: "Image loading fails")
+
+        let view = KFImage.dataProvider(FailingImageDataProvider())
+            .resizable()
+            .onFailureView {
+                Color.red
+                    .frame(maxHeight: maxHeight)
+            }
+            .loadTransition(.opacity)
+            .onFailure { _ in
+                failureExpectation.fulfill()
+            }
+            .aspectRatio(contentMode: .fit)
+
+        let measuredSize = await measureLayout(view, after: failureExpectation)
+
+        XCTAssertEqual(
+            measuredSize.height,
+            maxHeight,
+            accuracy: 0.5,
+            "The failure view should define the KFImage layout while loadedImage is nil. Before the fix, the empty image branch still participated in layout and made KFImage taller than the failure view."
+        )
+    }
+
+    @MainActor
     private func measureLayout<V: View>(
         _ view: V,
         after expectation: XCTestExpectation? = nil
@@ -133,17 +160,34 @@ class KFImageRendererTests: XCTestCase {
 
     // MARK: - Renderer intermediate states
     @MainActor
-    func testOpacityRendererKeepsPlaceholderWhileImageIsPrepared() async {
-        await assertPlaceholderIsRenderedWhileImageIsPrepared(swiftUITransition: nil)
+    func testFadeKeepsPlaceholderLayoutWhileImageIsPrepared() async {
+        let maxHeight: CGFloat = 200
+        let binder = KFImage.ImageBinder()
+        // Simulates the state ImageBinder creates before starting a fade animation.
+        binder.loadedImage = testImage
+
+        let context = KFImage.Context<Image>(source: nil)
+        context.placeholder = { _ in
+            AnyView(Color.gray.frame(height: maxHeight))
+        }
+        context.contentConfiguration = { image in
+            AnyView(image.resizable().aspectRatio(contentMode: .fit))
+        }
+
+        let measuredSize = await measureLayout(
+            KFImageRenderer(context: context, binder: binder)
+        )
+
+        XCTAssertEqual(
+            measuredSize.height,
+            maxHeight,
+            accuracy: 0.5,
+            "The prepared fade image must not affect placeholder layout before it is marked loaded."
+        )
     }
 
     @MainActor
     func testLoadTransitionKeepsPlaceholderWhileImageIsPrepared() async {
-        await assertPlaceholderIsRenderedWhileImageIsPrepared(swiftUITransition: .opacity)
-    }
-
-    @MainActor
-    private func assertPlaceholderIsRenderedWhileImageIsPrepared(swiftUITransition: AnyTransition?) async {
         let placeholderAppeared = expectation(description: "Placeholder appeared")
 
         let binder = KFImage.ImageBinder()
@@ -151,7 +195,7 @@ class KFImageRendererTests: XCTestCase {
         binder.loadedImage = testImage
 
         let context = KFImage.Context<Image>(source: nil)
-        context.swiftUITransition = swiftUITransition
+        context.swiftUITransition = .opacity
         context.placeholder = { _ in
             AnyView(
                 Color.gray
@@ -261,6 +305,9 @@ class KFImageRendererTests: XCTestCase {
     @MainActor
     func testExternalTransitionPreservesCachedImageInsertion() async throws {
         let cache = ImageCache(name: "com.onevcat.KingfisherTests.ExternalTransition.\(UUID().uuidString)")
+        addTeardownBlock {
+            clearCaches([cache])
+        }
         let url = URL(string: "https://example.com/image.png")!
         try await cache.store(testImage, forKey: url.cacheKey, toDisk: false)
 

--- a/Tests/KingfisherTests/KFImageRendererTests.swift
+++ b/Tests/KingfisherTests/KFImageRendererTests.swift
@@ -34,6 +34,7 @@ import XCTest
 
 @available(iOS 14.0, tvOS 14.0, *)
 class KFImageRendererTests: XCTestCase {
+    // MARK: - Layout
     @MainActor
     func testPlaceholderDefinesLayoutWhenLoadedImageIsNil() async {
         let maxHeight: CGFloat = 200
@@ -48,12 +49,12 @@ class KFImageRendererTests: XCTestCase {
 
         let measuredSize = await measureLayout(view)
 
-        XCTAssertLessThanOrEqual(
+        XCTAssertEqual(
             measuredSize.height,
-            maxHeight + 0.5,
+            maxHeight,
+            accuracy: 0.5,
             "The placeholder should define the KFImage layout while loadedImage is nil. Before the fix, the empty image branch still participated in layout and made KFImage taller than the placeholder."
         )
-        XCTAssertGreaterThan(measuredSize.height, 0)
     }
 
     @MainActor
@@ -74,12 +75,12 @@ class KFImageRendererTests: XCTestCase {
 
         let measuredSize = await measureLayout(view, after: failureExpectation)
 
-        XCTAssertLessThanOrEqual(
+        XCTAssertEqual(
             measuredSize.height,
-            maxHeight + 0.5,
+            maxHeight,
+            accuracy: 0.5,
             "The failure view should define the KFImage layout while loadedImage is nil. Before the fix, the empty image branch still participated in layout and made KFImage taller than the failure view."
         )
-        XCTAssertGreaterThan(measuredSize.height, 0)
     }
 
     @MainActor
@@ -128,6 +129,200 @@ class KFImageRendererTests: XCTestCase {
 
         window.isHidden = true
         return measuredSize
+    }
+
+    // MARK: - Renderer intermediate states
+    @MainActor
+    func testOpacityRendererKeepsPlaceholderWhileImageIsPrepared() async {
+        await assertPlaceholderIsRenderedWhileImageIsPrepared(swiftUITransition: nil)
+    }
+
+    @MainActor
+    func testLoadTransitionKeepsPlaceholderWhileImageIsPrepared() async {
+        await assertPlaceholderIsRenderedWhileImageIsPrepared(swiftUITransition: .opacity)
+    }
+
+    @MainActor
+    private func assertPlaceholderIsRenderedWhileImageIsPrepared(swiftUITransition: AnyTransition?) async {
+        let placeholderAppeared = expectation(description: "Placeholder appeared")
+
+        let binder = KFImage.ImageBinder()
+        // Simulates the render pass after `loadedImage` changes but before `loaded` does.
+        binder.loadedImage = testImage
+
+        let context = KFImage.Context<Image>(source: nil)
+        context.swiftUITransition = swiftUITransition
+        context.placeholder = { _ in
+            AnyView(
+                Color.gray
+                    .frame(height: 200)
+                    .onAppear {
+                        placeholderAppeared.fulfill()
+                    }
+            )
+        }
+
+        let view = KFImageRenderer(context: context, binder: binder)
+
+        let controller = UIHostingController(rootView: view)
+        let window = UIWindow(frame: .init(x: 0, y: 0, width: 390, height: 800))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+
+        await fulfillment(of: [placeholderAppeared], timeout: 1)
+        window.isHidden = true
+    }
+
+    // MARK: - Non-cached loading paths
+    @MainActor
+    func testFadeUsesFadePathForNonCachedImage() async {
+        let loaded = expectation(description: "Image loads from provider")
+
+        let view = makeNonCachedImage()
+            .resizable()
+            .placeholder {
+                Color.gray.frame(height: 200)
+            }
+            .fade(duration: 0.2)
+            .onSuccess { result in
+                XCTAssertEqual(result.cacheType, .none)
+                loaded.fulfill()
+            }
+
+        let controller = UIHostingController(rootView: view)
+        let window = UIWindow(frame: .init(x: 0, y: 0, width: 390, height: 800))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+
+        await fulfillment(of: [loaded], timeout: 1)
+        window.isHidden = true
+    }
+
+    @MainActor
+    func testLoadTransitionUsesLoadTransitionPathForNonCachedImage() async {
+        let loaded = expectation(description: "Image loads from provider")
+
+        let view = makeNonCachedImage()
+            .resizable()
+            .placeholder {
+                Color.gray.frame(height: 200)
+            }
+            .loadTransition(.opacity)
+            .onSuccess { result in
+                XCTAssertEqual(result.cacheType, .none)
+                loaded.fulfill()
+            }
+
+        let controller = UIHostingController(rootView: view)
+        let window = UIWindow(frame: .init(x: 0, y: 0, width: 390, height: 800))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+
+        await fulfillment(of: [loaded], timeout: 1)
+        window.isHidden = true
+    }
+
+    @MainActor
+    private func makeNonCachedImage() -> KFImage {
+        KFImage.data(
+            testImagePNGData,
+            cacheKey: "com.onevcat.KingfisherTests.\(UUID().uuidString)"
+        )
+    }
+
+    // MARK: - External transition
+    @MainActor
+    func testRendererKeepsImageBranchBeforeImageLoads() async {
+        let imageBranchAppeared = expectation(description: "Image branch appeared")
+
+        let binder = KFImage.ImageBinder()
+        let context = KFImage.Context<Image>(source: nil)
+        // Keep the image branch in the hierarchy before a cache hit resolves.
+        context.contentConfiguration = { _ in
+            AnyView(
+                Color.clear
+                    .onAppear {
+                        imageBranchAppeared.fulfill()
+                    }
+            )
+        }
+
+        let view = KFImageRenderer(context: context, binder: binder)
+
+        let controller = UIHostingController(rootView: view)
+        let window = UIWindow(frame: .init(x: 0, y: 0, width: 390, height: 800))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+
+        await fulfillment(of: [imageBranchAppeared], timeout: 1)
+        window.isHidden = true
+    }
+
+    @MainActor
+    func testExternalTransitionPreservesCachedImageInsertion() async throws {
+        let cache = ImageCache(name: "com.onevcat.KingfisherTests.ExternalTransition.\(UUID().uuidString)")
+        let url = URL(string: "https://example.com/image.png")!
+        try await cache.store(testImage, forKey: url.cacheKey, toDisk: false)
+
+        let state = ExternalTransitionState()
+        let loaded = expectation(description: "Cached image loads")
+
+        let view = ExternalTransitionHost(
+            state: state,
+            url: url,
+            cache: cache,
+            onSuccess: { result in
+                XCTAssertEqual(result.cacheType, .memory)
+                loaded.fulfill()
+            }
+        )
+
+        let controller = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+
+        for _ in 0..<2 {
+            await Task.yield()
+            controller.view.setNeedsLayout()
+            controller.view.layoutIfNeeded()
+        }
+
+        withAnimation(.linear(duration: 0.2)) {
+            state.showImage = true
+        }
+
+        await fulfillment(of: [loaded], timeout: 1)
+        window.isHidden = true
+    }
+}
+
+@MainActor
+private final class ExternalTransitionState: ObservableObject {
+    @Published var showImage = false
+}
+
+@available(iOS 14.0, tvOS 14.0, *)
+private struct ExternalTransitionHost: View {
+    @ObservedObject var state: ExternalTransitionState
+    let url: URL
+    let cache: ImageCache
+    let onSuccess: (RetrieveImageResult) -> Void
+
+    var body: some View {
+        ZStack {
+            if state.showImage {
+                KFImage(url)
+                    .targetCache(cache)
+                    .onSuccess { result in
+                        onSuccess(result)
+                    }
+                    .resizable()
+                    .frame(width: 100, height: 100)
+                    .transition(.slide)
+            }
+        }
+        .frame(width: 390, height: 200)
     }
 }
 

--- a/Tests/KingfisherTests/KFImageRendererTests.swift
+++ b/Tests/KingfisherTests/KFImageRendererTests.swift
@@ -59,6 +59,7 @@ class KFImageRendererTests: XCTestCase {
     @MainActor
     func testFailureViewDefinesLayoutWhenLoadedImageIsNil() async {
         let maxHeight: CGFloat = 200
+        let failureExpectation = expectation(description: "Image loading fails")
 
         let view = KFImage.dataProvider(FailingImageDataProvider())
             .resizable()
@@ -66,9 +67,12 @@ class KFImageRendererTests: XCTestCase {
                 Color.red
                     .frame(maxHeight: maxHeight)
             }
+            .onFailure { _ in
+                failureExpectation.fulfill()
+            }
             .aspectRatio(contentMode: .fit)
 
-        let measuredSize = await measureLayout(view)
+        let measuredSize = await measureLayout(view, after: failureExpectation)
 
         XCTAssertLessThanOrEqual(
             measuredSize.height,
@@ -79,7 +83,10 @@ class KFImageRendererTests: XCTestCase {
     }
 
     @MainActor
-    private func measureLayout<V: View>(_ view: V) async -> CGSize {
+    private func measureLayout<V: View>(
+        _ view: V,
+        after expectation: XCTestExpectation? = nil
+    ) async -> CGSize {
         let width: CGFloat = 390
         let height: CGFloat = 800
 
@@ -108,6 +115,10 @@ class KFImageRendererTests: XCTestCase {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: width, height: height))
         window.rootViewController = controller
         window.makeKeyAndVisible()
+
+        if let expectation {
+            await fulfillment(of: [expectation], timeout: 1)
+        }
 
         for _ in 0..<5 {
             await Task.yield()


### PR DESCRIPTION
## Summary

Fixes #2533.

`KFImageRenderer` now skips the image branch until `loadedImage` is available.

With the sample from #2533, `KFImage` can show a `placeholder` or `onFailureView` while an empty image branch is still in the view hierarchy. That image is invisible, but SwiftUI still includes it when it calculates layout. This can make the outer `KFImage` taller than the placeholder or failure view.

This lets the placeholder or failure view define the layout until Kingfisher has an image to render.

## Reproduction

I used the sample from #2533:

```swift
import Kingfisher
import SwiftUI

struct LazyImageWithKingFisher: View {
    let imageUrl: String

    var body: some View {
        KFImage(URL(string: imageUrl))
            .resizable()
            .placeholder {
                Color.gray
                    .frame(maxHeight: 200)
                    .border(.blue)
            }
            .onFailureView {
                Color.red
                    .frame(maxHeight: 200)
                    .border(.blue)
            }
            .clipShape(
                RoundedRectangle(cornerRadius: 12)
            )
            .aspectRatio(contentMode: .fit)
            .border(.red)
    }
}

#Preview {
    VStack(spacing: 0) {
        LazyImageWithKingFisher(
            imageUrl: "https://images.unsplash.com/photo-1506744038136-46273834b3fb"
        )
        LazyImageWithKingFisher(
            imageUrl: "https://httpbin.org/delay/10"
        )
        Spacer()
    }
}
```

Before:

<img alt="Before" src="https://github.com/user-attachments/assets/17479d82-0aef-4065-af3f-1c72568506e3" />

After:

<img alt="After" src="https://github.com/user-attachments/assets/6e262bd2-1905-442b-9906-139afe27190f" />

## Verification

I verified the sample from #2533 manually in Xcode Preview.

I also added regression tests for the `placeholder` and `onFailureView` layout paths:

- `KFImageRendererTests.testPlaceholderDefinesLayoutWhenLoadedImageIsNil`
- `KFImageRendererTests.testFailureViewDefinesLayoutWhenLoadedImageIsNil`

I verified that these tests fail before the renderer change and pass after it.

I checked:

- Loading state with `placeholder`
- Failure state with `onFailureView`
- Successful image loading
- The same sample without adding `.frame(maxHeight:)` to the whole `KFImage`
