### PR TITLE
Prepare disk storage before initial cache scan

### DIFF
--- a/Sources/Cache/DiskStorage.swift
+++ b/Sources/Cache/DiskStorage.swift
@@ -79,10 +79,11 @@ public enum DiskStorage {
         public convenience init(config: Config) throws {
             self.init(noThrowConfig: config, creatingDirectory: false)
             try prepareDirectory()
+            setupCacheChecking()
         }
 
-        // If `creatingDirectory` is `false`, the directory preparation will be skipped.
-        // We need to call `prepareDirectory` manually after this returns.
+        // If `creatingDirectory` is `false`, directory preparation and cache checking will be skipped.
+        // We need to call `prepareDirectory` and then `setupCacheChecking` manually after this returns.
         init(noThrowConfig config: Config, creatingDirectory: Bool) {
             var config = config
 
@@ -94,10 +95,10 @@ public enum DiskStorage {
             _config = config
 
             metaChangingQueue = DispatchQueue(label: creation.cacheName)
-            setupCacheChecking()
 
             if creatingDirectory {
                 try? prepareDirectory()
+                setupCacheChecking()
             }
         }
 
@@ -679,7 +680,7 @@ extension DiskStorage {
     }
 }
 
-extension Error {
+fileprivate extension Error {
     // `URL.resourceValues(forKeys:)` reports a nonexistent file (or a missing intermediate directory in its
     // path) as `NSFileReadNoSuchFileError`. Treating it as a normal cache miss allows the disk lookup to skip
     // a dedicated `fileExists` disk touch on the hot path.
@@ -687,9 +688,7 @@ extension Error {
         let nsError = self as NSError
         return nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileReadNoSuchFileError
     }
-}
 
-fileprivate extension Error {
     var isFolderMissing: Bool {
         let nsError = self as NSError
         guard nsError.domain == NSCocoaErrorDomain, nsError.code == 4 else {

--- a/Tests/KingfisherTests/DiskStorageTests.swift
+++ b/Tests/KingfisherTests/DiskStorageTests.swift
@@ -103,6 +103,50 @@ private final class DelayedDirectoryScanFileManager: FileManager, @unchecked Sen
     }
 }
 
+private final class DirectoryPreparationTrackingFileManager: FileManager, @unchecked Sendable {
+    private let scanStarted = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+
+    private var shouldCoordinateDirectoryCreation = true
+    private var _directoryExistedWhenScanStarted: Bool?
+
+    var directoryExistedWhenScanStarted: Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+        return _directoryExistedWhenScanStarted
+    }
+
+    override func contentsOfDirectory(atPath path: String) throws -> [String] {
+        let directoryExisted = super.fileExists(atPath: path)
+        lock.lock()
+        _directoryExistedWhenScanStarted = directoryExisted
+        lock.unlock()
+
+        scanStarted.signal()
+        return try super.contentsOfDirectory(atPath: path)
+    }
+
+    override func createDirectory(
+        atPath path: String,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]? = nil
+    ) throws {
+        lock.lock()
+        let shouldCoordinate = shouldCoordinateDirectoryCreation
+        shouldCoordinateDirectoryCreation = false
+        lock.unlock()
+
+        if shouldCoordinate {
+            _ = scanStarted.wait(timeout: .now() + 0.5)
+        }
+        try super.createDirectory(
+            atPath: path,
+            withIntermediateDirectories: createIntermediates,
+            attributes: attributes
+        )
+    }
+}
+
 class DiskStorageTests: XCTestCase {
 
     var storage: DiskStorage.Backend<String>!
@@ -118,6 +162,21 @@ class DiskStorageTests: XCTestCase {
     override func tearDown() {
         try! storage.removeAll(skipCreatingDirectory: true)
         super.tearDown()
+    }
+
+    private func waitUntilMaybeCachedIsReady(
+        for storage: DiskStorage.Backend<String>,
+        timeout: TimeInterval = 2
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        repeat {
+            let isReady = storage.maybeCachedCheckingQueue.sync {
+                storage.maybeCachedSetupCompleted && storage.maybeCached != nil
+            }
+            if isReady { return true }
+            Thread.sleep(forTimeInterval: 0.001)
+        } while Date() < deadline
+        return false
     }
 
     func testStoreAndGet() {
@@ -139,20 +198,26 @@ class DiskStorageTests: XCTestCase {
         try! storage.store(value: "1", forKey: "1")
         fileManager.finishDelayedScan(returning: [])
 
-        let deadline = Date().addingTimeInterval(2)
-        var initialScanApplied = false
-        repeat {
-            initialScanApplied = storage.maybeCachedCheckingQueue.sync {
-                storage.maybeCached != nil
-            }
-            if !initialScanApplied {
-                Thread.sleep(forTimeInterval: 0.001)
-            }
-        } while !initialScanApplied && Date() < deadline
-
-        XCTAssertTrue(initialScanApplied)
+        XCTAssertTrue(waitUntilMaybeCachedIsReady(for: storage))
         XCTAssertTrue(storage.isCached(forKey: "1"))
         XCTAssertEqual(try! storage.value(forKey: "1"), "1")
+    }
+
+    func testDirectoryIsPreparedBeforeInitialCacheScan() throws {
+        let fileManager = DirectoryPreparationTrackingFileManager()
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("test-\(UUID().uuidString)")
+        let config = DiskStorage.Config(
+            name: "test", sizeLimit: 5, fileManager: fileManager, directory: rootURL
+        )
+        let storage = try DiskStorage.Backend<String>(config: config)
+        defer {
+            try? storage.removeAll(skipCreatingDirectory: true)
+            try? FileManager.default.removeItem(at: rootURL)
+        }
+
+        XCTAssertTrue(waitUntilMaybeCachedIsReady(for: storage))
+        XCTAssertEqual(fileManager.directoryExistedWhenScanStarted, true)
     }
 
     func testRemove() {
@@ -368,6 +433,34 @@ class DiskStorageTests: XCTestCase {
         XCTAssertNil(try! storage.value(forKey: "1"))
     }
 
+    func testValueForDanglingSymbolicLinkUsesLinkMetadataThenFailsToLoad() throws {
+        let key = "dangling-link"
+        try storage.store(value: "1", forKey: key)
+
+        let fileURL = storage.cacheFileURL(forKey: key)
+        try FileManager.default.removeItem(at: fileURL)
+        try FileManager.default.createSymbolicLink(
+            at: fileURL,
+            withDestinationURL: storage.directoryURL.appendingPathComponent("missing-target")
+        )
+
+        XCTAssertTrue(storage.isCached(forKey: key, referenceDate: .distantPast))
+        XCTAssertThrowsError(
+            try storage.value(
+                forKey: key,
+                referenceDate: .distantPast,
+                actuallyLoad: true,
+                extendingExpiration: .none,
+                forcedExtension: nil
+            )
+        ) { error in
+            guard case KingfisherError.cacheError(reason: .cannotLoadDataFromDisk) = error else {
+                XCTFail("Expected cannotLoadDataFromDisk, but got \(error)")
+                return
+            }
+        }
+    }
+
     // When the metadata reading fails for a reason other than a missing file (here: no search permission on
     // the containing directory) and the file cannot be confirmed on disk either, the lookup reports a miss
     // instead of throwing.
@@ -470,15 +563,6 @@ class DiskStorageTests: XCTestCase {
                 return
             }
         }
-    }
-
-    func testIsFileMissingError() {
-        XCTAssertTrue((CocoaError(.fileReadNoSuchFile) as Error).isFileMissing)
-        XCTAssertFalse((CocoaError(.fileReadNoPermission) as Error).isFileMissing)
-        // The code alone is not enough: the domain has to match too.
-        XCTAssertFalse(
-            (NSError(domain: NSPOSIXErrorDomain, code: NSFileReadNoSuchFileError) as Error).isFileMissing
-        )
     }
 
     func testFileMetaOrder() {


### PR DESCRIPTION
## What

- Prepare the disk storage directory before starting the initial cache scan.
- Keep the `maybeCached` index available for a newly created cache instead of permanently falling back after a raced directory lookup.
- Make the missing-file error helper `fileprivate` and keep it alongside the existing folder-missing helper.
- Characterize the accepted dangling-symlink behavior from #2556.

## Why

This is a follow-up to #2556.

`setupCacheChecking()` was scheduled before `prepareDirectory()`. For a brand-new cache, the background directory scan could run first, fail because the directory did not exist yet, and leave `maybeCached` disabled for the lifetime of the storage. Preparing the directory first removes that race. The existing setup bookkeeping still preserves files stored while the scan is in progress.

A deterministic regression test coordinates directory creation with the background scan and verifies both that the directory exists when scanning starts and that `maybeCached` becomes ready.

## Validation

- Full macOS test suite: 716 passed
- macOS `DiskStorageTests`: 50 passed
- iOS Simulator `DiskStorageTests`: 50 passed