### PR TITLE
Remove version guards below the Kingfisher 8 baseline

### DIFF
--- a/Sources/Extensions/CPListItem+Kingfisher.swift
+++ b/Sources/Extensions/CPListItem+Kingfisher.swift
@@ -113,20 +113,7 @@ extension KingfisherWrapper where Base: CPListItem {
             with: source,
             imageAccessor: ImagePropertyAccessor(
                 setImage: { listItem, image, _ in
-                    /**
-                     * In iOS SDK 14.0-14.4 the image param was non-`nil`. The SDK changed in 14.5
-                     * to allow `nil`. The compiler version 5.4 was introduced in this same SDK,
-                     * which allows >=14.5 SDK to set a `nil` image. This compile check allows
-                     * newer SDK users to set the image to `nil`, while still allowing older SDK
-                     * users to compile the framework.
-                     */
-                    #if compiler(>=5.4)
                     listItem.setImage(image)
-                    #else
-                    if let image = image {
-                        listItem.setImage(image)
-                    }
-                    #endif
                 },
                 getImage: { listItem in
                     listItem.image

--- a/Sources/Extensions/HasImageComponent+Kingfisher.swift
+++ b/Sources/Extensions/HasImageComponent+Kingfisher.swift
@@ -65,9 +65,7 @@ extension NSCell: KingfisherHasImageComponent {}
 
 #if canImport(UIKit) && !os(watchOS)
 import UIKit
-@available(iOS 13.0, tvOS 13.0, *)
 extension UIAction: KingfisherHasImageComponent {}
-@available(iOS 13.0, tvOS 13.0, *)
 extension UICommand: KingfisherHasImageComponent {}
 extension UIBarItem: KingfisherHasImageComponent {}
 #endif

--- a/Sources/General/KF.swift
+++ b/Sources/General/KF.swift
@@ -315,7 +315,6 @@ extension KF.Builder {
     /// - Parameter monogramView: The monogram view which loads the task and should be set with the image.
     /// - Returns: A task represents the image downloading, if initialized.
     ///            This value is `nil` if the image is being loaded from cache.
-    @available(tvOS 12.0, *)
     @discardableResult
     public func set(to monogramView: TVMonogramView) -> DownloadTask? {
         let placeholderImage = placeholder as? KFCrossPlatformImage ?? nil

--- a/Sources/General/Kingfisher.swift
+++ b/Sources/General/Kingfisher.swift
@@ -121,7 +121,6 @@ extension PHLivePhotoView           : KingfisherCompatible { }
 
 
 #if os(tvOS) && canImport(TVUIKit)
-@available(tvOS 12.0, *)
 extension TVMonogramView            : KingfisherCompatible { }
 #endif
 

--- a/Sources/General/KingfisherError.swift
+++ b/Sources/General/KingfisherError.swift
@@ -464,8 +464,7 @@ public enum KingfisherError: Error {
     }
 
     var isLowDataModeConstrained: Bool {
-        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *),
-           case .responseError(reason: .URLSessionError(let sessionError)) = self,
+        if case .responseError(reason: .URLSessionError(let sessionError)) = self,
            let urlError = sessionError as? URLError,
            urlError.networkUnavailableReason == .constrained
         {

--- a/Sources/Networking/ImageDownloader.swift
+++ b/Sources/Networking/ImageDownloader.swift
@@ -388,7 +388,7 @@ open class ImageDownloader: @unchecked Sendable {
         // Creates default request.
         var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: downloadTimeout)
         request.httpShouldUsePipelining = requestsUsePipelining
-        if #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) , options.lowDataModeSource != nil {
+        if options.lowDataModeSource != nil {
             request.allowsConstrainedNetworkAccess = false
         }
         

--- a/Sources/Utility/DisplayLink.swift
+++ b/Sources/Utility/DisplayLink.swift
@@ -61,19 +61,14 @@ extension CADisplayLink: DisplayLinkCompatible, @unchecked Sendable {}
 #else
 extension NSView {
     func compatibleDisplayLink(target: Any, selector: Selector) -> any DisplayLinkCompatible {
-#if swift(>=5.9) // macOS 14 SDK is included in Xcode 15, which comes with swift 5.9. Add this check to make old compilers happy.
         if #available(macOS 14.0, *) {
             return displayLink(target: target, selector: selector)
         } else {
             return DisplayLink(target: target, selector: selector)
         }
-#else
-        return DisplayLink(target: target, selector: selector)
-#endif
     }
 }
 
-#if swift(>=5.9)
 @available(macOS 14.0, *)
 extension CADisplayLink: DisplayLinkCompatible {
     var preferredFramesPerSecond: NSInteger { return 0 }
@@ -85,7 +80,6 @@ extension CADisplayLink: @retroactive @unchecked Sendable { }
 @available(macOS 14.0, *)
 extension CADisplayLink: @unchecked Sendable { }
 #endif // compiler(>=6)
-#endif // swift(>=5.9)
 
 final class DisplayLink: DisplayLinkCompatible, @unchecked Sendable {
     private var link: CVDisplayLink?

--- a/Sources/Utility/String+SHA256.swift
+++ b/Sources/Utility/String+SHA256.swift
@@ -26,22 +26,13 @@
 
 import Foundation
 import CryptoKit
-import CommonCrypto
 
 extension String: KingfisherCompatibleValue { }
 extension KingfisherWrapper where Base == String {
     var sha256: String {
         guard let data = base.data(using: .utf8) else { return base }
-        if #available(iOS 13.0, tvOS 13.0, macOS 10.15, watchOS 6.0, macCatalyst 13.0, *) {
-            let hashed = SHA256.hash(data: data)
-            return hashed.compactMap { String(format: "%02x", $0) }.joined()
-        } else {
-            var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-            data.withUnsafeBytes { bytes in
-                _ = CC_SHA256(bytes.baseAddress, UInt32(data.count), &digest)
-            }
-            return digest.makeIterator().compactMap { String(format: "%02x", $0) }.joined()
-        }
+        let hashed = SHA256.hash(data: data)
+        return hashed.compactMap { String(format: "%02x", $0) }.joined()
     }
 
     var ext: String? {

--- a/Sources/Views/AnimatedImageView.swift
+++ b/Sources/Views/AnimatedImageView.swift
@@ -427,12 +427,7 @@ open class AnimatedImageView: KFCrossPlatformImageView {
             let scale = image.recommendedLayerContentsScale(window?.backingScaleFactor ?? 0.0)
             let contentMode = imageScaling
             #else
-            var scale: CGFloat = 0
-            if #available(iOS 13.0, tvOS 13.0, *) {
-                scale = UITraitCollection.current.displayScale
-            } else {
-                scale = UIScreen.main.scale
-            }
+            let scale = UITraitCollection.current.displayScale
             #endif
             currentFrame = image
             let targetSize = bounds.scaled(scale).size

--- a/Sources/Views/Indicator.swift
+++ b/Sources/Views/Indicator.swift
@@ -158,19 +158,11 @@ final class ActivityIndicator: Indicator {
             let indicatorStyle: UIActivityIndicatorView.Style
 
             #if os(tvOS)
-            if #available(tvOS 13.0, *) {
-                indicatorStyle = UIActivityIndicatorView.Style.large
-            } else {
-                indicatorStyle = UIActivityIndicatorView.Style.white
-            }
+            indicatorStyle = UIActivityIndicatorView.Style.large
             #elseif os(visionOS)
             indicatorStyle = UIActivityIndicatorView.Style.medium
             #else
-            if #available(iOS 13.0, * ) {
-                indicatorStyle = UIActivityIndicatorView.Style.medium
-            } else {
-                indicatorStyle = UIActivityIndicatorView.Style.gray
-            }
+            indicatorStyle = UIActivityIndicatorView.Style.medium
             #endif
 
             activityIndicatorView = UIActivityIndicatorView(style: indicatorStyle)

--- a/Sources/Views/Indicator.swift
+++ b/Sources/Views/Indicator.swift
@@ -170,18 +170,6 @@ final class ActivityIndicator: Indicator {
     }
 }
 
-#if canImport(UIKit)
-extension UIActivityIndicatorView.Style {
-    #if compiler(>=5.1)
-    #else
-    static let large = UIActivityIndicatorView.Style.white
-    #if !os(tvOS)
-    static let medium = UIActivityIndicatorView.Style.gray
-    #endif
-    #endif
-}
-#endif
-
 // MARK: - ImageIndicator
 // Displays an ImageView. Supports gif
 final class ImageIndicator: Indicator {


### PR DESCRIPTION
### Motivation

Kingfisher 8 requires iOS 13.0+ / tvOS 13.0+ / macOS 10.15+ / watchOS 6.0+ / visionOS 1.0+ and Swift 5.9+. Package.swift, Kingfisher.podspec, and the Xcode project all declare the same deployment targets. A few version checks below this baseline are still in the sources. They always take the same branch, so the other branch is dead code.

### Changes

- `String+SHA256`: the CryptoKit path is always available, so the CommonCrypto fallback and its import are removed. CommonCrypto is not used anywhere else.
- `Indicator`: picks the `.large` / `.medium` activity indicator styles directly. The `UIActivityIndicatorView.Style` compatibility extension only declared fallback constants for compilers older than 5.1, so nothing is left in it and the whole extension is removed.
- `AnimatedImageView`: reads `UITraitCollection.current.displayScale` directly instead of falling back to `UIScreen.main.scale`.
- `KingfisherError.isLowDataModeConstrained` and the low data mode request setup in `ImageDownloader`: only the `#available` clause is removed, the remaining conditions stay.
- `CPListItem`: every SDK that ships with Swift 5.4+ accepts `setImage(nil)`, so the image is set unconditionally.
- `DisplayLink`: the `swift(>=5.9)` guards are removed. The `#available(macOS 14.0, *)` check stays, since that is a real runtime check.
- The `@available(tvOS 12.0, *)` annotations on the `TVMonogramView` support and the `@available(iOS 13.0, tvOS 13.0, *)` annotations on the `UIAction` / `UICommand` conformances are at or below the baseline and no longer restrict anything, so they are removed as well.

The `compiler(>=5.10)`, `swift(>=5.10)`, and `compiler(>=6)` guards are left untouched. Their else branches still compile on a Swift 5.9 toolchain.

No behavior change is intended. The diff is deletions and indentation only.

### Tests

No new tests. The full suite passes on iOS and macOS locally, and tvOS / watchOS / visionOS still build.