### PR TITLE
Release remaining image targets during in-flight downloads

### DIFF
--- a/Sources/Extensions/CPListItem+Kingfisher.swift
+++ b/Sources/Extensions/CPListItem+Kingfisher.swift
@@ -109,11 +109,10 @@ extension KingfisherWrapper where Base: CPListItem {
         progressBlock: DownloadProgressBlock? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
     {
-        var mutatingSelf = self
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
-                setImage: { image, _ in
+                setImage: { listItem, image, _ in
                     /**
                      * In iOS SDK 14.0-14.4 the image param was non-`nil`. The SDK changed in 14.5
                      * to allow `nil`. The compiler version 5.4 was introduced in this same SDK,
@@ -122,23 +121,36 @@ extension KingfisherWrapper where Base: CPListItem {
                      * users to compile the framework.
                      */
                     #if compiler(>=5.4)
-                    self.base.setImage(image)
+                    listItem.setImage(image)
                     #else
                     if let image = image {
-                        self.base.setImage(image)
+                        listItem.setImage(image)
                     }
                     #endif
                 },
-                getImage: {
-                    self.base.image
+                getImage: { listItem in
+                    listItem.image
                 }
             ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: { mutatingSelf.taskIdentifier = $0 },
-                getTaskIdentifier: { mutatingSelf.taskIdentifier },
-                setTask: { mutatingSelf.imageTask = $0 },
-                getCancellationToken: { mutatingSelf.cancellationToken },
-                setCancellationToken: { mutatingSelf.cancellationToken = $0 }
+                setTaskIdentifier: { listItem, identifier in
+                    var wrapper = listItem.kf
+                    wrapper.taskIdentifier = identifier
+                },
+                getTaskIdentifier: { listItem in
+                    listItem.kf.taskIdentifier
+                },
+                setTask: { listItem, task in
+                    var wrapper = listItem.kf
+                    wrapper.imageTask = task
+                },
+                getCancellationToken: { listItem in
+                    listItem.kf.cancellationToken
+                },
+                setCancellationToken: { listItem, token in
+                    var wrapper = listItem.kf
+                    wrapper.cancellationToken = token
+                }
             ),
             placeholder: placeholder,
             parsedOptions: parsedOptions,

--- a/Sources/Extensions/HasImageComponent+Kingfisher.swift
+++ b/Sources/Extensions/HasImageComponent+Kingfisher.swift
@@ -87,17 +87,17 @@ import TVUIKit
 extension TVMonogramView: KingfisherHasImageComponent {}
 #endif
 
-struct ImagePropertyAccessor<ImageType>: Sendable {
-    let setImage: @Sendable @MainActor (ImageType?, KingfisherParsedOptionsInfo) -> Void
-    let getImage: @Sendable @MainActor () -> ImageType?
+struct ImagePropertyAccessor<Object: AnyObject, ImageType>: Sendable {
+    let setImage: @Sendable @MainActor (Object, ImageType?, KingfisherParsedOptionsInfo) -> Void
+    let getImage: @Sendable @MainActor (Object) -> ImageType?
 }
 
-struct TaskPropertyAccessor: Sendable {
-    let setTaskIdentifier: @Sendable @MainActor (Source.Identifier.Value?) -> Void
-    let getTaskIdentifier: @Sendable @MainActor () -> Source.Identifier.Value?
-    let setTask: @Sendable @MainActor (DownloadTask?) -> Void
-    let getCancellationToken: @Sendable @MainActor () -> CancellationToken?
-    let setCancellationToken: @Sendable @MainActor (CancellationToken) -> Void
+struct TaskPropertyAccessor<Object: AnyObject>: Sendable {
+    let setTaskIdentifier: @Sendable @MainActor (Object, Source.Identifier.Value?) -> Void
+    let getTaskIdentifier: @Sendable @MainActor (Object) -> Source.Identifier.Value?
+    let setTask: @Sendable @MainActor (Object, DownloadTask?) -> Void
+    let getCancellationToken: @Sendable @MainActor (Object) -> CancellationToken?
+    let setCancellationToken: @Sendable @MainActor (Object, CancellationToken) -> Void
 }
 
 @MainActor
@@ -362,23 +362,35 @@ extension KingfisherWrapper where Base: KingfisherImageSettable {
         progressBlock: DownloadProgressBlock? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
     ) -> DownloadTask? {
-        var mutatingSelf = self
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
-                setImage: { base.setImage($0, options: $1) },
-                getImage: { base.getImage() }
+                setImage: { base, image, options in
+                    base.setImage(image, options: options)
+                },
+                getImage: { base in
+                    base.getImage()
+                }
             ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: {
-                    mutatingSelf.taskIdentifier = $0
+                setTaskIdentifier: { base, identifier in
+                    var wrapper = base.kf
+                    wrapper.taskIdentifier = identifier
                 },
-                getTaskIdentifier: { self.taskIdentifier },
-                setTask: { task in
-                    mutatingSelf.imageTask = task
+                getTaskIdentifier: { base in
+                    base.kf.taskIdentifier
                 },
-                getCancellationToken: { self.cancellationToken },
-                setCancellationToken: { mutatingSelf.cancellationToken = $0 }
+                setTask: { base, task in
+                    var wrapper = base.kf
+                    wrapper.imageTask = task
+                },
+                getCancellationToken: { base in
+                    base.kf.cancellationToken
+                },
+                setCancellationToken: { base, token in
+                    var wrapper = base.kf
+                    wrapper.cancellationToken = token
+                }
             ),
             placeholder: placeholder,
             parsedOptions: parsedOptions,
@@ -389,11 +401,11 @@ extension KingfisherWrapper where Base: KingfisherImageSettable {
 }
 
 @MainActor
-extension KingfisherWrapper {
+extension KingfisherWrapper where Base: AnyObject {
     func setImage(
         with source: Source?,
-        imageAccessor: ImagePropertyAccessor<KFCrossPlatformImage>,
-        taskAccessor: TaskPropertyAccessor,
+        imageAccessor: ImagePropertyAccessor<Base, KFCrossPlatformImage>,
+        taskAccessor: TaskPropertyAccessor<Base>,
         placeholder: KFCrossPlatformImage? = nil,
         parsedOptions: KingfisherParsedOptionsInfo,
         progressBlock: DownloadProgressBlock? = nil,
@@ -401,8 +413,8 @@ extension KingfisherWrapper {
     ) -> DownloadTask?
     {
         guard let source = source else {
-            imageAccessor.setImage(placeholder, parsedOptions)
-            taskAccessor.setTaskIdentifier(nil)
+            imageAccessor.setImage(base, placeholder, parsedOptions)
+            taskAccessor.setTaskIdentifier(base, nil)
             completionHandler?(.failure(KingfisherError.imageSettingError(reason: .emptySource)))
             return nil
         }
@@ -413,35 +425,48 @@ extension KingfisherWrapper {
 #if os(watchOS)
         let usePlaceholderDuringLoading = !options.keepCurrentImageWhileLoading
 #else
-        let usePlaceholderDuringLoading = !options.keepCurrentImageWhileLoading || imageAccessor.getImage() == nil
+        let usePlaceholderDuringLoading = !options.keepCurrentImageWhileLoading || imageAccessor.getImage(base) == nil
 #endif
         if usePlaceholderDuringLoading {
-            imageAccessor.setImage(placeholder, options)
+            imageAccessor.setImage(base, placeholder, options)
         }
 
         let issuedIdentifier = Source.Identifier.next()
-        taskAccessor.setTaskIdentifier(issuedIdentifier)
+        taskAccessor.setTaskIdentifier(base, issuedIdentifier)
 
         let token = CancellationToken()
-        taskAccessor.getCancellationToken()?.cancel()
-        taskAccessor.setCancellationToken(token)
+        taskAccessor.getCancellationToken(base)?.cancel()
+        taskAccessor.setCancellationToken(base, token)
 
         if let block = progressBlock {
             options.onDataReceived = (options.onDataReceived ?? []) + [ImageLoadingProgressSideEffect(block)]
         }
         let finalOptions = options
 
+        // The accessors receive the target when they run, so escaping download callbacks only
+        // retain this weak box and do not extend the target's lifetime.
+        let weakBase = WeakBox(base)
         let task = KingfisherManager.shared.retrieveImage(
             with: source,
             options: finalOptions,
             downloadTaskUpdated: { task in
-                Task { @MainActor in taskAccessor.setTask(task) }
+                Task { @MainActor in
+                    guard let base = weakBase.value else { return }
+                    taskAccessor.setTask(base, task)
+                }
             },
-            progressiveImageSetter: { imageAccessor.setImage($0, finalOptions) },
+            progressiveImageSetter: { image in
+                guard let base = weakBase.value else { return }
+                imageAccessor.setImage(base, image, finalOptions)
+            },
             referenceTaskIdentifierChecker: { !token.isCancelled },
             completionHandler: { result in
                 CallbackQueueMain.currentOrAsync {
-                    guard issuedIdentifier == taskAccessor.getTaskIdentifier() else {
+                    guard let base = weakBase.value else {
+                        completionHandler?(result)
+                        return
+                    }
+                    guard issuedIdentifier == taskAccessor.getTaskIdentifier(base) else {
                         let reason: KingfisherError.ImageSettingErrorReason
                         do {
                             let value = try result.get()
@@ -454,22 +479,22 @@ extension KingfisherWrapper {
                         return
                     }
 
-                    taskAccessor.setTask(nil)
-                    taskAccessor.setTaskIdentifier(nil)
+                    taskAccessor.setTask(base, nil)
+                    taskAccessor.setTaskIdentifier(base, nil)
 
                     switch result {
                     case .success(let value):
-                        imageAccessor.setImage(value.image, finalOptions)
+                        imageAccessor.setImage(base, value.image, finalOptions)
                     case .failure:
                         if let image = finalOptions.onFailureImage {
-                            imageAccessor.setImage(image, finalOptions)
+                            imageAccessor.setImage(base, image, finalOptions)
                         }
                     }
                     completionHandler?(result)
                 }
             }
         )
-        taskAccessor.setTask(task)
+        taskAccessor.setTask(base, task)
         return task
     }
 }

--- a/Sources/Extensions/NSButton+Kingfisher.swift
+++ b/Sources/Extensions/NSButton+Kingfisher.swift
@@ -107,21 +107,36 @@ extension KingfisherWrapper where Base: NSButton {
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
     ) -> DownloadTask?
     {
-        var mutatingSelf = self
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
-                setImage: { image, _ in
-                    base.image = image
-                }, getImage: {
-                    base.image
-                }),
+                setImage: { button, image, _ in
+                    button.image = image
+                },
+                getImage: { button in
+                    button.image
+                }
+            ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: { mutatingSelf.taskIdentifier = $0 },
-                getTaskIdentifier: { mutatingSelf.taskIdentifier },
-                setTask: { mutatingSelf.imageTask = $0 },
-                getCancellationToken: { mutatingSelf.imageCancellationToken },
-                setCancellationToken: { mutatingSelf.imageCancellationToken = $0 }),
+                setTaskIdentifier: { button, identifier in
+                    var wrapper = button.kf
+                    wrapper.taskIdentifier = identifier
+                },
+                getTaskIdentifier: { button in
+                    button.kf.taskIdentifier
+                },
+                setTask: { button, task in
+                    var wrapper = button.kf
+                    wrapper.imageTask = task
+                },
+                getCancellationToken: { button in
+                    button.kf.imageCancellationToken
+                },
+                setCancellationToken: { button, token in
+                    var wrapper = button.kf
+                    wrapper.imageCancellationToken = token
+                }
+            ),
             placeholder: placeholder,
             parsedOptions: parsedOptions,
             progressBlock: progressBlock,
@@ -199,21 +214,35 @@ extension KingfisherWrapper where Base: NSButton {
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil
     ) -> DownloadTask?
     {
-        var mutatingSelf = self
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
-                setImage: { image, _ in
-                    base.alternateImage = image
-                }, getImage: {
-                    base.alternateImage
-                }),
+                setImage: { button, image, _ in
+                    button.alternateImage = image
+                },
+                getImage: { button in
+                    button.alternateImage
+                }
+            ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: { mutatingSelf.alternateTaskIdentifier = $0 },
-                getTaskIdentifier: { mutatingSelf.alternateTaskIdentifier },
-                setTask: { mutatingSelf.alternateImageTask = $0 },
-                getCancellationToken: { mutatingSelf.alternateImageCancellationToken },
-                setCancellationToken: { mutatingSelf.alternateImageCancellationToken = $0 }
+                setTaskIdentifier: { button, identifier in
+                    var wrapper = button.kf
+                    wrapper.alternateTaskIdentifier = identifier
+                },
+                getTaskIdentifier: { button in
+                    button.kf.alternateTaskIdentifier
+                },
+                setTask: { button, task in
+                    var wrapper = button.kf
+                    wrapper.alternateImageTask = task
+                },
+                getCancellationToken: { button in
+                    button.kf.alternateImageCancellationToken
+                },
+                setCancellationToken: { button, token in
+                    var wrapper = button.kf
+                    wrapper.alternateImageCancellationToken = token
+                }
             ),
             placeholder: placeholder,
             parsedOptions: parsedOptions,

--- a/Sources/Extensions/NSTextAttachment+Kingfisher.swift
+++ b/Sources/Extensions/NSTextAttachment+Kingfisher.swift
@@ -195,15 +195,23 @@ extension KingfisherWrapper where Base: NSTextAttachment {
             options.onDataReceived = (options.onDataReceived ?? []) + [ImageLoadingProgressSideEffect(block)]
         }
         let finalOptions = options
+        let weakBase = WeakBox(base)
+        let weakAttributedView = WeakBox(attributedView())
 
         let task = KingfisherManager.shared.retrieveImage(
             with: source,
             options: finalOptions,
-            progressiveImageSetter: { self.base.image = $0 },
+            progressiveImageSetter: { weakBase.value?.image = $0 },
             referenceTaskIdentifierChecker: { !token.isCancelled },
             completionHandler: { result in
                 CallbackQueueMain.currentOrAsync {
-                    guard issuedIdentifier == self.taskIdentifier else {
+                    guard let base = weakBase.value else {
+                        completionHandler?(result)
+                        return
+                    }
+                    let mutatingSelf = base.kf
+
+                    guard issuedIdentifier == mutatingSelf.taskIdentifier else {
                         let reason: KingfisherError.ImageSettingErrorReason
                         do {
                             let value = try result.get()
@@ -216,26 +224,27 @@ extension KingfisherWrapper where Base: NSTextAttachment {
                         return
                     }
 
-                    self.setImageTaskValue(nil)
-                    self.setTaskIdentifierValue(nil)
+                    mutatingSelf.setImageTaskValue(nil)
+                    mutatingSelf.setTaskIdentifierValue(nil)
 
                     switch result {
                     case .success(let value):
-                        self.base.image = value.image
-                        let view = attributedView()
-                        #if canImport(UIKit)
-                        view.setNeedsDisplay()
-                        #else
-                        view.setNeedsDisplay(view.bounds)
-                        #endif
+                        base.image = value.image
+                        if let view = weakAttributedView.value {
+                            #if canImport(UIKit)
+                            view.setNeedsDisplay()
+                            #else
+                            view.setNeedsDisplay(view.bounds)
+                            #endif
+                        }
                     case .failure:
                         if let image = finalOptions.onFailureImage {
-                            self.base.image = image
+                            base.image = image
                         }
                     }
                     completionHandler?(result)
                 }
-        }
+            }
         )
 
         setImageTaskValue(task)

--- a/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
+++ b/Sources/Extensions/PHLivePhotoView+Kingfisher.swift
@@ -206,7 +206,10 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
         // Copy these associated values to prevent issues from reentrance.
         let targetSize = targetSize
         let contentMode = contentMode
-        
+
+        // The task and the PhotoKit result handler only retain this weak box, so the view can be
+        // released while the retrieval is still in flight; terminal results are still forwarded.
+        let weakBase = WeakBox(base)
         let task = Task { @MainActor in
             do {
                 let loadingInfo = try await KingfisherManager.shared.retrieveLivePhoto(
@@ -215,7 +218,8 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
                     progressBlock: nil, // progressBlock, // Not supported yet
                     referenceTaskIdentifierChecker: taskIdentifierChecking
                 )
-                if let notCurrentTaskError = self.checkNotCurrentTask(
+                if let notCurrentTaskError = Self.checkNotCurrentTask(
+                    view: weakBase.value,
                     issuedIdentifier: issuedIdentifier,
                     result: .init(loadingInfo: loadingInfo, livePhoto: nil, info: nil),
                     error: nil,
@@ -224,7 +228,7 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
                     completionHandler?(.failure(notCurrentTaskError))
                     return
                 }
-                
+
                 PHLivePhoto.request(
                     withResourceFileURLs: loadingInfo.fileURLs,
                     placeholderImage: nil,
@@ -236,8 +240,9 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
                             livePhoto: livePhoto,
                             info: info
                         )
-                        
-                        if let notCurrentTaskError = self.checkNotCurrentTask(
+
+                        if let notCurrentTaskError = Self.checkNotCurrentTask(
+                            view: weakBase.value,
                             issuedIdentifier: issuedIdentifier,
                             result: result,
                             error: nil,
@@ -246,8 +251,8 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
                             completionHandler?(.failure(notCurrentTaskError))
                             return
                         }
-                        
-                        base.livePhoto = livePhoto
+
+                        weakBase.value?.livePhoto = livePhoto
                         
                         if let error = info[PHLivePhotoInfoErrorKey] as? NSError {
                             let failingReason: KingfisherError.ImageSettingErrorReason =
@@ -278,7 +283,8 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
                     }
                 )
             } catch {
-                if let notCurrentTaskError = self.checkNotCurrentTask(
+                if let notCurrentTaskError = Self.checkNotCurrentTask(
+                    view: weakBase.value,
                     issuedIdentifier: issuedIdentifier,
                     result: nil,
                     error: error,
@@ -303,13 +309,17 @@ extension KingfisherWrapper where Base: PHLivePhotoView {
         return task
     }
     
-    private func checkNotCurrentTask(
+    private static func checkNotCurrentTask(
+        view: Base?,
         issuedIdentifier: Source.Identifier.Value,
         result: RetrieveLivePhotoResult?,
         error: (any Error)?,
         source: LivePhotoSource
     ) -> KingfisherError? {
-        if issuedIdentifier == self.taskIdentifier {
+        // A released view cannot issue a newer task, so its in-flight task is still the current
+        // one and the terminal result should be forwarded.
+        guard let view else { return nil }
+        if issuedIdentifier == view.kf.taskIdentifier {
             return nil
         }
         return .imageSettingError(reason: .notCurrentLivePhotoSourceTask(result: result, error: error, source: source))

--- a/Sources/Extensions/UIButton+Kingfisher.swift
+++ b/Sources/Extensions/UIButton+Kingfisher.swift
@@ -114,19 +114,34 @@ extension KingfisherWrapper where Base: UIButton {
         progressBlock: DownloadProgressBlock? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
     {
-        var mutatingSelf = self
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
-                setImage: { image, _ in base.setImage(image, for: state) },
-                getImage: { base.image(for: state) }
+                setImage: { button, image, _ in
+                    button.setImage(image, for: state)
+                },
+                getImage: { button in
+                    button.image(for: state)
+                }
             ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: { setTaskIdentifier($0, for: state) },
-                getTaskIdentifier: { taskIdentifier(for: state) },
-                setTask: { mutatingSelf.imageTask = $0 },
-                getCancellationToken: { imageCancellationToken },
-                setCancellationToken: { mutatingSelf.imageCancellationToken = $0 }
+                setTaskIdentifier: { button, identifier in
+                    button.kf.setTaskIdentifier(identifier, for: state)
+                },
+                getTaskIdentifier: { button in
+                    button.kf.taskIdentifier(for: state)
+                },
+                setTask: { button, task in
+                    var wrapper = button.kf
+                    wrapper.imageTask = task
+                },
+                getCancellationToken: { button in
+                    button.kf.imageCancellationToken
+                },
+                setCancellationToken: { button, token in
+                    var wrapper = button.kf
+                    wrapper.imageCancellationToken = token
+                }
             ),
             placeholder: placeholder,
             parsedOptions: parsedOptions,
@@ -226,23 +241,34 @@ extension KingfisherWrapper where Base: UIButton {
         progressBlock: DownloadProgressBlock? = nil,
         completionHandler: (@MainActor @Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)? = nil) -> DownloadTask?
     {
-        var mutatingSelf = self
         return setImage(
             with: source,
             imageAccessor: ImagePropertyAccessor(
-                setImage: { image, _ in
-                    base.setBackgroundImage(image, for: state)
+                setImage: { button, image, _ in
+                    button.setBackgroundImage(image, for: state)
                 },
-                getImage: {
-                    base.backgroundImage(for: state)
+                getImage: { button in
+                    button.backgroundImage(for: state)
                 }
             ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: { setBackgroundTaskIdentifier($0, for: state) },
-                getTaskIdentifier: { backgroundTaskIdentifier(for: state) },
-                setTask: { mutatingSelf.backgroundImageTask = $0 },
-                getCancellationToken: { backgroundImageCancellationToken },
-                setCancellationToken: { mutatingSelf.backgroundImageCancellationToken = $0 }
+                setTaskIdentifier: { button, identifier in
+                    button.kf.setBackgroundTaskIdentifier(identifier, for: state)
+                },
+                getTaskIdentifier: { button in
+                    button.kf.backgroundTaskIdentifier(for: state)
+                },
+                setTask: { button, task in
+                    var wrapper = button.kf
+                    wrapper.backgroundImageTask = task
+                },
+                getCancellationToken: { button in
+                    button.kf.backgroundImageCancellationToken
+                },
+                setCancellationToken: { button, token in
+                    var wrapper = button.kf
+                    wrapper.backgroundImageCancellationToken = token
+                }
             ),
             placeholder: placeholder,
             parsedOptions: parsedOptions,

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -101,8 +101,17 @@ extension KFImage {
                         }
                     },
                     completionHandler: { [weak self] result in
-
-                        guard let self else { return }
+                        guard let self else {
+                            CallbackQueueMain.async {
+                                switch result {
+                                case .success(let value):
+                                    context.onSuccessDelegate.call(value)
+                                case .failure(let error):
+                                    context.onFailureDelegate.call(error)
+                                }
+                            }
+                            return
+                        }
 
                         CallbackQueueMain.currentOrAsync {
                             self.downloadTask = nil

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -88,12 +88,14 @@ extension KFImage {
                 .retrieveImage(
                     with: source,
                     options: context.options,
-                    progressBlock: { size, total in
+                    progressBlock: { [weak self] size, total in
+                        guard let self else { return }
                         self.updateProgress(downloaded: size, total: total)
                         context.onProgressDelegate.call((size, total))
                     },
-                    progressiveImageSetter: { image in
-                        CallbackQueueMain.currentOrAsync {
+                    progressiveImageSetter: { [weak self] image in
+                        CallbackQueueMain.currentOrAsync { [weak self] in
+                            guard let self else { return }
                             self.markLoaded(sendChangeEvent: true)
                             self.loadedImage = image
                         }

--- a/Sources/Utility/Box.swift
+++ b/Sources/Utility/Box.swift
@@ -35,13 +35,13 @@ class Box<T> {
 
 /// A `Sendable` box that holds its content weakly.
 ///
-/// It is used to hand a view to escaping download callbacks without extending the view's
-/// lifetime. The callbacks retain the box, but the box only references its `value` weakly, so
-/// a view whose owner was already released is not kept alive until the download finishes.
+/// It lets escaping image download callbacks refer to a UI target without extending that target's
+/// lifetime. The callbacks retain the box, but the box only references its `value` weakly, so a
+/// target whose owner was already released is not kept alive until the download finishes.
 /// See https://github.com/onevcat/Kingfisher/issues/2313
 ///
-/// The stored `value` is expected to be accessed on the main thread only (image views are
-/// deallocated on the main thread), which is why `@unchecked Sendable` is safe here.
+/// The stored `value` is expected to be accessed on the main thread only, which is why
+/// `@unchecked Sendable` is safe here.
 final class WeakBox<T: AnyObject>: @unchecked Sendable {
     weak var value: T?
 

--- a/Tests/KingfisherTests/ImageBinderTests.swift
+++ b/Tests/KingfisherTests/ImageBinderTests.swift
@@ -31,22 +31,34 @@ import UIKit
 import XCTest
 @testable import Kingfisher
 
+private enum DelayedImageDataProviderError: Error, Sendable {
+    case expected
+}
+
 private final class DelayedImageDataProvider: ImageDataProvider, @unchecked Sendable {
     let cacheKey = "com.onevcat.KingfisherTests.ImageBinder.\(UUID().uuidString)"
-    private let payload: Data
-    private let onDataProvided: @Sendable () -> Void
+    private let result: Result<Data, DelayedImageDataProviderError>
+    private let onResultProvided: @Sendable () -> Void
 
-    init(payload: Data, onDataProvided: @escaping @Sendable () -> Void) {
-        self.payload = payload
-        self.onDataProvided = onDataProvided
+    init(
+        result: Result<Data, DelayedImageDataProviderError>,
+        onResultProvided: @escaping @Sendable () -> Void
+    ) {
+        self.result = result
+        self.onResultProvided = onResultProvided
     }
 
     func data(handler: @escaping @Sendable (Result<Data, any Error>) -> Void) {
-        let payload = payload
-        let onDataProvided = onDataProvided
+        let result = result
+        let onResultProvided = onResultProvided
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            onDataProvided()
-            handler(.success(payload))
+            onResultProvided()
+            switch result {
+            case .success(let data):
+                handler(.success(data))
+            case .failure(let error):
+                handler(.failure(error))
+            }
         }
     }
 }
@@ -115,8 +127,8 @@ class ImageBinderTests: XCTestCase {
     func testBinderNotRetainedByInFlightDataProvider() async {
         let dataProvided = expectation(description: "Data provider finishes")
         let provider = DelayedImageDataProvider(
-            payload: testImagePNGData,
-            onDataProvided: { dataProvided.fulfill() }
+            result: .success(testImagePNGData),
+            onResultProvided: { dataProvided.fulfill() }
         )
         let context = KFImage.Context<Image>(source: .provider(provider))
 
@@ -130,6 +142,55 @@ class ImageBinderTests: XCTestCase {
         XCTAssertNil(weakBinder, "A binder should be released while its image retrieval is still in flight.")
 
         await fulfillment(of: [dataProvided], timeout: 1)
+    }
+
+    @MainActor
+    func testReleasedBinderForwardsSuccess() async {
+        let resultReceived = expectation(description: "Success is forwarded")
+        let provider = DelayedImageDataProvider(
+            result: .success(testImagePNGData),
+            onResultProvided: {}
+        )
+        let context = KFImage.Context<Image>(source: .provider(provider))
+        context.onSuccessDelegate.delegate(on: self) { _, result in
+            XCTAssertNotNil(result.image)
+            resultReceived.fulfill()
+        }
+
+        weak var weakBinder: KFImage.ImageBinder?
+        autoreleasepool {
+            let binder = KFImage.ImageBinder()
+            weakBinder = binder
+            binder.start(context: context)
+        }
+
+        XCTAssertNil(weakBinder, "A binder should be released while its image retrieval is still in flight.")
+
+        await fulfillment(of: [resultReceived], timeout: 1)
+    }
+
+    @MainActor
+    func testReleasedBinderForwardsFailure() async {
+        let resultReceived = expectation(description: "Failure is forwarded")
+        let provider = DelayedImageDataProvider(
+            result: .failure(.expected),
+            onResultProvided: {}
+        )
+        let context = KFImage.Context<Image>(source: .provider(provider))
+        context.onFailureDelegate.delegate(on: self) { _, _ in
+            resultReceived.fulfill()
+        }
+
+        weak var weakBinder: KFImage.ImageBinder?
+        autoreleasepool {
+            let binder = KFImage.ImageBinder()
+            weakBinder = binder
+            binder.start(context: context)
+        }
+
+        XCTAssertNil(weakBinder, "A binder should be released while its image retrieval is still in flight.")
+
+        await fulfillment(of: [resultReceived], timeout: 1)
     }
 }
 

--- a/Tests/KingfisherTests/ImageBinderTests.swift
+++ b/Tests/KingfisherTests/ImageBinderTests.swift
@@ -31,6 +31,26 @@ import UIKit
 import XCTest
 @testable import Kingfisher
 
+private final class DelayedImageDataProvider: ImageDataProvider, @unchecked Sendable {
+    let cacheKey = "com.onevcat.KingfisherTests.ImageBinder.\(UUID().uuidString)"
+    private let payload: Data
+    private let onDataProvided: @Sendable () -> Void
+
+    init(payload: Data, onDataProvided: @escaping @Sendable () -> Void) {
+        self.payload = payload
+        self.onDataProvided = onDataProvided
+    }
+
+    func data(handler: @escaping @Sendable (Result<Data, any Error>) -> Void) {
+        let payload = payload
+        let onDataProvided = onDataProvided
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            onDataProvided()
+            handler(.success(payload))
+        }
+    }
+}
+
 @available(iOS 14.0, tvOS 14.0, *)
 class ImageBinderTests: XCTestCase {
     @MainActor
@@ -89,6 +109,27 @@ class ImageBinderTests: XCTestCase {
         binder.start(context: context)
 
         await fulfillment(of: [success], timeout: 1)
+    }
+
+    @MainActor
+    func testBinderNotRetainedByInFlightDataProvider() async {
+        let dataProvided = expectation(description: "Data provider finishes")
+        let provider = DelayedImageDataProvider(
+            payload: testImagePNGData,
+            onDataProvided: { dataProvided.fulfill() }
+        )
+        let context = KFImage.Context<Image>(source: .provider(provider))
+
+        weak var weakBinder: KFImage.ImageBinder?
+        autoreleasepool {
+            let binder = KFImage.ImageBinder()
+            weakBinder = binder
+            binder.start(context: context)
+        }
+
+        XCTAssertNil(weakBinder, "A binder should be released while its image retrieval is still in flight.")
+
+        await fulfillment(of: [dataProvided], timeout: 1)
     }
 }
 

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -27,6 +27,10 @@
 import XCTest
 @testable import Kingfisher
 
+#if canImport(PhotosUI) && !os(watchOS)
+import PhotosUI
+#endif
+
 @MainActor
 private final class TestImageComponent: KingfisherHasImageComponent {
     var image: KFCrossPlatformImage?
@@ -241,6 +245,50 @@ class ImageViewExtensionTests: XCTestCase, @unchecked Sendable {
         waitForExpectations(timeout: 3, handler: nil)
         XCTAssertTrue(KingfisherManager.shared.cache.imageCachedType(forKey: url.cacheKey).cached)
     }
+
+    #if canImport(PhotosUI) && !os(watchOS)
+    @MainActor func testLivePhotoViewNotRetainedByInFlightDownload() {
+        let completion = expectation(description: #function)
+        let stubs = [
+            delayedStub(LivePhotoURL.heic, data: testImageData),
+            delayedStub(LivePhotoURL.mov, data: testImageData)
+        ]
+
+        weak var weakView: PHLivePhotoView?
+        autoreleasepool {
+            let view = PHLivePhotoView()
+            weakView = view
+            view.kf.setImage(with: [LivePhotoURL.heic, LivePhotoURL.mov]) { result in
+                // The stubbed data is not a real live photo, so PhotoKit ends the request with an
+                // error. What matters is that the terminal result is still forwarded after the
+                // view is released, and that the downloaded resources are cached.
+                XCTAssertTrue(Thread.isMainThread)
+                completion.fulfill()
+            }
+        }
+
+        XCTAssertNil(weakView, "A live photo view should be released while its downloads are still in flight.")
+
+        stubs.forEach { _ = $0.go() }
+        waitForExpectations(timeout: 5, handler: nil)
+
+        let cache = KingfisherManager.shared.cache
+        XCTAssertTrue(
+            cache.isCached(
+                forKey: LivePhotoURL.heic.cacheKey,
+                processorIdentifier: LivePhotoImageProcessor.default.identifier,
+                forcedExtension: LivePhotoURL.heic.pathExtension
+            )
+        )
+        XCTAssertTrue(
+            cache.isCached(
+                forKey: LivePhotoURL.mov.cacheKey,
+                processorIdentifier: LivePhotoImageProcessor.default.identifier,
+                forcedExtension: LivePhotoURL.mov.pathExtension
+            )
+        )
+    }
+    #endif
 
     @MainActor func testImageDownloadCancelPartialTaskBeforeRequest() {
         let exp = expectation(description: #function)

--- a/Tests/KingfisherTests/ImageViewExtensionTests.swift
+++ b/Tests/KingfisherTests/ImageViewExtensionTests.swift
@@ -27,6 +27,11 @@
 import XCTest
 @testable import Kingfisher
 
+@MainActor
+private final class TestImageComponent: KingfisherHasImageComponent {
+    var image: KFCrossPlatformImage?
+}
+
 class ImageViewExtensionTests: XCTestCase, @unchecked Sendable {
 
     var imageView: KFCrossPlatformImageView!
@@ -161,7 +166,7 @@ class ImageViewExtensionTests: XCTestCase, @unchecked Sendable {
         // A download that is still in flight must not keep its target image view alive. Once the
         // view's owner is released, the view should be deallocated immediately instead of surviving
         // until the download finishes.
-        let exp = expectation(description: #function)
+        let completion = expectation(description: #function)
         let url = testURLs[0]
         let stub = delayedStub(url, data: testImageData, length: 123)
 
@@ -169,20 +174,72 @@ class ImageViewExtensionTests: XCTestCase, @unchecked Sendable {
         autoreleasepool {
             let imageView = KFCrossPlatformImageView()
             weakImageView = imageView
-            imageView.kf.setImage(with: url)
+            imageView.kf.setImage(with: url) { result in
+                XCTAssertNotNil(result.value)
+                XCTAssertTrue(Thread.isMainThread)
+                completion.fulfill()
+            }
             // The stubbed response is delayed, so the download is still in flight at this point.
         }
 
         // The image view has no other owner, so the pending download must not keep it alive.
         XCTAssertNil(weakImageView, "The image view should be released while its download is still in flight.")
 
-        // The download itself should keep running and still populate the cache.
+        // The download itself should keep running, call the completion handler, and populate the cache.
         _ = stub.go()
-        delay(0.5) {
-            XCTAssertTrue(KingfisherManager.shared.cache.imageCachedType(forKey: url.cacheKey).cached)
-            exp.fulfill()
-        }
         waitForExpectations(timeout: 3, handler: nil)
+        XCTAssertTrue(KingfisherManager.shared.cache.imageCachedType(forKey: url.cacheKey).cached)
+
+    }
+
+    @MainActor func testImageSettableObjectNotRetainedByInFlightDownload() {
+        let completion = expectation(description: #function)
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData, length: 123)
+
+        weak var weakTarget: TestImageComponent?
+        autoreleasepool {
+            let target = TestImageComponent()
+            weakTarget = target
+            target.kf.setImage(with: url) { result in
+                XCTAssertNotNil(result.value)
+                XCTAssertTrue(Thread.isMainThread)
+                completion.fulfill()
+            }
+        }
+
+        XCTAssertNil(weakTarget, "An image-settable object should be released while its download is still in flight.")
+
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+        XCTAssertTrue(KingfisherManager.shared.cache.imageCachedType(forKey: url.cacheKey).cached)
+    }
+
+    @MainActor func testTextAttachmentAndAttributedViewNotRetainedByInFlightDownload() {
+        let completion = expectation(description: #function)
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData, length: 123)
+
+        weak var weakAttachment: NSTextAttachment?
+        weak var weakAttributedView: KFCrossPlatformView?
+        autoreleasepool {
+            let attributedView = KFCrossPlatformView()
+            let attachment = NSTextAttachment()
+            weakAttachment = attachment
+            weakAttributedView = attributedView
+            attachment.kf.setImage(with: url, attributedView: attributedView, completionHandler: { result in
+                XCTAssertNotNil(result.value)
+                XCTAssertTrue(Thread.isMainThread)
+                completion.fulfill()
+            })
+        }
+
+        XCTAssertNil(weakAttachment, "A text attachment should be released while its download is still in flight.")
+        XCTAssertNil(weakAttributedView, "An attributed view should not be retained by an attachment download.")
+
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+        XCTAssertTrue(KingfisherManager.shared.cache.imageCachedType(forKey: url.cacheKey).cached)
     }
 
     @MainActor func testImageDownloadCancelPartialTaskBeforeRequest() {

--- a/Tests/KingfisherTests/NSButtonExtensionTests.swift
+++ b/Tests/KingfisherTests/NSButtonExtensionTests.swift
@@ -109,6 +109,54 @@ class NSButtonExtensionTests: XCTestCase, @unchecked Sendable {
     }
     
     @MainActor
+    func testButtonNotRetainedByInFlightImageDownload() {
+        let completion = expectation(description: #function)
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData, length: 123)
+
+        weak var weakButton: NSButton?
+        autoreleasepool {
+            let button = NSButton()
+            weakButton = button
+            button.kf.setImage(with: url, completionHandler: { result in
+                XCTAssertNotNil(result.value)
+                XCTAssertTrue(Thread.isMainThread)
+                completion.fulfill()
+            })
+        }
+
+        XCTAssertNil(weakButton, "A button should be released while its image download is still in flight.")
+
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+        XCTAssertTrue(KingfisherManager.shared.cache.imageCachedType(forKey: url.cacheKey).cached)
+    }
+
+    @MainActor
+    func testButtonNotRetainedByInFlightAlternateImageDownload() {
+        let completion = expectation(description: #function)
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData, length: 123)
+
+        weak var weakButton: NSButton?
+        autoreleasepool {
+            let button = NSButton()
+            weakButton = button
+            button.kf.setAlternateImage(with: url, completionHandler: { result in
+                XCTAssertNotNil(result.value)
+                XCTAssertTrue(Thread.isMainThread)
+                completion.fulfill()
+            })
+        }
+
+        XCTAssertNil(weakButton, "A button should be released while its alternate image download is still in flight.")
+
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+        XCTAssertTrue(KingfisherManager.shared.cache.imageCachedType(forKey: url.cacheKey).cached)
+    }
+
+    @MainActor
     func testCancelImageTask() {
         let exp = expectation(description: #function)
         let url = testURLs[0]

--- a/Tests/KingfisherTests/UIButtonExtensionTests.swift
+++ b/Tests/KingfisherTests/UIButtonExtensionTests.swift
@@ -110,6 +110,52 @@ class UIButtonExtensionTests: XCTestCase, @unchecked Sendable {
         waitForExpectations(timeout: 3, handler: nil)
     }
     
+    @MainActor func testButtonNotRetainedByInFlightImageDownload() {
+        let completion = expectation(description: #function)
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData, length: 123)
+
+        weak var weakButton: UIButton?
+        autoreleasepool {
+            let button = UIButton()
+            weakButton = button
+            button.kf.setImage(with: url, for: .normal, completionHandler: { result in
+                XCTAssertNotNil(result.value)
+                XCTAssertTrue(Thread.isMainThread)
+                completion.fulfill()
+            })
+        }
+
+        XCTAssertNil(weakButton, "A button should be released while its image download is still in flight.")
+
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+        XCTAssertTrue(KingfisherManager.shared.cache.imageCachedType(forKey: url.cacheKey).cached)
+    }
+
+    @MainActor func testButtonNotRetainedByInFlightBackgroundImageDownload() {
+        let completion = expectation(description: #function)
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData, length: 123)
+
+        weak var weakButton: UIButton?
+        autoreleasepool {
+            let button = UIButton()
+            weakButton = button
+            button.kf.setBackgroundImage(with: url, for: .normal, completionHandler: { result in
+                XCTAssertNotNil(result.value)
+                XCTAssertTrue(Thread.isMainThread)
+                completion.fulfill()
+            })
+        }
+
+        XCTAssertNil(weakButton, "A button should be released while its background image download is still in flight.")
+
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+        XCTAssertTrue(KingfisherManager.shared.cache.imageCachedType(forKey: url.cacheKey).cached)
+    }
+
     @MainActor func testCancelImageTask() {
         let exp = expectation(description: #function)
         let url = testURLs[0]


### PR DESCRIPTION
## Summary
- release image-settable targets, buttons, CarPlay list items, text attachments, attributed views, and SwiftUI binders while their retrieval is in flight
- keep downloads and caching active, while forwarding terminal results after a target has been released
- add lifecycle regressions for every affected imperative path and `ImageBinder`

Follow-up to #2313 and #2561.

## Verification
- `bundle exec fastlane tests`
- targeted lifecycle regressions on iOS, macOS, and tvOS
- watchOS build