### PR TITLE
Look up disk cache entries with a single metadata syscall

### DIFF
--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -256,17 +256,12 @@ public enum DiskStorage {
                 throw KingfisherError.cacheError(reason: .diskStorageIsNotReady(cacheURL: directoryURL))
             }
 
-            let fileManager = config.fileManager
             let fileURL = cacheFileURL(forKey: key, forcedExtension: forcedExtension)
-            let filePath = fileURL.path
 
             let fileMaybeCached = maybeCachedCheckingQueue.sync {
                 return !maybeCachedSetupCompleted || (maybeCached?.contains(fileURL.lastPathComponent) ?? true)
             }
             guard fileMaybeCached else {
-                return nil
-            }
-            guard fileManager.fileExists(atPath: filePath) else {
                 return nil
             }
 
@@ -275,6 +270,17 @@ public enum DiskStorage {
                 let resourceKeys: Set<URLResourceKey> = [.contentModificationDateKey, .creationDateKey]
                 meta = try FileMeta(fileURL: fileURL, resourceKeys: resourceKeys)
             } catch {
+                // A missing file is already reported by the resource values reading, so a separate `fileExists`
+                // check before it is not needed. This runs on the caller thread when probing cache existence, so
+                // it should touch the disk as few times as possible.
+                if error.isFileMissing {
+                    return nil
+                }
+                // Other metadata failures keep the original semantics: a file that cannot be confirmed on disk
+                // is a cache miss, while an existing file with unreadable metadata is an error.
+                guard config.fileManager.fileExists(atPath: fileURL.path) else {
+                    return nil
+                }
                 throw KingfisherError.cacheError(
                     reason: .invalidURLResource(error: error, key: key, url: fileURL))
             }
@@ -670,6 +676,16 @@ extension DiskStorage {
             cacheName = "com.onevcat.Kingfisher.ImageCache.\(config.name)"
             directoryURL = config.cachePathBlock(url, cacheName)
         }
+    }
+}
+
+extension Error {
+    // `URL.resourceValues(forKeys:)` reports a nonexistent file (or a missing intermediate directory in its
+    // path) as `NSFileReadNoSuchFileError`. Treating it as a normal cache miss allows the disk lookup to skip
+    // a dedicated `fileExists` disk touch on the hot path.
+    var isFileMissing: Bool {
+        let nsError = self as NSError
+        return nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileReadNoSuchFileError
     }
 }
 

--- a/Tests/KingfisherTests/DiskStorageTests.swift
+++ b/Tests/KingfisherTests/DiskStorageTests.swift
@@ -42,6 +42,26 @@ extension String {
     public static var empty: String { return "" }
 }
 
