### PR TITLE
Track download priority per shared-task consumer

### DIFF
--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -144,6 +144,16 @@ public final class DownloadTask: @unchecked Sendable {
         guard let sessionTask, let cancelToken else { return }
         sessionTask.cancel(token: cancelToken)
     }
+
+    func setPriority(_ priority: Float) {
+        guard let sessionTask, let cancelToken else { return }
+        sessionTask.setPriority(priority, for: cancelToken)
+    }
+
+    func resetPriority() {
+        guard let sessionTask, let cancelToken else { return }
+        sessionTask.resetPriority(for: cancelToken)
+    }
     
     public var isInitialized: Bool {
         propertyQueue.sync {
@@ -423,7 +433,6 @@ open class ImageDownloader: @unchecked Sendable {
             downloadTask = existingDownloadTask
         } else {
             let sessionDataTask = session.dataTask(with: context.request)
-            sessionDataTask.priority = context.options.downloadPriority
             downloadTask = sessionDelegate.add(sessionDataTask, url: context.url, callback: callback)
         }
         return downloadTask

--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -76,6 +76,7 @@ public class SessionDataTask: @unchecked Sendable {
     public let task: URLSessionDataTask
     
     private var callbacksStore = [CancelToken: TaskCallback]()
+    private var prioritiesStore = [CancelToken: Float]()
     private var completed = false
 
     var callbacks: [SessionDataTask.TaskCallback] {
@@ -126,6 +127,8 @@ public class SessionDataTask: @unchecked Sendable {
         guard !completed else { return nil }
 
         callbacksStore[currentToken] = callback
+        prioritiesStore[currentToken] = callback.options.downloadPriority
+        updateTaskPriority()
         defer { currentToken += 1 }
         return currentToken
     }
@@ -135,9 +138,32 @@ public class SessionDataTask: @unchecked Sendable {
         defer { lock.unlock() }
         if let callback = callbacksStore[token] {
             callbacksStore[token] = nil
+            prioritiesStore[token] = nil
+            updateTaskPriority()
             return callback
         }
         return nil
+    }
+
+    func setPriority(_ priority: Float, for token: CancelToken) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard callbacksStore[token] != nil else { return }
+        prioritiesStore[token] = priority
+        updateTaskPriority()
+    }
+
+    func resetPriority(for token: CancelToken) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let callback = callbacksStore[token] else { return }
+        prioritiesStore[token] = callback.options.downloadPriority
+        updateTaskPriority()
+    }
+
+    private func updateTaskPriority() {
+        guard let priority = prioritiesStore.values.max() else { return }
+        task.priority = priority
     }
     
     @discardableResult
@@ -146,6 +172,7 @@ public class SessionDataTask: @unchecked Sendable {
         defer { lock.unlock() }
         let callbacks = callbacksStore.values
         callbacksStore.removeAll()
+        prioritiesStore.removeAll()
         return Array(callbacks)
     }
 
@@ -156,6 +183,7 @@ public class SessionDataTask: @unchecked Sendable {
         completed = true
         let callbacks = callbacksStore.values
         callbacksStore.removeAll()
+        prioritiesStore.removeAll()
         return Array(callbacks)
     }
 

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -187,16 +187,16 @@ extension KFImage {
             loading = false
         }
         
-        /// Restores the download task priority to default if it is in progress.
+        /// Restores the original download task priority if it is in progress.
         func restorePriorityOnAppear() {
             guard let downloadTask = downloadTask, loading == true else { return }
-            downloadTask.sessionTask?.task.priority = URLSessionTask.defaultPriority
+            downloadTask.resetPriority()
         }
         
         /// Reduce the download task priority if it is in progress.
         func reducePriorityOnDisappear() {
             guard let downloadTask = downloadTask, loading == true else { return }
-            downloadTask.sessionTask?.task.priority = URLSessionTask.lowPriority
+            downloadTask.setPriority(URLSessionTask.lowPriority)
         }
     }
 }

