### PR TITLE
Handle download priority per consumer of a shared download task

### DIFF
--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -110,7 +110,7 @@ public final class DownloadTask: @unchecked Sendable {
     }
 
     private var _cancelToken: SessionDataTask.CancelToken? = nil
-    
+
     /// The cancellation token used to cancel the task.
     ///
     /// This is solely for identifying the task when it is cancelled. To cancel a ``DownloadTask``, call
@@ -118,6 +118,58 @@ public final class DownloadTask: @unchecked Sendable {
     public private(set) var cancelToken: SessionDataTask.CancelToken? {
         get { propertyQueue.sync { _cancelToken ?? _linkedTask?.cancelToken } }
         set { propertyQueue.sync { _cancelToken = newValue } }
+    }
+
+    // The last priority set through the `priority` setter.
+    // It is kept around so it can be applied when the task is linked, or re-applied when a retry links a new task.
+    private var _explicitPriority: Float? = nil
+
+    /// The relative priority of this download task.
+    ///
+    /// The value is between 0.0 and 1.0, with `URLSessionTask.defaultPriority` (0.5) as the default.
+    /// See the documentation of `URLSessionTask.priority` for more about how the value is used.
+    ///
+    /// In Kingfisher, the underlying session task may be shared by multiple `DownloadTask`s requesting the same URL.
+    /// Setting this value only changes the priority this task asks for.
+    /// The shared session task always runs at the highest priority among all `DownloadTask`s currently sharing it.
+    /// So lowering the value here never slows down another consumer of the same URL.
+    public var priority: Float {
+        get {
+            propertyQueue.sync {
+                if let linked = _linkedTask { return linked.priority }
+                if let sessionTask = _sessionTask, let token = _cancelToken,
+                   let value = sessionTask.priority(forToken: token)
+                {
+                    return value
+                }
+                return _explicitPriority ?? URLSessionTask.defaultPriority
+            }
+        }
+        set {
+            enum Target {
+                case linked(DownloadTask)
+                case session(SessionDataTask, SessionDataTask.CancelToken)
+                case notLinkedYet
+            }
+            // Decide the forwarding target under `propertyQueue`.
+            // The forwarding itself takes other locks and must happen outside of it.
+            let target: Target = propertyQueue.sync {
+                _explicitPriority = newValue
+                if let linked = _linkedTask { return .linked(linked) }
+                if let sessionTask = _sessionTask, let token = _cancelToken {
+                    return .session(sessionTask, token)
+                }
+                return .notLinkedYet
+            }
+            switch target {
+            case .linked(let task):
+                task.priority = newValue
+            case .session(let sessionTask, let token):
+                sessionTask.updatePriority(newValue, forToken: token)
+            case .notLinkedYet:
+                break // Applied in `linkToTask` once the actual task exists.
+            }
+        }
     }
 
     /// Cancel this single download task if it is running.
@@ -154,8 +206,13 @@ public final class DownloadTask: @unchecked Sendable {
     }
     
     func linkToTask(_ task: DownloadTask) {
-        propertyQueue.sync {
+        let explicitPriority: Float? = propertyQueue.sync {
             _linkedTask = task
+            return _explicitPriority
+        }
+        // Forward a priority that was set before this link, so a value set on the shell is not lost.
+        if let explicitPriority {
+            task.priority = explicitPriority
         }
     }
 }

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -416,6 +416,8 @@ open class ImageDownloader: @unchecked Sendable {
         defer { lock.unlock() }
 
         // Ready to start download. Add it to session task manager (`sessionHandler`)
+        // `addCallback` applies `options.downloadPriority` in both branches.
+        // This is how a request joining an in-flight task can still raise the shared task priority (#2567).
         let downloadTask: DownloadTask
         if let existingTask = sessionDelegate.task(for: context.url),
            let existingDownloadTask = sessionDelegate.append(existingTask, callback: callback)
@@ -423,7 +425,6 @@ open class ImageDownloader: @unchecked Sendable {
             downloadTask = existingDownloadTask
         } else {
             let sessionDataTask = session.dataTask(with: context.request)
-            sessionDataTask.priority = context.options.downloadPriority
             downloadTask = sessionDelegate.add(sessionDataTask, url: context.url, callback: callback)
         }
         return downloadTask

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -146,28 +146,17 @@ public final class DownloadTask: @unchecked Sendable {
             }
         }
         set {
-            enum Target {
-                case linked(DownloadTask)
-                case session(SessionDataTask, SessionDataTask.CancelToken)
-                case notLinkedYet
-            }
-            // Decide the forwarding target under `propertyQueue`.
-            // The forwarding itself takes other locks and must happen outside of it.
-            let target: Target = propertyQueue.sync {
+            // Forwarding under `propertyQueue` keeps the stored value and its publication atomic.
+            // Otherwise this setter and `linkToTask` could interleave and publish a stale value.
+            // The links form a chain towards the session task, so the nested locking cannot cycle.
+            propertyQueue.sync {
                 _explicitPriority = newValue
-                if let linked = _linkedTask { return .linked(linked) }
-                if let sessionTask = _sessionTask, let token = _cancelToken {
-                    return .session(sessionTask, token)
+                if let linked = _linkedTask {
+                    linked.priority = newValue
+                } else if let sessionTask = _sessionTask, let token = _cancelToken {
+                    sessionTask.updatePriority(newValue, forToken: token)
                 }
-                return .notLinkedYet
-            }
-            switch target {
-            case .linked(let task):
-                task.priority = newValue
-            case .session(let sessionTask, let token):
-                sessionTask.updatePriority(newValue, forToken: token)
-            case .notLinkedYet:
-                break // Applied in `linkToTask` once the actual task exists.
+                // Without a target yet, the value is applied in `linkToTask` once the task exists.
             }
         }
     }
@@ -206,13 +195,14 @@ public final class DownloadTask: @unchecked Sendable {
     }
     
     func linkToTask(_ task: DownloadTask) {
-        let explicitPriority: Float? = propertyQueue.sync {
+        // Linking and forwarding happen under `propertyQueue` as one step.
+        // A concurrent `priority` setter is then ordered fully before or after this, so neither can
+        // overwrite the other's forwarded value with a stale one.
+        propertyQueue.sync {
             _linkedTask = task
-            return _explicitPriority
-        }
-        // Forward a priority that was set before this link, so a value set on the shell is not lost.
-        if let explicitPriority {
-            task.priority = explicitPriority
+            if let explicitPriority = _explicitPriority {
+                task.priority = explicitPriority
+            }
         }
     }
 }

--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -127,41 +127,37 @@ public class SessionDataTask: @unchecked Sendable {
 
     func addCallback(_ callback: TaskCallback) -> CancelToken? {
         lock.lock()
-        guard !completed else {
-            lock.unlock()
-            return nil
-        }
+        defer { lock.unlock() }
+        guard !completed else { return nil }
 
         let token = currentToken
         currentToken += 1
         callbacksStore[token] = callback
         priorities[token] = callback.options.downloadPriority
-        let aggregated = aggregatedPriority
-        lock.unlock()
-
-        if let aggregated { task.priority = aggregated }
+        applyAggregatedPriority()
         return token
     }
 
     func removeCallback(_ token: CancelToken) -> TaskCallback? {
         lock.lock()
-        guard let callback = callbacksStore[token] else {
-            lock.unlock()
-            return nil
-        }
+        defer { lock.unlock() }
+        guard let callback = callbacksStore[token] else { return nil }
+
         callbacksStore[token] = nil
         priorities[token] = nil
-        let aggregated = aggregatedPriority
-        lock.unlock()
-
-        // `aggregated` is nil when no consumer remains; the task is about to be cancelled then.
-        if let aggregated { task.priority = aggregated }
+        applyAggregatedPriority()
         return callback
     }
 
     // Must be called while holding `lock`.
-    private var aggregatedPriority: Float? {
-        priorities.values.max()
+    // This keeps a change to `priorities` and its publication to the task atomic.
+    // Otherwise a paused thread could publish a stale aggregate over a newer one.
+    // Assigning `URLSessionTask.priority` does not call back into Kingfisher.
+    private func applyAggregatedPriority() {
+        // The maximum is nil when no consumer remains; the task is about to be cancelled then.
+        if let aggregated = priorities.values.max() {
+            task.priority = aggregated
+        }
     }
 
     func priority(forToken token: CancelToken) -> Float? {
@@ -172,16 +168,12 @@ public class SessionDataTask: @unchecked Sendable {
 
     func updatePriority(_ priority: Float, forToken token: CancelToken) {
         lock.lock()
+        defer { lock.unlock() }
         // A missing token means the callback behind it is already completed or cancelled.
-        guard priorities[token] != nil else {
-            lock.unlock()
-            return
-        }
-        priorities[token] = priority
-        let aggregated = aggregatedPriority
-        lock.unlock()
+        guard priorities[token] != nil else { return }
 
-        if let aggregated { task.priority = aggregated }
+        priorities[token] = priority
+        applyAggregatedPriority()
     }
     
     @discardableResult

--- a/Sources/Networking/SessionDataTask.swift
+++ b/Sources/Networking/SessionDataTask.swift
@@ -78,6 +78,11 @@ public class SessionDataTask: @unchecked Sendable {
     private var callbacksStore = [CancelToken: TaskCallback]()
     private var completed = false
 
+    // The download priority each joined callback asks for, keyed by its cancel token.
+    // `task.priority` is kept at the maximum of these values.
+    // This way one consumer lowering its own priority cannot degrade another consumer of the shared task.
+    private var priorities = [CancelToken: Float]()
+
     var callbacks: [SessionDataTask.TaskCallback] {
         lock.lock()
         defer { lock.unlock() }
@@ -122,22 +127,61 @@ public class SessionDataTask: @unchecked Sendable {
 
     func addCallback(_ callback: TaskCallback) -> CancelToken? {
         lock.lock()
-        defer { lock.unlock() }
-        guard !completed else { return nil }
+        guard !completed else {
+            lock.unlock()
+            return nil
+        }
 
-        callbacksStore[currentToken] = callback
-        defer { currentToken += 1 }
-        return currentToken
+        let token = currentToken
+        currentToken += 1
+        callbacksStore[token] = callback
+        priorities[token] = callback.options.downloadPriority
+        let aggregated = aggregatedPriority
+        lock.unlock()
+
+        if let aggregated { task.priority = aggregated }
+        return token
     }
 
     func removeCallback(_ token: CancelToken) -> TaskCallback? {
         lock.lock()
-        defer { lock.unlock() }
-        if let callback = callbacksStore[token] {
-            callbacksStore[token] = nil
-            return callback
+        guard let callback = callbacksStore[token] else {
+            lock.unlock()
+            return nil
         }
-        return nil
+        callbacksStore[token] = nil
+        priorities[token] = nil
+        let aggregated = aggregatedPriority
+        lock.unlock()
+
+        // `aggregated` is nil when no consumer remains; the task is about to be cancelled then.
+        if let aggregated { task.priority = aggregated }
+        return callback
+    }
+
+    // Must be called while holding `lock`.
+    private var aggregatedPriority: Float? {
+        priorities.values.max()
+    }
+
+    func priority(forToken token: CancelToken) -> Float? {
+        lock.lock()
+        defer { lock.unlock() }
+        return priorities[token]
+    }
+
+    func updatePriority(_ priority: Float, forToken token: CancelToken) {
+        lock.lock()
+        // A missing token means the callback behind it is already completed or cancelled.
+        guard priorities[token] != nil else {
+            lock.unlock()
+            return
+        }
+        priorities[token] = priority
+        let aggregated = aggregatedPriority
+        lock.unlock()
+
+        if let aggregated { task.priority = aggregated }
     }
     
     @discardableResult
@@ -146,6 +190,7 @@ public class SessionDataTask: @unchecked Sendable {
         defer { lock.unlock() }
         let callbacks = callbacksStore.values
         callbacksStore.removeAll()
+        priorities.removeAll()
         return Array(callbacks)
     }
 
@@ -156,6 +201,7 @@ public class SessionDataTask: @unchecked Sendable {
         completed = true
         let callbacks = callbacksStore.values
         callbacksStore.removeAll()
+        priorities.removeAll()
         return Array(callbacks)
     }
 

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -205,13 +205,13 @@ extension KFImage {
         /// Restores the download task priority to default if it is in progress.
         func restorePriorityOnAppear() {
             guard let downloadTask = downloadTask, loading == true else { return }
-            downloadTask.sessionTask?.task.priority = URLSessionTask.defaultPriority
+            downloadTask.priority = URLSessionTask.defaultPriority
         }
-        
+
         /// Reduce the download task priority if it is in progress.
         func reducePriorityOnDisappear() {
             guard let downloadTask = downloadTask, loading == true else { return }
-            downloadTask.sessionTask?.task.priority = URLSessionTask.lowPriority
+            downloadTask.priority = URLSessionTask.lowPriority
         }
     }
 }

--- a/Sources/SwiftUI/ImageBinder.swift
+++ b/Sources/SwiftUI/ImageBinder.swift
@@ -41,6 +41,10 @@ extension KFImage {
         var downloadTask: DownloadTask?
         private var loading = false
 
+        // The priority the load originally asked for.
+        // `restorePriorityOnAppear` returns to it instead of the global default.
+        private var originalPriority: Float = URLSessionTask.defaultPriority
+
         var loadingOrSucceeded: Bool {
             return loading || loadedImage != nil
         }
@@ -97,7 +101,8 @@ extension KFImage {
             }
 
             loading = true
-            
+
+            originalPriority = context.options.downloadPriority
             progress = .init()
             downloadTask = KingfisherManager.shared
                 .retrieveImage(
@@ -202,10 +207,10 @@ extension KFImage {
             loading = false
         }
         
-        /// Restores the download task priority to default if it is in progress.
+        /// Restores the download task priority to the originally requested one if it is in progress.
         func restorePriorityOnAppear() {
             guard let downloadTask = downloadTask, loading == true else { return }
-            downloadTask.priority = URLSessionTask.defaultPriority
+            downloadTask.priority = originalPriority
         }
 
         /// Reduce the download task priority if it is in progress.

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -825,6 +825,58 @@ class ImageDownloaderTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testDownloadTaskPriorityChangesOwnShareOnly() {
+        let exp = expectation(description: #function)
+
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData)
+
+        let group = DispatchGroup()
+        group.enter()
+        let firstTask = downloader.downloadImage(with: url) { _ in group.leave() }
+        group.enter()
+        let secondTask = downloader.downloadImage(with: url) { _ in group.leave() }
+
+        XCTAssertTrue(firstTask.sessionTask === secondTask.sessionTask)
+
+        secondTask.priority = URLSessionTask.lowPriority
+        XCTAssertEqual(secondTask.priority, URLSessionTask.lowPriority)
+        XCTAssertEqual(firstTask.priority, URLSessionTask.defaultPriority)
+        XCTAssertEqual(firstTask.sessionTask?.task.priority, URLSessionTask.defaultPriority)
+
+        firstTask.priority = URLSessionTask.lowPriority
+        XCTAssertEqual(firstTask.sessionTask?.task.priority, URLSessionTask.lowPriority)
+
+        firstTask.priority = URLSessionTask.highPriority
+        XCTAssertEqual(firstTask.sessionTask?.task.priority, URLSessionTask.highPriority)
+
+        group.notify(queue: .main) { exp.fulfill() }
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testDownloadTaskPriorityAppliedWhenLinkedLater() {
+        let exp = expectation(description: #function)
+
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData)
+
+        // A not-yet-linked shell.
+        // `KingfisherManager` returns one like this while a cache check or an async request modifier is running.
+        let shell = DownloadTask()
+        shell.priority = URLSessionTask.highPriority
+        XCTAssertEqual(shell.priority, URLSessionTask.highPriority)
+
+        let task = downloader.downloadImage(with: url) { _ in exp.fulfill() }
+        shell.linkToTask(task)
+
+        XCTAssertEqual(shell.sessionTask?.task.priority, URLSessionTask.highPriority)
+        XCTAssertEqual(shell.priority, URLSessionTask.highPriority)
+
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
     func testSessionDelegate() {
         class ExtensionDelegate: SessionDelegate, @unchecked Sendable {
             //'exp' only for test

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -722,8 +722,109 @@ class ImageDownloaderTests: XCTestCase {
         XCTAssertEqual(task.sessionTask?.task.priority, URLSessionTask.highPriority)
         waitForExpectations(timeout: 3, handler: nil)
     }
-    
-    
+
+    func testDownloadPriorityEscalatedWhenJoiningRequestAsksHigher() {
+        let exp = expectation(description: #function)
+
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData)
+
+        let group = DispatchGroup()
+        group.enter()
+        let lowTask = downloader.downloadImage(
+            with: url, options: [.downloadPriority(URLSessionTask.lowPriority)])
+        {
+            _ in
+            group.leave()
+        }
+        group.enter()
+        let highTask = downloader.downloadImage(
+            with: url, options: [.downloadPriority(URLSessionTask.highPriority)])
+        {
+            _ in
+            group.leave()
+        }
+
+        XCTAssertTrue(
+            lowTask.sessionTask === highTask.sessionTask,
+            "The second request should join the in-flight session task."
+        )
+        XCTAssertEqual(lowTask.sessionTask?.task.priority, URLSessionTask.highPriority)
+
+        group.notify(queue: .main) { exp.fulfill() }
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testDownloadPriorityNotDegradedByJoiningRequestAskingLower() {
+        let exp = expectation(description: #function)
+
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData)
+
+        let group = DispatchGroup()
+        group.enter()
+        let highTask = downloader.downloadImage(
+            with: url, options: [.downloadPriority(URLSessionTask.highPriority)])
+        {
+            _ in
+            group.leave()
+        }
+        group.enter()
+        let lowTask = downloader.downloadImage(
+            with: url, options: [.downloadPriority(URLSessionTask.lowPriority)])
+        {
+            _ in
+            group.leave()
+        }
+
+        XCTAssertTrue(
+            highTask.sessionTask === lowTask.sessionTask,
+            "The second request should join the in-flight session task."
+        )
+        XCTAssertEqual(highTask.sessionTask?.task.priority, URLSessionTask.highPriority)
+
+        group.notify(queue: .main) { exp.fulfill() }
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testDownloadPriorityRecalculatedWhenConsumerCancels() {
+        let exp = expectation(description: #function)
+
+        let url = testURLs[0]
+        let stub = delayedStub(url, data: testImageData)
+
+        let lowTask = downloader.downloadImage(
+            with: url, options: [.downloadPriority(URLSessionTask.lowPriority)])
+        {
+            result in
+            XCTAssertNotNil(result.value)
+            exp.fulfill()
+        }
+        let highTask = downloader.downloadImage(
+            with: url, options: [.downloadPriority(URLSessionTask.highPriority)])
+        {
+            result in
+            XCTAssertTrue(result.error?.isTaskCancelled ?? false)
+        }
+
+        XCTAssertTrue(
+            lowTask.sessionTask === highTask.sessionTask,
+            "The second request should join the in-flight session task."
+        )
+        XCTAssertEqual(lowTask.sessionTask?.task.priority, URLSessionTask.highPriority)
+
+        highTask.cancel()
+        XCTAssertEqual(
+            lowTask.sessionTask?.task.priority, URLSessionTask.lowPriority,
+            "After the high priority consumer leaves, the task should run at the remaining consumer's priority."
+        )
+
+        _ = stub.go()
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
     func testSessionDelegate() {
         class ExtensionDelegate: SessionDelegate, @unchecked Sendable {
             //'exp' only for test

--- a/Tests/KingfisherTests/ImageDownloaderTests.swift
+++ b/Tests/KingfisherTests/ImageDownloaderTests.swift
@@ -877,6 +877,74 @@ class ImageDownloaderTests: XCTestCase {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testConcurrentPriorityUpdatesPublishConsistently() {
+        let url = URL(string: "https://example.com/concurrent-priority")!
+        let options = KingfisherParsedOptionsInfo(nil)
+
+        for _ in 0..<50 {
+            let task = SessionDataTask(task: URLSession.shared.dataTask(with: url))
+            let stayingToken = task.addCallback(.init(onCompleted: nil, options: options))!
+            let cancelledToken = task.addCallback(.init(onCompleted: nil, options: options))!
+
+            let group = DispatchGroup()
+            func hammer(_ body: @escaping () -> Void) {
+                group.enter()
+                DispatchQueue.global().async {
+                    body()
+                    group.leave()
+                }
+            }
+
+            hammer { for i in 0..<100 { task.updatePriority(i % 2 == 0 ? 0.25 : 0.75, forToken: stayingToken) } }
+            hammer { for i in 0..<100 { task.updatePriority(i % 2 == 0 ? 0.75 : 0.25, forToken: cancelledToken) } }
+            hammer { _ = task.removeCallback(cancelledToken) }
+            hammer {
+                for _ in 0..<50 {
+                    if let token = task.addCallback(.init(onCompleted: nil, options: options)) {
+                        _ = task.removeCallback(token)
+                    }
+                }
+            }
+            group.wait()
+
+            // At quiescence the published priority must match the aggregate of the stored values.
+            // Only `stayingToken` remains, so the aggregate is its stored value.
+            XCTAssertEqual(task.task.priority, task.priority(forToken: stayingToken))
+        }
+    }
+
+    func testLinkToTaskConcurrentWithPrioritySetterKeepsNewestValue() {
+        let url = URL(string: "https://example.com/concurrent-linking")!
+        let options = KingfisherParsedOptionsInfo(nil)
+
+        for _ in 0..<200 {
+            let sessionTask = SessionDataTask(task: URLSession.shared.dataTask(with: url))
+            let token = sessionTask.addCallback(.init(onCompleted: nil, options: options))!
+            let target = DownloadTask(sessionTask: sessionTask, cancelToken: token)
+
+            let shell = DownloadTask()
+            shell.priority = 0.25
+
+            let group = DispatchGroup()
+            group.enter()
+            DispatchQueue.global().async {
+                shell.linkToTask(target)
+                group.leave()
+            }
+            group.enter()
+            DispatchQueue.global().async {
+                shell.priority = 0.75
+                group.leave()
+            }
+            group.wait()
+
+            // Whatever the interleaving, the newer value must win over the one captured for linking.
+            XCTAssertEqual(shell.priority, 0.75)
+            XCTAssertEqual(sessionTask.priority(forToken: token), 0.75)
+            XCTAssertEqual(sessionTask.task.priority, 0.75)
+        }
+    }
+
     func testSessionDelegate() {
         class ExtensionDelegate: SessionDelegate, @unchecked Sendable {
             //'exp' only for test


### PR DESCRIPTION
### Motivation

Fixes #2567. When multiple requests share one in-flight download, the priority is not handled per consumer: a request joining a shared task has its `downloadPriority` dropped, and `reducePriorityOnDisappear` writes to the shared `URLSessionDataTask` directly, lowering the priority for every consumer still waiting on that URL. The issue has the details and the history.

### What this changes

`SessionDataTask` now tracks the priority each joined callback asks for, keyed by its cancel token, and keeps the underlying task at the maximum of those values. The value updates when a callback joins, is cancelled, or changes its own priority. So the task speeds up when a visible view joins a prefetch, and drops back once the high-priority consumers leave.

The settable `priority` that 2.0.0 exposed on the download task (c85a3fc, for #73), lost in the 5.0 downloader rewrite (5e26180), is restored on `DownloadTask`, adapted to the model where the session task can be shared: the setter changes only the priority this task asks for. A value set before the shell is linked to an actual task (async cache probe, async request modifier) is applied on linking, and re-applied when a retry links a new task.

`KFImage`'s appear/disappear handling goes through this instead of the raw writes, and `restorePriorityOnAppear` now restores the priority the view originally requested instead of the global default.

The work is split into four commits along these lines, so the API restoration and the behavior change can be reviewed or dropped separately.

### Tests

Added to `ImageDownloaderTests`, using `delayedStub` so two requests reliably coalesce onto one session task:

- a joining request raises the shared task's priority; a lower-priority joiner does not degrade it
- the priority is recalculated when a consumer cancels
- `DownloadTask.priority` changes only the caller's share, and a value set before linking is applied once linked

The full suite passes on macOS locally; other platforms are left to CI. A pre-existing `DataReceivingSideEffectTests` failure on the Xcode 27 beta reproduces on `master` and is unrelated.

`CHANGELOG.md` is untouched, since it looks like it is updated in the release commits.