### PR TITLE
Reuse wrappers

### DIFF
--- a/Sources/Extensions/CPListItem+Kingfisher.swift
+++ b/Sources/Extensions/CPListItem+Kingfisher.swift
@@ -133,22 +133,19 @@ extension KingfisherWrapper where Base: CPListItem {
                 }
             ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: { listItem, identifier in
-                    var wrapper = listItem.kf
+                setTaskIdentifier: { wrapper, identifier in
                     wrapper.taskIdentifier = identifier
                 },
-                getTaskIdentifier: { listItem in
-                    listItem.kf.taskIdentifier
+                getTaskIdentifier: { wrapper in
+                    wrapper.taskIdentifier
                 },
-                setTask: { listItem, task in
-                    var wrapper = listItem.kf
+                setTask: { wrapper, task in
                     wrapper.imageTask = task
                 },
-                getCancellationToken: { listItem in
-                    listItem.kf.cancellationToken
+                getCancellationToken: { wrapper in
+                    wrapper.cancellationToken
                 },
-                setCancellationToken: { listItem, token in
-                    var wrapper = listItem.kf
+                setCancellationToken: { wrapper, token in
                     wrapper.cancellationToken = token
                 }
             ),
@@ -182,7 +179,7 @@ extension KingfisherWrapper where Base: CPListItem {
             let box: Box<Source.Identifier.Value>? = getAssociatedObject(base, &taskIdentifierKey)
             return box?.value
         }
-        set {
+        nonmutating set {
             let box = newValue.map { Box($0) }
             setRetainedAssociatedObject(base, &taskIdentifierKey, box)
         }
@@ -190,12 +187,12 @@ extension KingfisherWrapper where Base: CPListItem {
 
     var cancellationToken: CancellationToken? {
         get { getAssociatedObject(base, &cancellationTokenKey) }
-        set { setRetainedAssociatedObject(base, &cancellationTokenKey, newValue) }
+        nonmutating set { setRetainedAssociatedObject(base, &cancellationTokenKey, newValue) }
     }
 
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
-        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+        nonmutating set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
     }
 }
 #endif

--- a/Sources/Extensions/HasImageComponent+Kingfisher.swift
+++ b/Sources/Extensions/HasImageComponent+Kingfisher.swift
@@ -93,11 +93,11 @@ struct ImagePropertyAccessor<Object: AnyObject, ImageType>: Sendable {
 }
 
 struct TaskPropertyAccessor<Object: AnyObject>: Sendable {
-    let setTaskIdentifier: @Sendable @MainActor (Object, Source.Identifier.Value?) -> Void
-    let getTaskIdentifier: @Sendable @MainActor (Object) -> Source.Identifier.Value?
-    let setTask: @Sendable @MainActor (Object, DownloadTask?) -> Void
-    let getCancellationToken: @Sendable @MainActor (Object) -> CancellationToken?
-    let setCancellationToken: @Sendable @MainActor (Object, CancellationToken) -> Void
+    let setTaskIdentifier: @Sendable @MainActor (KingfisherWrapper<Object>, Source.Identifier.Value?) -> Void
+    let getTaskIdentifier: @Sendable @MainActor (KingfisherWrapper<Object>) -> Source.Identifier.Value?
+    let setTask: @Sendable @MainActor (KingfisherWrapper<Object>, DownloadTask?) -> Void
+    let getCancellationToken: @Sendable @MainActor (KingfisherWrapper<Object>) -> CancellationToken?
+    let setCancellationToken: @Sendable @MainActor (KingfisherWrapper<Object>, CancellationToken) -> Void
 }
 
 @MainActor
@@ -373,22 +373,19 @@ extension KingfisherWrapper where Base: KingfisherImageSettable {
                 }
             ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: { base, identifier in
-                    var wrapper = base.kf
+                setTaskIdentifier: { wrapper, identifier in
                     wrapper.taskIdentifier = identifier
                 },
-                getTaskIdentifier: { base in
-                    base.kf.taskIdentifier
+                getTaskIdentifier: { wrapper in
+                    wrapper.taskIdentifier
                 },
-                setTask: { base, task in
-                    var wrapper = base.kf
+                setTask: { wrapper, task in
                     wrapper.imageTask = task
                 },
-                getCancellationToken: { base in
-                    base.kf.cancellationToken
+                getCancellationToken: { wrapper in
+                    wrapper.cancellationToken
                 },
-                setCancellationToken: { base, token in
-                    var wrapper = base.kf
+                setCancellationToken: { wrapper, token in
                     wrapper.cancellationToken = token
                 }
             ),
@@ -414,7 +411,7 @@ extension KingfisherWrapper where Base: AnyObject {
     {
         guard let source = source else {
             imageAccessor.setImage(base, placeholder, parsedOptions)
-            taskAccessor.setTaskIdentifier(base, nil)
+            taskAccessor.setTaskIdentifier(self, nil)
             completionHandler?(.failure(KingfisherError.imageSettingError(reason: .emptySource)))
             return nil
         }
@@ -432,11 +429,11 @@ extension KingfisherWrapper where Base: AnyObject {
         }
 
         let issuedIdentifier = Source.Identifier.next()
-        taskAccessor.setTaskIdentifier(base, issuedIdentifier)
+        taskAccessor.setTaskIdentifier(self, issuedIdentifier)
 
         let token = CancellationToken()
-        taskAccessor.getCancellationToken(base)?.cancel()
-        taskAccessor.setCancellationToken(base, token)
+        taskAccessor.getCancellationToken(self)?.cancel()
+        taskAccessor.setCancellationToken(self, token)
 
         if let block = progressBlock {
             options.onDataReceived = (options.onDataReceived ?? []) + [ImageLoadingProgressSideEffect(block)]
@@ -452,7 +449,7 @@ extension KingfisherWrapper where Base: AnyObject {
             downloadTaskUpdated: { task in
                 Task { @MainActor in
                     guard let base = weakBase.value else { return }
-                    taskAccessor.setTask(base, task)
+                    taskAccessor.setTask(.init(base), task)
                 }
             },
             progressiveImageSetter: { image in
@@ -466,7 +463,8 @@ extension KingfisherWrapper where Base: AnyObject {
                         completionHandler?(result)
                         return
                     }
-                    guard issuedIdentifier == taskAccessor.getTaskIdentifier(base) else {
+                    let wrapper = KingfisherWrapper(base)
+                    guard issuedIdentifier == taskAccessor.getTaskIdentifier(wrapper) else {
                         let reason: KingfisherError.ImageSettingErrorReason
                         do {
                             let value = try result.get()
@@ -479,8 +477,8 @@ extension KingfisherWrapper where Base: AnyObject {
                         return
                     }
 
-                    taskAccessor.setTask(base, nil)
-                    taskAccessor.setTaskIdentifier(base, nil)
+                    taskAccessor.setTask(wrapper, nil)
+                    taskAccessor.setTaskIdentifier(wrapper, nil)
 
                     switch result {
                     case .success(let value):
@@ -494,7 +492,7 @@ extension KingfisherWrapper where Base: AnyObject {
                 }
             }
         )
-        taskAccessor.setTask(base, task)
+        taskAccessor.setTask(self, task)
         return task
     }
 }
@@ -513,7 +511,7 @@ extension KingfisherWrapper where Base: KingfisherImageSettable {
             let box: Box<Source.Identifier.Value>? = getAssociatedObject(base, &taskIdentifierKey)
             return box?.value
         }
-        set {
+        nonmutating set {
             let box = newValue.map { Box($0) }
             setRetainedAssociatedObject(base, &taskIdentifierKey, box)
         }
@@ -521,12 +519,12 @@ extension KingfisherWrapper where Base: KingfisherImageSettable {
     
     var cancellationToken: CancellationToken? {
         get { getAssociatedObject(base, &cancellationTokenKey) }
-        set { setRetainedAssociatedObject(base, &cancellationTokenKey, newValue) }
+        nonmutating set { setRetainedAssociatedObject(base, &cancellationTokenKey, newValue) }
     }
 
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
-        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+        nonmutating set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
     }
     
     /// Cancels the image download task of the image view if it is running.

--- a/Sources/Extensions/NSButton+Kingfisher.swift
+++ b/Sources/Extensions/NSButton+Kingfisher.swift
@@ -118,22 +118,19 @@ extension KingfisherWrapper where Base: NSButton {
                 }
             ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: { button, identifier in
-                    var wrapper = button.kf
+                setTaskIdentifier: { wrapper, identifier in
                     wrapper.taskIdentifier = identifier
                 },
-                getTaskIdentifier: { button in
-                    button.kf.taskIdentifier
+                getTaskIdentifier: { wrapper in
+                    wrapper.taskIdentifier
                 },
-                setTask: { button, task in
-                    var wrapper = button.kf
+                setTask: { wrapper, task in
                     wrapper.imageTask = task
                 },
-                getCancellationToken: { button in
-                    button.kf.imageCancellationToken
+                getCancellationToken: { wrapper in
+                    wrapper.imageCancellationToken
                 },
-                setCancellationToken: { button, token in
-                    var wrapper = button.kf
+                setCancellationToken: { wrapper, token in
                     wrapper.imageCancellationToken = token
                 }
             ),
@@ -225,22 +222,19 @@ extension KingfisherWrapper where Base: NSButton {
                 }
             ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: { button, identifier in
-                    var wrapper = button.kf
+                setTaskIdentifier: { wrapper, identifier in
                     wrapper.alternateTaskIdentifier = identifier
                 },
-                getTaskIdentifier: { button in
-                    button.kf.alternateTaskIdentifier
+                getTaskIdentifier: { wrapper in
+                    wrapper.alternateTaskIdentifier
                 },
-                setTask: { button, task in
-                    var wrapper = button.kf
+                setTask: { wrapper, task in
                     wrapper.alternateImageTask = task
                 },
-                getCancellationToken: { button in
-                    button.kf.alternateImageCancellationToken
+                getCancellationToken: { wrapper in
+                    wrapper.alternateImageCancellationToken
                 },
-                setCancellationToken: { button, token in
-                    var wrapper = button.kf
+                setCancellationToken: { wrapper, token in
                     wrapper.alternateImageCancellationToken = token
                 }
             ),
@@ -282,7 +276,7 @@ extension KingfisherWrapper where Base: NSButton {
             let box: Box<Source.Identifier.Value>? = getAssociatedObject(base, &taskIdentifierKey)
             return box?.value
         }
-        set {
+        nonmutating set {
             let box = newValue.map { Box($0) }
             setRetainedAssociatedObject(base, &taskIdentifierKey, box)
         }
@@ -290,12 +284,12 @@ extension KingfisherWrapper where Base: NSButton {
     
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
-        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+        nonmutating set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
     }
 
     private var imageCancellationToken: CancellationToken? {
         get { getAssociatedObject(base, &imageCancellationTokenKey) }
-        set { setRetainedAssociatedObject(base, &imageCancellationTokenKey, newValue) }
+        nonmutating set { setRetainedAssociatedObject(base, &imageCancellationTokenKey, newValue) }
     }
 
     public private(set) var alternateTaskIdentifier: Source.Identifier.Value? {
@@ -303,7 +297,7 @@ extension KingfisherWrapper where Base: NSButton {
             let box: Box<Source.Identifier.Value>? = getAssociatedObject(base, &alternateTaskIdentifierKey)
             return box?.value
         }
-        set {
+        nonmutating set {
             let box = newValue.map { Box($0) }
             setRetainedAssociatedObject(base, &alternateTaskIdentifierKey, box)
         }
@@ -311,12 +305,12 @@ extension KingfisherWrapper where Base: NSButton {
 
     private var alternateImageTask: DownloadTask? {
         get { return getAssociatedObject(base, &alternateImageTaskKey) }
-        set { setRetainedAssociatedObject(base, &alternateImageTaskKey, newValue)}
+        nonmutating set { setRetainedAssociatedObject(base, &alternateImageTaskKey, newValue)}
     }
 
     private var alternateImageCancellationToken: CancellationToken? {
         get { getAssociatedObject(base, &alternateImageCancellationTokenKey) }
-        set { setRetainedAssociatedObject(base, &alternateImageCancellationTokenKey, newValue) }
+        nonmutating set { setRetainedAssociatedObject(base, &alternateImageCancellationTokenKey, newValue) }
     }
 }
 #endif

--- a/Sources/Extensions/UIButton+Kingfisher.swift
+++ b/Sources/Extensions/UIButton+Kingfisher.swift
@@ -125,21 +125,19 @@ extension KingfisherWrapper where Base: UIButton {
                 }
             ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: { button, identifier in
-                    button.kf.setTaskIdentifier(identifier, for: state)
+                setTaskIdentifier: { wrapper, identifier in
+                    wrapper.setTaskIdentifier(identifier, for: state)
                 },
-                getTaskIdentifier: { button in
-                    button.kf.taskIdentifier(for: state)
+                getTaskIdentifier: { wrapper in
+                    wrapper.taskIdentifier(for: state)
                 },
-                setTask: { button, task in
-                    var wrapper = button.kf
+                setTask: { wrapper, task in
                     wrapper.imageTask = task
                 },
-                getCancellationToken: { button in
-                    button.kf.imageCancellationToken
+                getCancellationToken: { wrapper in
+                    wrapper.imageCancellationToken
                 },
-                setCancellationToken: { button, token in
-                    var wrapper = button.kf
+                setCancellationToken: { wrapper, token in
                     wrapper.imageCancellationToken = token
                 }
             ),
@@ -252,21 +250,19 @@ extension KingfisherWrapper where Base: UIButton {
                 }
             ),
             taskAccessor: TaskPropertyAccessor(
-                setTaskIdentifier: { button, identifier in
-                    button.kf.setBackgroundTaskIdentifier(identifier, for: state)
+                setTaskIdentifier: { wrapper, identifier in
+                    wrapper.setBackgroundTaskIdentifier(identifier, for: state)
                 },
-                getTaskIdentifier: { button in
-                    button.kf.backgroundTaskIdentifier(for: state)
+                getTaskIdentifier: { wrapper in
+                    wrapper.backgroundTaskIdentifier(for: state)
                 },
-                setTask: { button, task in
-                    var wrapper = button.kf
+                setTask: { wrapper, task in
                     wrapper.backgroundImageTask = task
                 },
-                getCancellationToken: { button in
-                    button.kf.backgroundImageCancellationToken
+                getCancellationToken: { wrapper in
+                    wrapper.backgroundImageCancellationToken
                 },
-                setCancellationToken: { button, token in
-                    var wrapper = button.kf
+                setCancellationToken: { wrapper, token in
                     wrapper.backgroundImageCancellationToken = token
                 }
             ),
@@ -315,12 +311,12 @@ extension KingfisherWrapper where Base: UIButton {
     
     private var imageTask: DownloadTask? {
         get { return getAssociatedObject(base, &imageTaskKey) }
-        set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
+        nonmutating set { setRetainedAssociatedObject(base, &imageTaskKey, newValue)}
     }
 
     private var imageCancellationToken: CancellationToken? {
         get { getAssociatedObject(base, &imageCancellationTokenKey) }
-        set { setRetainedAssociatedObject(base, &imageCancellationTokenKey, newValue) }
+        nonmutating set { setRetainedAssociatedObject(base, &imageCancellationTokenKey, newValue) }
     }
 }
 
@@ -350,12 +346,12 @@ extension KingfisherWrapper where Base: UIButton {
     
     private var backgroundImageTask: DownloadTask? {
         get { return getAssociatedObject(base, &backgroundImageTaskKey) }
-        mutating set { setRetainedAssociatedObject(base, &backgroundImageTaskKey, newValue) }
+        nonmutating set { setRetainedAssociatedObject(base, &backgroundImageTaskKey, newValue) }
     }
 
     private var backgroundImageCancellationToken: CancellationToken? {
         get { getAssociatedObject(base, &backgroundImageCancellationTokenKey) }
-        set { setRetainedAssociatedObject(base, &backgroundImageCancellationTokenKey, newValue) }
+        nonmutating set { setRetainedAssociatedObject(base, &backgroundImageCancellationTokenKey, newValue) }
     }
 }
 #endif


### PR DESCRIPTION
Since setters on `KingfisherWrapper` do not mutate itself, all setters can be marked `nonmutating`. This enables us to have direct access to getters/setters without accessing `base` nor initializing new wrappers. In other words, it eliminates most of `KingfisherWrapper` initializations on `setImage(...)` lifecycle and reuse just an instance (we only initialize new instance on escaping closures).