### PR TITLE
Add an isLoaded flag to the contentConfigure block

### DIFF
--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -51,7 +51,7 @@ extension KFImage {
 
         private(set) var animating = false
 
-        var loadedImage: KFCrossPlatformImage? = nil { willSet { objectWillChange.send() } }
+        private(set) var loadedImage: KFCrossPlatformImage? = nil { willSet { objectWillChange.send() } }
         var failureView: (() -> AnyView)? = nil { willSet { objectWillChange.send() } }
         var progress: Progress = .init()
 
@@ -63,8 +63,9 @@ extension KFImage {
         ///
         /// A cancelled request can still deliver its failure after a restarted load has begun, so the two values have
         /// to change as a pair. Otherwise the provenance outlives the image it described, and a retrieved image ends
-        /// up reported as a fallback. Assigning here also covers the change event, since `loadedImage` sends it.
-        private func setLoadedImage(_ image: KFCrossPlatformImage?, isFailureImage: Bool = false) {
+        /// up reported as a fallback. Going through here is the only way to set the image, so no assignment site can
+        /// leave the two out of step. It also covers the change event, since `loadedImage` sends it.
+        func setLoadedImage(_ image: KFCrossPlatformImage?, isFailureImage: Bool = false) {
             usesFailureImage = isFailureImage
             loadedImage = image
         }

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -57,9 +57,17 @@ extension KFImage {
 
         /// Whether the current `loadedImage` is the fallback supplied by the deprecated `onFailureImage`, instead of
         /// an image retrieved from the cache or the network.
-        ///
-        /// It is always set right before `loadedImage`, so the change event sent by `loadedImage` also covers it.
         private(set) var usesFailureImage = false
+
+        /// Sets `loadedImage` together with where that image came from.
+        ///
+        /// A cancelled request can still deliver its failure after a restarted load has begun, so the two values have
+        /// to change as a pair. Otherwise the provenance outlives the image it described, and a retrieved image ends
+        /// up reported as a fallback. Assigning here also covers the change event, since `loadedImage` sends it.
+        private func setLoadedImage(_ image: KFCrossPlatformImage?, isFailureImage: Bool = false) {
+            usesFailureImage = isFailureImage
+            loadedImage = image
+        }
 
         func markLoading() {
             loading = true
@@ -73,18 +81,13 @@ extension KFImage {
         }
 
         func start<HoldingView: KFImageHoldingView>(context: Context<HoldingView>) where HoldingView: Sendable {
-            // `onFailureImage` accepts a `nil` image, which leaves `loadedImage` empty while the flag is set. That
-            // state is not terminal, so a retry has to clear the flag before it can set a retrieved image again.
-            usesFailureImage = false
-
             guard let source = context.source else {
                 CallbackQueueMain.currentOrAsync {
                     context.onFailureDelegate.call(KingfisherError.imageSettingError(reason: .emptySource))
                     if let view = context.failureView {
                         self.failureView = view
                     } else if let image = context.options.onFailureImage {
-                        self.usesFailureImage = true
-                        self.loadedImage = image
+                        self.setLoadedImage(image, isFailureImage: true)
                     }
                     self.loading = false
                     self.markLoaded(sendChangeEvent: false)
@@ -108,7 +111,7 @@ extension KFImage {
                         CallbackQueueMain.currentOrAsync { [weak self] in
                             guard let self else { return }
                             self.markLoaded(sendChangeEvent: true)
-                            self.loadedImage = image
+                            self.setLoadedImage(image)
                         }
                     },
                     completionHandler: { [weak self] result in
@@ -136,7 +139,7 @@ extension KFImage {
                                    context.shouldApplyFade(cacheType: value.cacheType) {
                                     // Apply SwiftUI loadTransition with custom animation (higher priority than fade)
                                     self.animating = true
-                                    self.loadedImage = value.image
+                                    self.setLoadedImage(value.image)
 
                                     let animation = context.swiftUIAnimation ?? .default
                                     CallbackQueueMain.async {
@@ -148,7 +151,7 @@ extension KFImage {
                                     }
                                 } else if let fadeDuration = context.fadeTransitionDuration(cacheType: value.cacheType) {
                                     self.animating = true
-                                    self.loadedImage = value.image
+                                    self.setLoadedImage(value.image)
 
                                     let animation = Animation.linear(duration: fadeDuration)
                                     CallbackQueueMain.async {
@@ -161,7 +164,7 @@ extension KFImage {
                                     }
                                 } else {
                                     self.markLoaded(sendChangeEvent: false)
-                                    self.loadedImage = value.image
+                                    self.setLoadedImage(value.image)
 
                                     CallbackQueueMain.async {
                                         context.onSuccessDelegate.call(value)
@@ -173,8 +176,7 @@ extension KFImage {
                                 if let view = context.failureView {
                                     self.failureView = view
                                 } else if let image = context.options.onFailureImage {
-                                    self.usesFailureImage = true
-                                    self.loadedImage = image
+                                    self.setLoadedImage(image, isFailureImage: true)
                                 }
                                 self.markLoaded(sendChangeEvent: false)
                             }

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -55,6 +55,12 @@ extension KFImage {
         var failureView: (() -> AnyView)? = nil { willSet { objectWillChange.send() } }
         var progress: Progress = .init()
 
+        /// Whether the current `loadedImage` is the fallback supplied by the deprecated `onFailureImage`, instead of
+        /// an image retrieved from the cache or the network.
+        ///
+        /// It is always set right before `loadedImage`, so the change event sent by `loadedImage` also covers it.
+        private(set) var usesFailureImage = false
+
         func markLoading() {
             loading = true
         }
@@ -67,12 +73,17 @@ extension KFImage {
         }
 
         func start<HoldingView: KFImageHoldingView>(context: Context<HoldingView>) where HoldingView: Sendable {
+            // `onFailureImage` accepts a `nil` image, which leaves `loadedImage` empty while the flag is set. That
+            // state is not terminal, so a retry has to clear the flag before it can set a retrieved image again.
+            usesFailureImage = false
+
             guard let source = context.source else {
                 CallbackQueueMain.currentOrAsync {
                     context.onFailureDelegate.call(KingfisherError.imageSettingError(reason: .emptySource))
                     if let view = context.failureView {
                         self.failureView = view
                     } else if let image = context.options.onFailureImage {
+                        self.usesFailureImage = true
                         self.loadedImage = image
                     }
                     self.loading = false
@@ -162,6 +173,7 @@ extension KFImage {
                                 if let view = context.failureView {
                                     self.failureView = view
                                 } else if let image = context.options.onFailureImage {
+                                    self.usesFailureImage = true
                                     self.loadedImage = image
                                 }
                                 self.markLoaded(sendChangeEvent: false)

--- a/Sources/SwiftUI/ImageContext.swift
+++ b/Sources/SwiftUI/ImageContext.swift
@@ -55,8 +55,9 @@ extension KFImage {
             set { propertyQueue.sync { _renderConfigurations = newValue } }
         }
         
-        var _contentConfiguration: ((HoldingView) -> AnyView)? = nil
-        var contentConfiguration: ((HoldingView) -> AnyView)? {
+        // The `Bool` parameter tells whether the passed-in view holds an image retrieved from the cache or the network.
+        var _contentConfiguration: ((HoldingView, Bool) -> AnyView)? = nil
+        var contentConfiguration: ((HoldingView, Bool) -> AnyView)? {
             get { propertyQueue.sync { _contentConfiguration } }
             set { propertyQueue.sync { _contentConfiguration = newValue } }
         }

--- a/Sources/SwiftUI/KFImageProtocol.swift
+++ b/Sources/SwiftUI/KFImageProtocol.swift
@@ -105,8 +105,8 @@ extension KFImageProtocol {
     /// Configures the current image with a `block` and returns a `View` to use as the final content, with a flag
     /// telling whether the image is loaded as input.
     ///
-    /// This block will be lazily applied when creating the final `Image`. Since the block is also evaluated before the
-    /// image is loaded, the `isLoaded` parameter lets you skip configurations that only make sense for a real image:
+    /// This block will be lazily applied when creating the final `Image`. It does not run only for images the caller
+    /// retrieved, so the `isLoaded` parameter lets you gate configurations that only make sense for a real image:
     ///
     /// ```swift
     /// KFImage(url)
@@ -120,13 +120,15 @@ extension KFImageProtocol {
     /// ```
     ///
     /// The `isLoaded` parameter is `true` only when the image comes from the cache or the network, including a partial
-    /// image delivered by progressive loading. It is `false` before the loading finishes, as well as for the fallback
-    /// supplied by the deprecated `onFailureImage`.
+    /// image delivered by progressive loading. It is `false` in two situations, which differ in whether the view the
+    /// block returns reaches the screen:
     ///
-    /// - Note: The view returned while `isLoaded` is `false` does not appear on screen, since the image branch is kept
-    /// hidden until an image is available. Use `placeholder(_:)` for the loading state and ``onFailureView(_:)`` for
-    /// the failure state instead. If a load transition is set by `loadTransition(_:animation:)`, the block is only
-    /// evaluated after the image is loaded, so `isLoaded` is always `true` there.
+    /// - **Before any image exists.** The default rendering path still evaluates the block, but keeps the image branch
+    /// hidden, so what the block returns is not displayed. Setting a load transition with
+    /// `loadTransition(_:animation:)` skips this evaluation instead. Use `placeholder(_:)` to fill the loading state.
+    /// - **While the fallback supplied by the deprecated `onFailureImage` is shown.** That fallback is a real image, so
+    /// the block is evaluated *and* its result displayed with `isLoaded` as `false` — on the default path and with a
+    /// load transition alike. Use ``onFailureView(_:)`` to render a failure state that is not an image.
     ///
     /// If multiple `contentConfigure` modifiers are added to the image, only the last one will be stored and used.
     ///

--- a/Sources/SwiftUI/KFImageProtocol.swift
+++ b/Sources/SwiftUI/KFImageProtocol.swift
@@ -98,9 +98,45 @@ extension KFImageProtocol {
     /// - Parameter block: The block applies to the loaded image. The block should return a `View` that is configured.
     /// - Returns: A ``KFImage`` or ``KFAnimatedImage`` view that configures the internal `Image` with the provided
     /// `block`.
-    public func contentConfigure<V: View>(_ block: @escaping (HoldingView) -> V) -> Self {
+    public func contentConfigure<V: View>(@ViewBuilder _ block: @escaping (HoldingView) -> V) -> Self {
+        contentConfigure { view, _ in block(view) }
+    }
+
+    /// Configures the current image with a `block` and returns a `View` to use as the final content, with a flag
+    /// telling whether the image is loaded as input.
+    ///
+    /// This block will be lazily applied when creating the final `Image`. Since the block is also evaluated before the
+    /// image is loaded, the `isLoaded` parameter lets you skip configurations that only make sense for a real image:
+    ///
+    /// ```swift
+    /// KFImage(url)
+    ///     .contentConfigure { image, isLoaded in
+    ///         if isLoaded {
+    ///             image.resizable().scaledToFit().overlay(Badge())
+    ///         } else {
+    ///             image
+    ///         }
+    ///     }
+    /// ```
+    ///
+    /// The `isLoaded` parameter is `true` only when the image comes from the cache or the network, including a partial
+    /// image delivered by progressive loading. It is `false` before the loading finishes, as well as for the fallback
+    /// supplied by the deprecated `onFailureImage`.
+    ///
+    /// - Note: The view returned while `isLoaded` is `false` does not appear on screen, since the image branch is kept
+    /// hidden until an image is available. Use `placeholder(_:)` for the loading state and ``onFailureView(_:)`` for
+    /// the failure state instead. If a load transition is set by `loadTransition(_:animation:)`, the block is only
+    /// evaluated after the image is loaded, so `isLoaded` is always `true` there.
+    ///
+    /// If multiple `contentConfigure` modifiers are added to the image, only the last one will be stored and used.
+    ///
+    /// - Parameter block: The block applies to the loaded image and a flag telling whether the image is loaded. The
+    /// block should return a `View` that is configured.
+    /// - Returns: A ``KFImage`` or ``KFAnimatedImage`` view that configures the internal `Image` with the provided
+    /// `block`.
+    public func contentConfigure<V: View>(@ViewBuilder _ block: @escaping (HoldingView, Bool) -> V) -> Self {
         let result = copyForMutation()
-        result.context.contentConfiguration = { AnyView(block($0)) }
+        result.context.contentConfiguration = { AnyView(block($0, $1)) }
         return result
     }
 }

--- a/Sources/SwiftUI/KFImageRenderer.swift
+++ b/Sources/SwiftUI/KFImageRenderer.swift
@@ -52,8 +52,6 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
         }
         
         return ZStack {
-            let isImageRenderable = binder.loadedImage != nil && binder.loaded
-
             if context.swiftUITransition == nil {
                 // Fade transition or no transition: use opacity control
                 // Keep the image branch for external transitions without affecting layout while no
@@ -120,6 +118,20 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
         .onAppear()
     }
     
+    /// Whether the image branch takes part in rendering and layout.
+    ///
+    /// The fallback set by the deprecated `onFailureImage` also has to be rendered, so this stays independent of
+    /// `isImageLoaded`.
+    private var isImageRenderable: Bool {
+        binder.loadedImage != nil && binder.loaded
+    }
+
+    /// Whether the rendered image was retrieved from the cache or the network, as opposed to the fallback set by the
+    /// deprecated `onFailureImage`.
+    private var isImageLoaded: Bool {
+        isImageRenderable && !binder.usesFailureImage
+    }
+
     @ViewBuilder
     private func renderedImage() -> some View {
         if let swiftUITransition = context.swiftUITransition {
@@ -139,7 +151,7 @@ struct KFImageRenderer<HoldingView> : View where HoldingView: KFImageHoldingView
         
         // Apply contentConfiguration first, then loadTransition as the final step
         if let contentConfiguration = context.contentConfiguration {
-            contentConfiguration(configuredImage)
+            contentConfiguration(configuredImage, isImageLoaded)
         } else {
             configuredImage
         }

--- a/Tests/KingfisherTests/ImageBinderTests.swift
+++ b/Tests/KingfisherTests/ImageBinderTests.swift
@@ -192,6 +192,41 @@ class ImageBinderTests: XCTestCase {
 
         await fulfillment(of: [resultReceived], timeout: 1)
     }
+
+    // A cancelled request keeps `loadedImage` empty, so the binder can be restarted before that request has delivered
+    // its failure. When the failure lands afterwards it installs the fallback image and records it, and the restarted
+    // load must still be able to report its own image as retrieved.
+    @MainActor
+    @available(*, deprecated) // Silences the deprecation warning for `onFailureImage` under test.
+    func testRetrievedImageClearsProvenanceLeftByAStaleFailureCallback() async {
+        let binder = KFImage.ImageBinder()
+        let success = expectation(description: "The restarted loading succeeds")
+
+        // The restarted request. A fresh cache key keeps it out of the cache, so it stays in flight below.
+        let provider = RawImageDataProvider(
+            data: testImagePNGData,
+            cacheKey: "com.onevcat.KingfisherTests.ImageBinder.\(UUID().uuidString)"
+        )
+        let restartedContext = KFImage.Context<Image>(source: .provider(provider))
+        restartedContext.onSuccessDelegate.delegate(on: self) { _, _ in
+            success.fulfill()
+        }
+        binder.start(context: restartedContext)
+
+        // Stands in for the cancelled request delivering its failure while the restarted one is still loading.
+        let staleFailureContext = KFImage.Context<Image>(source: nil)
+        staleFailureContext.options.onFailureImage = .some(testImage)
+        binder.start(context: staleFailureContext)
+        XCTAssertTrue(binder.usesFailureImage, "The stale failure callback should install the fallback image.")
+
+        await fulfillment(of: [success], timeout: 1)
+
+        XCTAssertNotNil(binder.loadedImage)
+        XCTAssertFalse(
+            binder.usesFailureImage,
+            "A retrieved image must carry its own provenance instead of inheriting the stale one."
+        )
+    }
 }
 
 #endif

--- a/Tests/KingfisherTests/KFImageRendererTests.swift
+++ b/Tests/KingfisherTests/KFImageRendererTests.swift
@@ -222,22 +222,37 @@ class KFImageRendererTests: XCTestCase {
         )
     }
 
+    // A cancelled request keeps `loadedImage` empty, so the binder can be restarted while the cancelled request has
+    // not delivered its failure yet. When that failure lands afterwards it installs the fallback image, and the
+    // restarted load must still be able to report its own image as retrieved.
     @MainActor
     @available(*, deprecated) // Silences the deprecation warning for `onFailureImage` under test.
-    func testFailureImageFlagIsResetWhenLoadingRestarts() {
+    func testRetrievedImageClearsProvenanceLeftByAStaleFailureCallback() async {
         let binder = KFImage.ImageBinder()
+        let successExpectation = expectation(description: "Restarted loading succeeds")
 
-        // `onFailureImage` accepts a `nil` image, so the flag can be set while `loadedImage` stays empty. That state
-        // is not terminal, and a stale flag would make the next successful load look like a fallback image.
-        let failingContext = KFImage.Context<Image>(source: nil)
-        failingContext.options.onFailureImage = .some(nil)
+        // The restarted request. A fresh cache key keeps it out of the cache, so it stays in flight below.
+        let restartedContext = KFImage.Context<Image>(
+            source: .provider(RawImageDataProvider(data: testImageData, cacheKey: UUID().uuidString))
+        )
+        restartedContext.onSuccessDelegate.delegate(on: self) { _, _ in
+            successExpectation.fulfill()
+        }
+        binder.start(context: restartedContext)
 
-        binder.start(context: failingContext)
-        XCTAssertTrue(binder.usesFailureImage)
-        XCTAssertNil(binder.loadedImage)
+        // The cancelled request delivers its failure while the restarted one is still loading.
+        let staleFailureContext = KFImage.Context<Image>(source: nil)
+        staleFailureContext.options.onFailureImage = .some(testImage)
+        binder.start(context: staleFailureContext)
+        XCTAssertTrue(binder.usesFailureImage, "The stale failure callback should install the fallback image.")
 
-        binder.start(context: KFImage.Context<Image>(source: nil))
-        XCTAssertFalse(binder.usesFailureImage)
+        await fulfillment(of: [successExpectation], timeout: 1)
+
+        XCTAssertNotNil(binder.loadedImage)
+        XCTAssertFalse(
+            binder.usesFailureImage,
+            "A retrieved image must carry its own provenance instead of inheriting the stale one."
+        )
     }
 
     // MARK: - Renderer intermediate states

--- a/Tests/KingfisherTests/KFImageRendererTests.swift
+++ b/Tests/KingfisherTests/KFImageRendererTests.swift
@@ -162,22 +162,13 @@ class KFImageRendererTests: XCTestCase {
     // The `isLoaded` flag lets the caller gate configurations that only make sense for a real image. It must
     // distinguish an image retrieved from the cache or the network from the fallback set by `onFailureImage`, which
     // is rendered through the very same branch.
-    private let loadedHeight: CGFloat = 123
-    private let notLoadedHeight: CGFloat = 45
-
     @MainActor
     func testContentConfigureReceivesIsLoadedAfterSuccess() async {
         let successExpectation = expectation(description: "Image loading succeeds")
 
         let view = KFImage
             .data(testImageData, cacheKey: "com.onevcat.KingfisherTests.contentConfigureIsLoadedOnSuccess")
-            .contentConfigure { image, isLoaded in
-                if isLoaded {
-                    image.resizable().frame(height: self.loadedHeight)
-                } else {
-                    image.resizable().frame(height: self.notLoadedHeight)
-                }
-            }
+            .measuringIsLoaded()
             .onSuccess { _ in
                 successExpectation.fulfill()
             }
@@ -186,7 +177,7 @@ class KFImageRendererTests: XCTestCase {
 
         XCTAssertEqual(
             measuredSize.height,
-            loadedHeight,
+            isLoadedTrueHeight,
             accuracy: 0.5,
             "`isLoaded` should be `true` once the image is retrieved from the cache or the network."
         )
@@ -199,13 +190,7 @@ class KFImageRendererTests: XCTestCase {
 
         let view = KFImage.dataProvider(FailingImageDataProvider())
             .onFailureImage(testImage)
-            .contentConfigure { image, isLoaded in
-                if isLoaded {
-                    image.resizable().frame(height: self.loadedHeight)
-                } else {
-                    image.resizable().frame(height: self.notLoadedHeight)
-                }
-            }
+            .measuringIsLoaded()
             .onFailure { _ in
                 failureExpectation.fulfill()
             }
@@ -216,42 +201,9 @@ class KFImageRendererTests: XCTestCase {
         // rather than from an empty image branch.
         XCTAssertEqual(
             measuredSize.height,
-            notLoadedHeight,
+            isLoadedFalseHeight,
             accuracy: 0.5,
             "`isLoaded` should be `false` for the fallback set by `onFailureImage`, even while it is rendered."
-        )
-    }
-
-    // A cancelled request keeps `loadedImage` empty, so the binder can be restarted while the cancelled request has
-    // not delivered its failure yet. When that failure lands afterwards it installs the fallback image, and the
-    // restarted load must still be able to report its own image as retrieved.
-    @MainActor
-    @available(*, deprecated) // Silences the deprecation warning for `onFailureImage` under test.
-    func testRetrievedImageClearsProvenanceLeftByAStaleFailureCallback() async {
-        let binder = KFImage.ImageBinder()
-        let successExpectation = expectation(description: "Restarted loading succeeds")
-
-        // The restarted request. A fresh cache key keeps it out of the cache, so it stays in flight below.
-        let restartedContext = KFImage.Context<Image>(
-            source: .provider(RawImageDataProvider(data: testImageData, cacheKey: UUID().uuidString))
-        )
-        restartedContext.onSuccessDelegate.delegate(on: self) { _, _ in
-            successExpectation.fulfill()
-        }
-        binder.start(context: restartedContext)
-
-        // The cancelled request delivers its failure while the restarted one is still loading.
-        let staleFailureContext = KFImage.Context<Image>(source: nil)
-        staleFailureContext.options.onFailureImage = .some(testImage)
-        binder.start(context: staleFailureContext)
-        XCTAssertTrue(binder.usesFailureImage, "The stale failure callback should install the fallback image.")
-
-        await fulfillment(of: [successExpectation], timeout: 1)
-
-        XCTAssertNotNil(binder.loadedImage)
-        XCTAssertFalse(
-            binder.usesFailureImage,
-            "A retrieved image must carry its own provenance instead of inheriting the stale one."
         )
     }
 
@@ -265,7 +217,7 @@ class KFImageRendererTests: XCTestCase {
     func testFadeRestoresImageLayoutBeforeAnimationBegins() async {
         let binder = KFImage.ImageBinder()
         // Simulates the state ImageBinder creates before starting a fade animation.
-        binder.loadedImage = testImage
+        binder.setLoadedImage(testImage)
 
         let context = KFImage.Context<Image>(source: nil)
         context.placeholder = { _ in
@@ -294,7 +246,7 @@ class KFImageRendererTests: XCTestCase {
 
         let binder = KFImage.ImageBinder()
         // Simulates the render pass after `loadedImage` changes but before `loaded` does.
-        binder.loadedImage = testImage
+        binder.setLoadedImage(testImage)
 
         let context = KFImage.Context<Image>(source: nil)
         context.swiftUITransition = .opacity
@@ -502,6 +454,24 @@ private struct ExternalTransitionHost: View {
             }
         }
         .frame(width: 390, height: 200)
+    }
+}
+
+private let isLoadedTrueHeight: CGFloat = 123
+private let isLoadedFalseHeight: CGFloat = 45
+
+@available(iOS 14.0, tvOS 14.0, *)
+private extension KFImageProtocol where HoldingView == Image {
+    /// Gives the image a different height per `isLoaded` value, so the measured layout reveals which value the
+    /// `contentConfigure` block received. The `if` / `else` body also exercises the overload's `@ViewBuilder`.
+    func measuringIsLoaded() -> Self {
+        contentConfigure { image, isLoaded in
+            if isLoaded {
+                image.resizable().frame(height: isLoadedTrueHeight)
+            } else {
+                image.resizable().frame(height: isLoadedFalseHeight)
+            }
+        }
     }
 }
 

--- a/Tests/KingfisherTests/KFImageRendererTests.swift
+++ b/Tests/KingfisherTests/KFImageRendererTests.swift
@@ -207,6 +207,31 @@ class KFImageRendererTests: XCTestCase {
         )
     }
 
+    // A load transition drops the render pass that evaluates the block before an image exists, but it does not change
+    // what a displayed fallback reports: the fallback is still an image the caller did not retrieve.
+    @MainActor
+    @available(*, deprecated) // Silences the deprecation warning for `onFailureImage` under test.
+    func testContentConfigureReceivesIsLoadedFalseForFailureImageWithLoadTransition() async {
+        let failureExpectation = expectation(description: "Image loading fails")
+
+        let view = KFImage.dataProvider(FailingImageDataProvider())
+            .onFailureImage(testImage)
+            .measuringIsLoaded()
+            .loadTransition(.opacity)
+            .onFailure { _ in
+                failureExpectation.fulfill()
+            }
+
+        let measuredSize = await measureLayout(view, after: failureExpectation)
+
+        XCTAssertEqual(
+            measuredSize.height,
+            isLoadedFalseHeight,
+            accuracy: 0.5,
+            "A displayed `onFailureImage` fallback should report `isLoaded` as `false` with a load transition too."
+        )
+    }
+
     // MARK: - Renderer intermediate states
     // Regression test for the fade scaling artifact. The image branch keeps a zero frame while
     // `loadedImage` is nil, and the zero frame must be released as soon as `loadedImage` is set —

--- a/Tests/KingfisherTests/KFImageRendererTests.swift
+++ b/Tests/KingfisherTests/KFImageRendererTests.swift
@@ -158,6 +158,88 @@ class KFImageRendererTests: XCTestCase {
         return measuredSize
     }
 
+    // MARK: - contentConfigure isLoaded
+    // The `isLoaded` flag lets the caller gate configurations that only make sense for a real image. It must
+    // distinguish an image retrieved from the cache or the network from the fallback set by `onFailureImage`, which
+    // is rendered through the very same branch.
+    private let loadedHeight: CGFloat = 123
+    private let notLoadedHeight: CGFloat = 45
+
+    @MainActor
+    func testContentConfigureReceivesIsLoadedAfterSuccess() async {
+        let successExpectation = expectation(description: "Image loading succeeds")
+
+        let view = KFImage
+            .data(testImageData, cacheKey: "com.onevcat.KingfisherTests.contentConfigureIsLoadedOnSuccess")
+            .contentConfigure { image, isLoaded in
+                if isLoaded {
+                    image.resizable().frame(height: self.loadedHeight)
+                } else {
+                    image.resizable().frame(height: self.notLoadedHeight)
+                }
+            }
+            .onSuccess { _ in
+                successExpectation.fulfill()
+            }
+
+        let measuredSize = await measureLayout(view, after: successExpectation)
+
+        XCTAssertEqual(
+            measuredSize.height,
+            loadedHeight,
+            accuracy: 0.5,
+            "`isLoaded` should be `true` once the image is retrieved from the cache or the network."
+        )
+    }
+
+    @MainActor
+    @available(*, deprecated) // Silences the deprecation warning for `onFailureImage` under test.
+    func testContentConfigureReceivesIsLoadedFalseForFailureImage() async {
+        let failureExpectation = expectation(description: "Image loading fails")
+
+        let view = KFImage.dataProvider(FailingImageDataProvider())
+            .onFailureImage(testImage)
+            .contentConfigure { image, isLoaded in
+                if isLoaded {
+                    image.resizable().frame(height: self.loadedHeight)
+                } else {
+                    image.resizable().frame(height: self.notLoadedHeight)
+                }
+            }
+            .onFailure { _ in
+                failureExpectation.fulfill()
+            }
+
+        let measuredSize = await measureLayout(view, after: failureExpectation)
+
+        // A non-zero height proves the image branch is rendered, so the `false` flag comes from the fallback image
+        // rather than from an empty image branch.
+        XCTAssertEqual(
+            measuredSize.height,
+            notLoadedHeight,
+            accuracy: 0.5,
+            "`isLoaded` should be `false` for the fallback set by `onFailureImage`, even while it is rendered."
+        )
+    }
+
+    @MainActor
+    @available(*, deprecated) // Silences the deprecation warning for `onFailureImage` under test.
+    func testFailureImageFlagIsResetWhenLoadingRestarts() {
+        let binder = KFImage.ImageBinder()
+
+        // `onFailureImage` accepts a `nil` image, so the flag can be set while `loadedImage` stays empty. That state
+        // is not terminal, and a stale flag would make the next successful load look like a fallback image.
+        let failingContext = KFImage.Context<Image>(source: nil)
+        failingContext.options.onFailureImage = .some(nil)
+
+        binder.start(context: failingContext)
+        XCTAssertTrue(binder.usesFailureImage)
+        XCTAssertNil(binder.loadedImage)
+
+        binder.start(context: KFImage.Context<Image>(source: nil))
+        XCTAssertFalse(binder.usesFailureImage)
+    }
+
     // MARK: - Renderer intermediate states
     // Regression test for the fade scaling artifact. The image branch keeps a zero frame while
     // `loadedImage` is nil, and the zero frame must be released as soon as `loadedImage` is set —
@@ -174,7 +256,7 @@ class KFImageRendererTests: XCTestCase {
         context.placeholder = { _ in
             AnyView(Color.gray.frame(height: 200))
         }
-        context.contentConfiguration = { image in
+        context.contentConfiguration = { image, _ in
             AnyView(image.resizable().aspectRatio(contentMode: .fit))
         }
 
@@ -287,7 +369,7 @@ class KFImageRendererTests: XCTestCase {
         let binder = KFImage.ImageBinder()
         let context = KFImage.Context<Image>(source: nil)
         // Keep the image branch in the hierarchy before a cache hit resolves.
-        context.contentConfiguration = { _ in
+        context.contentConfiguration = { _, _ in
             AnyView(
                 Color.clear
                     .onAppear {


### PR DESCRIPTION
### Motivation

`contentConfigure` hands the loaded image to the caller, but the block is also evaluated in two states where there is no retrieved image:

- **Before the loading finishes.** On the default path (`swiftUITransition == nil`) the image branch is always rendered and only hidden with `opacity(0)` and a zero frame, so the block runs with an empty `Image`.
- **On failure**, when the deprecated `onFailureImage` fills `binder.loadedImage` with a caller-supplied fallback.

The caller has no way to tell either of those apart from a real image.

### What this adds

A `contentConfigure(_:)` overload that passes an `isLoaded` flag along with the image:

```swift
KFImage(url)
    .contentConfigure { image, isLoaded in
        if isLoaded {
            image.resizable().scaledToFit().overlay(Badge())
        } else {
            image
        }
    }
```

| State | `loadedImage` | `isLoaded` |
|---|---|---|
| Before / during loading | `nil` | `false` |
| Partial image from progressive loading | partial | `true` |
| Success (cache or network) | image | `true` |
| Failure with the deprecated `onFailureImage` | fallback | `false` |
| Failure with `onFailureView`, or neither | `nil` | `false` |

Progressive partial images are `true` on purpose. They come from a successful load in flight, and treating them as not loaded would drop the caller's sizing configuration and make the layout jump once the load completes.

### Notes on the implementation

- The existing single-argument overload keeps its signature and forwards to the new one, following the pattern `placeholder` already uses for its `(Progress) -> P` / `() -> P` pair.
- Both overloads take a `@ViewBuilder` block now, so an `if` / `else` body behaves the same in either one. This is source compatible: it only widens the accepted block shapes, and a block with an explicit `return` is left untransformed.
- `isImageRenderable` keeps its meaning and all of its uses (opacity, frame, branching). The fallback image still has to be rendered, so the new `isImageLoaded` is derived separately rather than changing it.
- The view returned while `isLoaded` is `false` does not appear on screen, since the image branch stays hidden until an image is available. `isLoaded` is meant for gating the caller's own configuration, not for drawing loading or failure UI — `placeholder` and `onFailureView` own those states. This is spelled out in the DocC comment.
- `ImageBinder` gains a `usesFailureImage` flag, reset at the start of `start()`. `onFailureImage` accepts a `nil` image, which leaves `loadedImage` empty while the flag is set; that state is not terminal, so without the reset a later successful load would still look like a fallback image.

### Tests

Three tests in `KFImageRendererTests`, reusing the existing `measureLayout` harness. They apply a different `frame(height:)` per `isLoaded` value and assert the measured layout, so no extra recorder object is needed.

- `testContentConfigureReceivesIsLoadedAfterSuccess`
- `testContentConfigureReceivesIsLoadedFalseForFailureImage` — the non-zero measured height proves the image branch is rendered while `isLoaded` stays `false`
- `testFailureImageFlagIsResetWhenLoadingRestarts` — covers the `onFailureImage(nil)` case described above

Two existing tests assign `context.contentConfiguration` directly and were updated for the new closure arity.

Verified on the iOS simulator: 400 tests, 0 failures. I also checked that the new tests fail in both directions when `isImageLoaded` is forced to a constant. Other platforms are left to CI.

`CHANGELOG.md` is untouched, since it looks like it is updated in the release commits.