--- a/Tests/KingfisherTests/ImageBinderTests.swift
+++ b/Tests/KingfisherTests/ImageBinderTests.swift
@@ -65,6 +65,20 @@ private final class DelayedImageDataProvider: ImageDataProvider, @unchecked Send
 
 @available(iOS 14.0, tvOS 14.0, *)
 class ImageBinderTests: XCTestCase {
+    private func makeSharedDownloadTasks(priorities: [Float]) -> [DownloadTask] {
+        let url = URL(string: "https://example.com/shared-priority.png")!
+        let sessionTask = SessionDataTask(task: URLSession.shared.dataTask(with: url))
+        return priorities.map { priority in
+            let options = KingfisherParsedOptionsInfo([.downloadPriority(priority)])
+            let callback = SessionDataTask.TaskCallback(onCompleted: nil, options: options)
+            let token = sessionTask.addCallback(callback)!
+            let actualTask = DownloadTask(sessionTask: sessionTask, cancelToken: token)
+            let linkedTask = DownloadTask()
+            linkedTask.linkToTask(actualTask)
+            return linkedTask
+        }
+    }
+
     @MainActor
     func testFadeCallsSuccessAfterMarkingLoadedOnCustomCallbackQueue() async {
         let callbackQueue = DispatchQueue(
@@ -191,6 +205,37 @@ class ImageBinderTests: XCTestCase {
         XCTAssertNil(weakBinder, "A binder should be released while its image retrieval is still in flight.")
 
         await fulfillment(of: [resultReceived], timeout: 1)
+    }
+
+    @MainActor
+    func testReducingPriorityDoesNotAffectHigherPriorityConsumer() {
+        let tasks = makeSharedDownloadTasks(
+            priorities: [URLSessionTask.highPriority, URLSessionTask.defaultPriority]
+        )
+        let visibleTask = tasks[0]
+        let disappearingTask = tasks[1]
+        let binder = KFImage.ImageBinder()
+        binder.downloadTask = disappearingTask
+        binder.markLoading()
+
+        binder.reducePriorityOnDisappear()
+
+        XCTAssertTrue(visibleTask.sessionTask === disappearingTask.sessionTask)
+        XCTAssertEqual(visibleTask.sessionTask?.task.priority, URLSessionTask.highPriority)
+    }
+
+    @MainActor
+    func testRestoringPriorityUsesOriginalRequestPriority() {
+        let task = makeSharedDownloadTasks(priorities: [URLSessionTask.highPriority])[0]
+        let binder = KFImage.ImageBinder()
+        binder.downloadTask = task
+        binder.markLoading()
+
+        binder.reducePriorityOnDisappear()
+        XCTAssertEqual(task.sessionTask?.task.priority, URLSessionTask.lowPriority)
+
+        binder.restorePriorityOnAppear()
+        XCTAssertEqual(task.sessionTask?.task.priority, URLSessionTask.highPriority)
     }
 }
 

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -750,6 +750,60 @@ class ImageDownloaderTests: XCTestCase {
         _ = stub.go()
         waitForExpectations(timeout: 3, handler: nil)
     }
+
+    func testJoiningDownloadTaskDoesNotLowerSharedPriority() {
+        let exp = expectation(description: #function)
+        exp.expectedFulfillmentCount = 2
+
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData)
+        let highPriorityTask = downloader.downloadImage(
+            with: url,
+            options: [.downloadPriority(URLSessionTask.highPriority)]
+        ) { _ in
+            exp.fulfill()
+        }
+        let lowPriorityTask = downloader.downloadImage(
+            with: url,
+            options: [.downloadPriority(URLSessionTask.lowPriority)]
+        ) { _ in
+            exp.fulfill()
+        }
+
+        XCTAssertTrue(highPriorityTask.sessionTask === lowPriorityTask.sessionTask)
+        XCTAssertEqual(highPriorityTask.sessionTask?.task.priority, URLSessionTask.highPriority)
+
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testSharedPriorityFallsBackAfterHighPriorityTaskCancellation() {
+        let exp = expectation(description: #function)
+        exp.expectedFulfillmentCount = 2
+
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData)
+        let lowPriorityTask = downloader.downloadImage(
+            with: url,
+            options: [.downloadPriority(URLSessionTask.lowPriority)]
+        ) { _ in
+            exp.fulfill()
+        }
+        let highPriorityTask = downloader.downloadImage(
+            with: url,
+            options: [.downloadPriority(URLSessionTask.highPriority)]
+        ) { _ in
+            exp.fulfill()
+        }
+        XCTAssertEqual(lowPriorityTask.sessionTask?.task.priority, URLSessionTask.highPriority)
+
+        highPriorityTask.cancel()
+
+        XCTAssertEqual(lowPriorityTask.sessionTask?.task.priority, URLSessionTask.lowPriority)
+
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+    }
     
     
     func testSessionDelegate() {

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -528,6 +528,12 @@ class ImageDownloaderTests: XCTestCase {
 
             hammer { for _ in 0..<20 { _ = task.addCallback(.init(onCompleted: nil, options: options)) } }
             hammer { for _ in 0..<5 { task.forceCancel() } }
+            hammer {
+                for token in 0..<20 {
+                    task.setPriority(URLSessionTask.highPriority, for: token)
+                    task.resetPriority(for: token)
+                }
+            }
             hammer { for _ in 0..<20 { task.resume() } }
             hammer { for _ in 0..<20 { _ = task.started; _ = task.containsCallbacks } }
             hammer { for _ in 0..<20 { task.didReceiveData(Data([0x01])); _ = task.mutableDataCount } }
@@ -799,6 +805,9 @@ class ImageDownloaderTests: XCTestCase {
 
         highPriorityTask.cancel()
 
+        XCTAssertEqual(lowPriorityTask.sessionTask?.task.priority, URLSessionTask.lowPriority)
+
+        highPriorityTask.setPriority(URLSessionTask.highPriority)
         XCTAssertEqual(lowPriorityTask.sessionTask?.task.priority, URLSessionTask.lowPriority)
 
         _ = stub.go()

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -722,6 +722,34 @@ class ImageDownloaderTests: XCTestCase {
         XCTAssertEqual(task.sessionTask?.task.priority, URLSessionTask.highPriority)
         waitForExpectations(timeout: 3, handler: nil)
     }
+
+    func testJoiningDownloadTaskRaisesSharedPriority() {
+        let exp = expectation(description: #function)
+        exp.expectedFulfillmentCount = 2
+
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData)
+        let lowPriorityTask = downloader.downloadImage(
+            with: url,
+            options: [.downloadPriority(URLSessionTask.lowPriority)]
+        ) { _ in
+            exp.fulfill()
+        }
+        XCTAssertEqual(lowPriorityTask.sessionTask?.task.priority, URLSessionTask.lowPriority)
+
+        let highPriorityTask = downloader.downloadImage(
+            with: url,
+            options: [.downloadPriority(URLSessionTask.highPriority)]
+        ) { _ in
+            exp.fulfill()
+        }
+
+        XCTAssertTrue(lowPriorityTask.sessionTask === highPriorityTask.sessionTask)
+        XCTAssertEqual(lowPriorityTask.sessionTask?.task.priority, URLSessionTask.highPriority)
+
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+    }
     
     
     func testSessionDelegate() {


### PR DESCRIPTION
## What

- Track the current download priority for each callback token in `SessionDataTask`.
- Set the underlying `URLSessionDataTask` priority to the maximum priority requested by active consumers.
- Recalculate the shared priority when a consumer joins, changes priority, or is cancelled.
- Route SwiftUI disappear/appear priority changes through the consumer token.
- Restore each SwiftUI request's original download priority instead of always restoring the default value.

## Why

Requests for the same final URL share one in-flight download task. Previously, a joining request could not raise that task's priority, and `reducePriorityOnDisappear` directly modified the shared task, potentially lowering the priority for other visible consumers.

## How tested

- Added regression coverage for a high-priority request joining an in-flight low-priority download.
- Covered lower-priority joins, cancellation fallback, and stale-token updates.
- Covered isolation between SwiftUI consumers and restoration of custom priorities.
- Extended the existing concurrent-access test with priority updates and resets.
- Ran the complete iOS test suite: 402 tests, 0 failures.

Fixes #2567

onevtail - an assistant to @onevcat