+// Reports the given paths as existing regardless of the disk state, so tests can separate the
+// "file exists but its metadata is unreadable" case from the "file is missing" one.
+private final class FileExistsLyingFileManager: FileManager, @unchecked Sendable {
+    private let lock = NSLock()
+    private var lyingPaths = Set<String>()
+
+    func lieAboutExistence(ofPath path: String) {
+        lock.lock()
+        lyingPaths.insert(path)
+        lock.unlock()
+    }
+
+    override func fileExists(atPath path: String) -> Bool {
+        lock.lock()
+        let lying = lyingPaths.contains(path)
+        lock.unlock()
+        return lying || super.fileExists(atPath: path)
+    }
+}
+
 private final class DelayedDirectoryScanFileManager: FileManager, @unchecked Sendable {
     private let scanStarted = DispatchSemaphore(value: 0)
     private let releaseScan = DispatchSemaphore(value: 0)
@@ -332,6 +352,133 @@ class DiskStorageTests: XCTestCase {
         storage.config.autoExtAfterHashedFileName = true
         let hashedFileName = storage.cacheFileName(forKey: key)
         XCTAssertEqual(hashedFileName, key.kf.sha256)
+    }
+
+    // The value lookup reads the file metadata directly and treats a missing file as a normal cache miss,
+    // without a separate `fileExists` check. Removing the file behind the storage keeps its name in the
+    // `maybeCached` shortcut, so the lookup must reach the metadata reading and observe the missing file there.
+    func testValueForFileRemovedBehindStorageIsMiss() {
+        try! storage.store(value: "1", forKey: "1")
+        XCTAssertTrue(storage.isCached(forKey: "1"))
+
+        let fileURL = storage.cacheFileURL(forKey: "1")
+        try! FileManager.default.removeItem(at: fileURL)
+
+        XCTAssertFalse(storage.isCached(forKey: "1"))
+        XCTAssertNil(try! storage.value(forKey: "1"))
+    }
+
+    // When the metadata reading fails for a reason other than a missing file (here: no search permission on
+    // the containing directory) and the file cannot be confirmed on disk either, the lookup reports a miss
+    // instead of throwing.
+    func testValueWithUnreadableDirectoryReportsMiss() throws {
+        try XCTSkipIf(geteuid() == 0, "File permissions are not effective for root.")
+
+        let config = DiskStorage.Config(name: "test-\(UUID().uuidString)", sizeLimit: 5)
+        let storage = try DiskStorage.Backend<String>(config: config)
+        try storage.store(value: "1", forKey: "1")
+
+        let directoryPath = storage.directoryURL.path
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: directoryPath)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directoryPath)
+            try? storage.removeAll(skipCreatingDirectory: true)
+        }
+
+        XCTAssertFalse(storage.isCached(forKey: "1"))
+        XCTAssertNil(try storage.value(forKey: "1"))
+    }
+
+    // Once the initial directory scan is applied, a key that was never stored is answered from the
+    // `maybeCached` shortcut without any disk touch. The scan bookkeeping is driven directly to keep the
+    // shortcut state deterministic regardless of the background scan timing.
+    func testMissForUnknownKeyAfterInitialScanApplied() {
+        storage.maybeCachedCheckingQueue.sync {
+            storage.maybeCached = []
+            storage.maybeCachedSetupCompleted = true
+        }
+
+        XCTAssertFalse(storage.isCached(forKey: "never-stored"))
+        XCTAssertNil(try! storage.value(forKey: "never-stored"))
+    }
+
+    // A file whose metadata is readable but whose content is not fails the actual loading, not the probe.
+    func testValueWithUnreadableFileDataThrows() throws {
+        try XCTSkipIf(geteuid() == 0, "File permissions are not effective for root.")
+
+        try storage.store(value: "1", forKey: "1")
+        let filePath = storage.cacheFileURL(forKey: "1").path
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: filePath)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: filePath)
+        }
+
+        // The existence probe reads only metadata, so it still reports a hit.
+        XCTAssertTrue(storage.isCached(forKey: "1"))
+        XCTAssertThrowsError(try storage.value(forKey: "1")) { error in
+            guard case KingfisherError.cacheError(reason: .cannotLoadDataFromDisk) = error else {
+                XCTFail("Expected cannotLoadDataFromDisk, but got \(error)")
+                return
+            }
+        }
+    }
+
+    // A file that is confirmed on disk but whose metadata cannot be read keeps failing with
+    // `invalidURLResource`, as it did when `fileExists` guarded the metadata reading.
+    func testValueWithUnreadableMetadataOnExistingFileThrows() throws {
+        try XCTSkipIf(geteuid() == 0, "File permissions are not effective for root.")
+
+        let fileManager = FileExistsLyingFileManager()
+        let config = DiskStorage.Config(
+            name: "test-\(UUID().uuidString)", sizeLimit: 5, fileManager: fileManager
+        )
+        let storage = try DiskStorage.Backend<String>(config: config)
+        try storage.store(value: "1", forKey: "1")
+        fileManager.lieAboutExistence(ofPath: storage.cacheFileURL(forKey: "1").path)
+
+        let directoryPath = storage.directoryURL.path
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: directoryPath)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: directoryPath)
+            try? storage.removeAll(skipCreatingDirectory: true)
+        }
+
+        XCTAssertThrowsError(try storage.value(forKey: "1")) { error in
+            guard case KingfisherError.cacheError(reason: .invalidURLResource) = error else {
+                XCTFail("Expected invalidURLResource, but got \(error)")
+                return
+            }
+        }
+    }
+
+    func testValueOnNotReadyStorageThrows() {
+        let fileManager = FileManager.default
+        let fileBlockingDirectory = URL(
+            fileURLWithPath: NSTemporaryDirectory()
+        ).appendingPathComponent(UUID().uuidString)
+        fileManager.createFile(atPath: fileBlockingDirectory.path, contents: Data())
+        defer { try? fileManager.removeItem(at: fileBlockingDirectory) }
+
+        // Creating the storage folder under a regular file fails, which marks the storage as not ready.
+        let config = DiskStorage.Config(name: "test", sizeLimit: 5, directory: fileBlockingDirectory)
+        let storage = DiskStorage.Backend<String>(noThrowConfig: config, creatingDirectory: true)
+
+        XCTAssertFalse(storage.isCached(forKey: "1"))
+        XCTAssertThrowsError(try storage.value(forKey: "1")) { error in
+            guard case KingfisherError.cacheError(reason: .diskStorageIsNotReady) = error else {
+                XCTFail("Expected diskStorageIsNotReady, but got \(error)")
+                return
+            }
+        }
+    }
+
+    func testIsFileMissingError() {
+        XCTAssertTrue((CocoaError(.fileReadNoSuchFile) as Error).isFileMissing)
+        XCTAssertFalse((CocoaError(.fileReadNoPermission) as Error).isFileMissing)
+        // The code alone is not enough: the domain has to match too.
+        XCTAssertFalse(
+            (NSError(domain: NSPOSIXErrorDomain, code: NSFileReadNoSuchFileError) as Error).isFileMissing
+        )
     }
 
     func testFileMetaOrder() {


### PR DESCRIPTION
### What

`DiskStorage.Backend.value(forKey:...)` used to touch the file system twice for every disk cache lookup:

1. `fileManager.fileExists(atPath:)` — a `stat` syscall
2. `FileMeta(fileURL:resourceKeys:)` (backed by `URL.resourceValues(forKeys:)`) — a `getattrlist` syscall

`URL.resourceValues(forKeys:)` already reports a nonexistent file (or a missing intermediate directory) with `NSFileReadNoSuchFileError`, so the `fileExists` gate only duplicates the disk touch. This PR reads the metadata directly and treats that error as a regular cache miss, halving the blocking syscalls of the lookup.

### Why it matters

With default options, `KingfisherManager.retrieveImage` probes cache existence **on the caller thread** — the main thread for `kf.setImage` / `KFImage` loads (`retrieveImageFromCache` → `imageCachedType` → `diskStorage.isCached` → this lookup). When the storage stack is under I/O load, each blocked syscall on that path shows up as dropped frames: #2217 reports exactly this at scale, and its trace points at the `fileExists(atPath:)` call this PR removes; #2323 profiles the same stall from `retrieveImage`. The probe also runs a second round for the original key when a non-default processor is used, so a scrolling list with e.g. downsampling pays up to 4 blocking syscalls per cell today, and 2 after this change.

The change composes with the opt-in `asyncCacheTypeCheck`: users who opt in move the remaining syscall off the caller thread entirely, while everyone on the default path now blocks half as often. The actual data loading path also drops from 3 file system touches to 2, which additionally helps `.loadDiskFileSynchronously` users.

Micro-benchmark of the probe sequence (release build, Apple Silicon, hot file cache; the relative win grows when the disk queue is contended, which is the reported scenario):

| Case | Before | After |
|---|---|---|
| Lookup of an existing entry | 3.70 µs (stat + getattrlist) | 1.11 µs (getattrlist) |
| Lookup of a missing entry that passed `maybeCached` | 1.50 µs | 2.79 µs |

The missing-entry case costs slightly more because constructing the thrown error is heavier than a plain `stat` returning false. That path is only reached for stale `maybeCached` entries (for example, the first probe after an expired file was swept); the common miss is still answered from the in-memory `maybeCached` set with no syscall at all, and the hit case dominates steady-state scrolling.

### Behavior compatibility

| Situation | Before | After |
|---|---|---|
| File missing / missing intermediate directory | `nil` (miss) | `nil` (miss), via `NSFileReadNoSuchFileError` |
| File present and valid | value | value |
| File present but expired | `nil` | `nil` |
| Metadata unreadable, file not confirmable on disk (e.g. no search permission on the folder) | `nil` | `nil`, via a cold-path `fileExists` fallback |
| Metadata unreadable on a file confirmed to exist | `invalidURLResource` | `invalidURLResource` |

The only observable difference is for foreign entries the storage never writes itself (for example, a dangling symlink manually placed in the cache folder under a hashed name): the existence probe now reports it as cached and the actual load fails, where it previously reported a miss. `store` only ever writes regular files, so this cannot arise from Kingfisher's own operation.

### Tests

`DiskStorageTests` gains seven cases pinning every branch of the changed lookup, verified at 100% line coverage of the changed function and the new error helper with `xccov`:

- File removed behind the storage (name still in `maybeCached`, so the lookup reaches the metadata reading and observes the missing file there) → miss, for both the existence probe and the value load.
- Unknown key answered by the `maybeCached` shortcut → miss without any disk touch.
- Unreadable containing directory (metadata fails, file not confirmable) → miss instead of an error.
- Unreadable metadata on a file confirmed to exist → `invalidURLResource`.
- Unreadable file content with readable metadata → the probe reports a hit, the load fails with `cannotLoadDataFromDisk`.
- Storage whose directory creation failed → `diskStorageIsNotReady`.
- Direct checks of the `isFileMissing` error classification (matching code and domain).

### How to verify

```
xcodebuild -project Kingfisher.xcodeproj -scheme Kingfisher -destination "platform=macOS" test
xcodebuild -project Kingfisher.xcodeproj -scheme Kingfisher -destination "platform=iOS Simulator,name=iPhone 17,OS=26.0" test
```

Both full suites pass locally on macOS 15 / Xcode 17.
