### PR TITLE
Release the image view while its download is still in flight

### DIFF
--- a/Sources/Extensions/ImageView+Kingfisher.swift
+++ b/Sources/Extensions/ImageView+Kingfisher.swift
@@ -324,18 +324,34 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
         }
         let finalOptions = options
 
+        // Hold the image view weakly in the escaping download callbacks below. Otherwise an
+        // in-flight download keeps the view alive until it finishes, so a view whose owner was
+        // already released (for example, an image view in a popped view controller) survives
+        // longer than expected. The download itself keeps running and still populates the cache.
+        // See https://github.com/onevcat/Kingfisher/issues/2313
+        let weakBase = WeakBox(base)
+
         let task = KingfisherManager.shared.retrieveImage(
             with: source,
             options: finalOptions,
             downloadTaskUpdated: { task in
-                CallbackQueueMain.currentOrAsync { self.setImageTaskValue(task) }
+                CallbackQueueMain.currentOrAsync { weakBase.value?.kf.setImageTaskValue(task) }
             },
-            progressiveImageSetter: { self.base.image = $0 },
+            progressiveImageSetter: { weakBase.value?.image = $0 },
             referenceTaskIdentifierChecker: { !token.isCancelled },
             completionHandler: { result in
                 CallbackQueueMain.currentOrAsync {
+                    // The image view might have been released while the download was still in
+                    // flight. In that case skip every UI update, but still forward the result so
+                    // callers awaiting completion are not left hanging.
+                    guard let base = weakBase.value else {
+                        completionHandler?(result)
+                        return
+                    }
+                    let mutatingSelf = base.kf
+
                     maybeIndicator?.stopAnimatingView()
-                    guard issuedIdentifier == self.taskIdentifier else {
+                    guard issuedIdentifier == mutatingSelf.taskIdentifier else {
                         let reason: KingfisherError.ImageSettingErrorReason
                         do {
                             let value = try result.get()
@@ -348,26 +364,26 @@ extension KingfisherWrapper where Base: KFCrossPlatformImageView {
                         return
                     }
 
-                    self.setImageTaskValue(nil)
-                    self.setTaskIdentifierValue(nil)
+                    mutatingSelf.setImageTaskValue(nil)
+                    mutatingSelf.setTaskIdentifierValue(nil)
 
                     switch result {
                     case .success(let value):
-                        guard self.needsTransition(options: finalOptions, cacheType: value.cacheType) else {
-                            self.setPlaceholderValue(nil)
-                            self.base.image = value.image
+                        guard mutatingSelf.needsTransition(options: finalOptions, cacheType: value.cacheType) else {
+                            mutatingSelf.setPlaceholderValue(nil)
+                            base.image = value.image
                             completionHandler?(result)
                             return
                         }
 
-                        self.makeTransition(image: value.image, transition: finalOptions.transition) {
+                        mutatingSelf.makeTransition(image: value.image, transition: finalOptions.transition) {
                             completionHandler?(result)
                         }
 
                     case .failure:
                         if let image = finalOptions.onFailureImage {
-                            self.setPlaceholderValue(nil)
-                            self.base.image = image
+                            mutatingSelf.setPlaceholderValue(nil)
+                            base.image = image
                         }
                         completionHandler?(result)
                     }

--- a/Sources/Utility/Box.swift
+++ b/Sources/Utility/Box.swift
@@ -27,8 +27,25 @@ import Foundation
 
 class Box<T> {
     var value: T
-    
+
     init(_ value: T) {
+        self.value = value
+    }
+}
+
+/// A `Sendable` box that holds its content weakly.
+///
+/// It is used to hand a view to escaping download callbacks without extending the view's
+/// lifetime. The callbacks retain the box, but the box only references its `value` weakly, so
+/// a view whose owner was already released is not kept alive until the download finishes.
+/// See https://github.com/onevcat/Kingfisher/issues/2313
+///
+/// The stored `value` is expected to be accessed on the main thread only (image views are
+/// deallocated on the main thread), which is why `@unchecked Sendable` is safe here.
+final class WeakBox<T: AnyObject>: @unchecked Sendable {
+    weak var value: T?
+
+    init(_ value: T?) {
         self.value = value
     }
 }

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -156,6 +156,35 @@ class ImageViewExtensionTests: XCTestCase, @unchecked Sendable {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    @MainActor func testImageViewNotRetainedByInFlightDownload() {
+        // https://github.com/onevcat/Kingfisher/issues/2313
+        // A download that is still in flight must not keep its target image view alive. Once the
+        // view's owner is released, the view should be deallocated immediately instead of surviving
+        // until the download finishes.
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData, length: 123)
+
+        weak var weakImageView: KFCrossPlatformImageView?
+        autoreleasepool {
+            let imageView = KFCrossPlatformImageView()
+            weakImageView = imageView
+            imageView.kf.setImage(with: url)
+            // The stubbed response is delayed, so the download is still in flight at this point.
+        }
+
+        // The image view has no other owner, so the pending download must not keep it alive.
+        XCTAssertNil(weakImageView, "The image view should be released while its download is still in flight.")
+
+        // The download itself should keep running and still populate the cache.
+        _ = stub.go()
+        delay(0.5) {
+            XCTAssertTrue(KingfisherManager.shared.cache.imageCachedType(forKey: url.cacheKey).cached)
+            exp.fulfill()
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
     @MainActor func testImageDownloadCancelPartialTaskBeforeRequest() {
         let exp = expectation(description: #function)
         let url = testURLs[0]


### PR DESCRIPTION
## What

Fixes #2313.

`imageView.kf.setImage(with:)` hands several closures to `KingfisherManager.retrieveImage` (`downloadTaskUpdated`, `progressiveImageSetter`, `completionHandler`). Each of them captures `self`, which is a `KingfisherWrapper` value that references the target image view **strongly**. Those closures live on the in-flight `SessionDataTask` until the download finishes, so the image view is kept alive until the request completes — even after its owner has been released.

In practice, an image view inside a view controller that is popped/dismissed while an image is still downloading is not deallocated until the download finishes (or until `cancelDownloadTask()` is called manually, as suggested in the issue thread).

## Fix

Hold the image view **weakly** inside those callbacks through a tiny `WeakBox`:

- `downloadTaskUpdated` / `progressiveImageSetter` become no-ops once the view is gone.
- `completionHandler` skips all UI work when the view is gone, but still forwards the result to the caller so anyone awaiting completion is not left hanging.

The download itself is untouched — it keeps running and still populates the cache — and the behavior is identical while the view is alive. This only removes Kingfisher's own retention of the view; there is no public API change.

**Scope note:** this PR addresses the `UIImageView` / `NSImageView` path reported in #2313. The button / `CPListItem` / `NSTextAttachment` paths in `HasImageComponent+Kingfisher.swift` use an accessor-closure indirection and can get the same treatment in a follow-up; I kept this PR focused per the contribution guidelines.

## Tests

Added `testImageViewNotRetainedByInFlightDownload` in `ImageViewExtensionTests`:

1. Start a download backed by a delayed stub, so it stays in flight.
2. Release the only strong reference to the image view.
3. Assert the view is deallocated immediately (a `weak` reference becomes `nil`).
4. Let the stub finish and assert the image is still cached, proving the download was not cancelled.

I confirmed the test **fails on `master`** (the view is retained) and **passes with this change**. The full `ImageViewExtensionTests` suite (35 tests) passes on the iOS simulator.

## Why it matters

Keeping a view alive for the duration of a download is surprising and can noticeably increase peak memory in image-heavy, fast-scrolling screens where cells/controllers are torn down before their images arrive. Capturing the view weakly matches the common expectation (and the behavior of other image libraries) that setting an image should not extend the view's lifetime.
