### PR TITLE
Avoid repeated decoding of cached original images

### DIFF
--- a/Sources/Cache/CacheSerializer.swift
+++ b/Sources/Cache/CacheSerializer.swift
@@ -62,10 +62,23 @@ public protocol CacheSerializer: Sendable {
     /// By default, it is `false`, and the actual processed image is assumed to be serialized to and later deserialized
     /// from the disk. That means the processed version of the image is stored and loaded.
     var originalDataUsed: Bool { get }
+
+    /// Indicates whether ``data(with:original:)`` writes a self-describing image format, such as PNG, JPEG or GIF.
+    ///
+    /// When `true`, Kingfisher may hand the cached bytes straight to an ``ImageProcessor`` as
+    /// ``ImageProcessItem/data(_:)`` instead of deserializing them first. Data-based processors — most notably
+    /// ``DownsamplingImageProcessor`` — re-encode an image input to get back to data, so deserializing first costs a
+    /// full size decode and re-encode that the processor immediately discards.
+    ///
+    /// By default it is `false`, and ``image(with:options:)`` is always used. Return `true` only if the bytes this
+    /// serializer writes can be decoded by the system image APIs on their own; a serializer that encrypts or
+    /// otherwise wraps its payload must leave it `false`.
+    var producesDecodableImageData: Bool { get }
 }
 
 public extension CacheSerializer {
     var originalDataUsed: Bool { false }
+    var producesDecodableImageData: Bool { false }
 }
 
 /// Represents a basic and default `CacheSerializer` used in the Kingfisher disk cache system.
@@ -84,6 +97,9 @@ public extension CacheSerializer {
 /// > Tip: If you create a new image instance from an animated image in a custom processor, use
 /// > ``KingfisherWrapper/copyKingfisherState(to:)`` to propagate the embedded animated data to the new image.
 public struct DefaultCacheSerializer: CacheSerializer {
+
+    /// Writes PNG, JPEG or GIF, so the cached bytes can be decoded directly.
+    public var producesDecodableImageData: Bool { true }
     
     /// The default general cache serializer utilized throughout Kingfisher's caching mechanism.
     public static let `default` = DefaultCacheSerializer()

--- a/Sources/Cache/FormatIndicatedCacheSerializer.swift
+++ b/Sources/Cache/FormatIndicatedCacheSerializer.swift
@@ -60,6 +60,9 @@ import UIKit
 /// imageView.kf.setImage(with: url, options: optionsInfo)
 /// ```
 public struct FormatIndicatedCacheSerializer: CacheSerializer {
+
+    /// Writes the indicated image format, so the cached bytes can be decoded directly.
+    public var producesDecodableImageData: Bool { true }
     
     /// A ``FormatIndicatedCacheSerializer`` instance that converts images to and from the PNG format. 
     ///

--- a/Sources/Cache/ImageCache.swift
+++ b/Sources/Cache/ImageCache.swift
@@ -736,6 +736,13 @@ open class ImageCache: @unchecked Sendable {
         case stale
     }
 
+    /// Represents the outcome of a raw disk cache data retrieval.
+    internal enum DiskDataRetrievalOutcome: Sendable {
+        case data(Data)
+        case notFound
+        case stale
+    }
+
     func retrieveImageInDiskCache(
         forKey key: String,
         options: KingfisherParsedOptionsInfo,
@@ -806,6 +813,55 @@ open class ImageCache: @unchecked Sendable {
                 }
             case .failure(let error):
                 completionHandler(.failure(error))
+            }
+        }
+    }
+
+    /// Retrieves the data stored on disk for `key`, without deserializing it to an image.
+    ///
+    /// Prefer this when the data is going to be passed to an ``ImageProcessor`` as
+    /// ``ImageProcessItem/data(_:)``. Deserializing first costs a full size decode, and data based
+    /// processors re-encode the image to get back to the data anyway.
+    func retrieveDataInDiskCache(
+        forKey key: String,
+        options: KingfisherParsedOptionsInfo,
+        callbackQueue: CallbackQueue = .untouch,
+        outcomeHandler: @escaping @Sendable (Result<DiskDataRetrievalOutcome, KingfisherError>) -> Void)
+    {
+        let computedKey = key.computedKey(with: options.processor.identifier)
+        let loadingQueue: CallbackQueue = options.loadDiskFileSynchronously ? .untouch : .dispatch(ioQueue)
+        loadingQueue.execute {
+            // CHECK 1: The task is likely already stale by the time a block queued on the serial
+            // ioQueue begins executing during fast scrolling.
+            if options.isSourceTaskStale {
+                callbackQueue.execute { outcomeHandler(.success(.stale)) }
+                return
+            }
+
+            do {
+                guard let data = try self.diskStorage.value(
+                    forKey: computedKey,
+                    forcedExtension: options.forcedExtension,
+                    extendingExpiration: options.diskCacheAccessExtendingExpiration
+                ) else {
+                    callbackQueue.execute { outcomeHandler(.success(.notFound)) }
+                    return
+                }
+
+                // CHECK 2: Catches staleness that occurred during a slow disk read.
+                if options.isSourceTaskStale {
+                    callbackQueue.execute { outcomeHandler(.success(.stale)) }
+                    return
+                }
+
+                callbackQueue.execute { outcomeHandler(.success(.data(data))) }
+            } catch let error as KingfisherError {
+                callbackQueue.execute { outcomeHandler(.failure(error)) }
+            } catch {
+                assertionFailure("The internal thrown error should be a `KingfisherError`.")
+                // Callers coalesce on this handler, so it has to run on every path. Reporting a miss
+                // lets the caller heal by downloading.
+                callbackQueue.execute { outcomeHandler(.success(.notFound)) }
             }
         }
     }

--- a/Sources/Cache/Storage.swift
+++ b/Sources/Cache/Storage.swift
@@ -33,7 +33,7 @@ struct TimeConstants {
 }
 
 /// Represents the expiration strategy utilized in storage.
-public enum StorageExpiration: Sendable {
+public enum StorageExpiration: Hashable, Sendable {
     
     /// The item never expires.
     case never
@@ -89,7 +89,7 @@ public enum StorageExpiration: Sendable {
 }
 
 /// Represents the expiration extension strategy used in storage after access.
-public enum ExpirationExtending: Sendable {
+public enum ExpirationExtending: Hashable, Sendable {
     /// The item expires after the original time, without extension after access.
     case none
     /// The item expiration extends to the original cache time after each access.

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -182,6 +182,8 @@ public class KingfisherManager: @unchecked Sendable {
     }
 
     private let processingQueue: CallbackQueue
+
+    private let originalProcessingCoalescer = OriginalImageProcessingCoalescer()
     
     private convenience init() {
         self.init(downloader: .default, cache: .default)
@@ -979,15 +981,20 @@ public class KingfisherManager: @unchecked Sendable {
         fallbackToDownload: @escaping @Sendable () -> Void,
         completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?)
     {
-        // Now we are ready to get found the original image from cache. We need the unprocessed image, so remove
-        // any processor from options first.
-        var optionsWithoutProcessor = options
-        optionsWithoutProcessor.processor = DefaultImageProcessor.default
-        originalCache.retrieveImage(forKey: key, options: optionsWithoutProcessor) { result in
-
+        // Only reading and processing the original is shared between coalesced requests. Everything
+        // below stays per request, so a single request behaves as before.
+        let deliver: @Sendable (Result<KFCrossPlatformImage?, KingfisherError>) -> Void = { result in
             result.match(
-                onSuccess: { cacheResult in
-                    guard let image = cacheResult.image else {
+                onSuccess: { processedImage in
+                    // This request may have been superseded while the shared read was in flight. The read is
+                    // deliberately not gated on any one request's checker, so the verdict is applied here.
+                    if processedImage != nil, options.isSourceTaskStale {
+                        let error = KingfisherError.cacheError(reason: .imageNotExisting(key: key))
+                        options.callbackQueue.execute { completionHandler?(.failure(error)) }
+                        return
+                    }
+
+                    guard let processedImage = processedImage else {
                         // If the task is stale, report error instead of downloading.
                         if options.isSourceTaskStale {
                             let error = KingfisherError.cacheError(reason: .imageNotExisting(key: key))
@@ -1006,57 +1013,220 @@ public class KingfisherManager: @unchecked Sendable {
                         return
                     }
 
-                    let processor = options.processor
-                    (options.processingQueue ?? self.processingQueue).execute {
-                        let item = ImageProcessItem.image(image)
-                        guard let processedImage = processor.process(item: item, options: options) else {
-                            let error = KingfisherError.processorError(
-                                reason: .processingFailed(processor: processor, item: item))
-                            options.callbackQueue.execute { completionHandler?(.failure(error)) }
-                            return
-                        }
+                    var cacheOptions = options
+                    cacheOptions.callbackQueue = .untouch
 
-                        var cacheOptions = options
-                        cacheOptions.callbackQueue = .untouch
+                    let coordinator = CacheCallbackCoordinator(
+                        shouldWaitForCache: options.waitForCache, shouldCacheOriginal: false)
 
-                        let coordinator = CacheCallbackCoordinator(
-                            shouldWaitForCache: options.waitForCache, shouldCacheOriginal: false)
+                    let image = options.imageModifier?.modify(processedImage) ?? processedImage
+                    let result = RetrieveImageResult(
+                        image: image,
+                        cacheType: .none,
+                        source: source,
+                        originalSource: context.originalSource,
+                        data: { options.cacheSerializer.data(with: processedImage, original: nil) }
+                    )
 
-                        let image = options.imageModifier?.modify(processedImage) ?? processedImage
-                        let result = RetrieveImageResult(
-                            image: image,
-                            cacheType: .none,
-                            source: source,
-                            originalSource: context.originalSource,
-                            data: { options.cacheSerializer.data(with: processedImage, original: nil) }
-                        )
-
-                        targetCache.store(
-                            processedImage,
-                            forKey: key,
-                            options: cacheOptions,
-                            toDisk: !options.cacheMemoryOnly)
-                        {
-                            _ in
-                            coordinator.apply(.cachingImage) {
-                                options.callbackQueue.execute { completionHandler?(.success(result)) }
-                            }
-                        }
-
-                        coordinator.apply(.cacheInitiated) {
+                    targetCache.store(
+                        processedImage,
+                        forKey: key,
+                        options: cacheOptions,
+                        toDisk: !options.cacheMemoryOnly)
+                    {
+                        _ in
+                        coordinator.apply(.cachingImage) {
                             options.callbackQueue.execute { completionHandler?(.success(result)) }
                         }
                     }
+
+                    coordinator.apply(.cacheInitiated) {
+                        options.callbackQueue.execute { completionHandler?(.success(result)) }
+                    }
                 },
                 onFailure: { error in
-                    // This should not happen actually, since we already confirmed `originalImageCached` is `true`.
-                    // Just in case...
-                    if let completionHandler = completionHandler {
-                        options.callbackQueue.execute { completionHandler(.failure(error)) }
-                    }
+                    options.callbackQueue.execute { completionHandler?(.failure(error)) }
                 }
             )
         }
+
+        // A serializer whose data only it can read keeps the previous route verbatim, and is not coalesced: a
+        // shared read carries one serializer, and only this one can turn its own bytes back into an image.
+        guard options.cacheSerializer.producesDecodableImageData else {
+            loadOriginalImage(from: originalCache, key: key, options: options, completionHandler: deliver)
+            return
+        }
+
+        let identifier = Self.originalProcessingIdentifier(originalCache: originalCache, key: key, options: options)
+
+        // An identical read and process is already running. It reports to every joiner when it lands.
+        guard originalProcessingCoalescer.join(
+            identifier,
+            isCurrent: options.sourceTaskIdentifierChecker,
+            completion: deliver
+        ) else { return }
+
+        // Held strongly, so the joined requests are still answered if this manager goes away, and drained on
+        // deinit so a dropped processing block cannot strand them.
+        let drain = OriginalProcessingDrain(identifier: identifier, coalescer: originalProcessingCoalescer)
+        processOriginal(in: originalCache, key: key, options: options, identifier: identifier) { result in
+            drain.finish(result)
+        }
+    }
+
+    // Master's route, for a serializer whose data only it can read. `options` is passed through untouched apart
+    // from the processor, so the staleness checks inside `retrieveImageInDiskCache` still short-circuit a
+    // superseded request before it deserializes and promotes a full size original into the memory cache.
+    private func loadOriginalImage(
+        from originalCache: ImageCache,
+        key: String,
+        options: KingfisherParsedOptionsInfo,
+        completionHandler: @escaping @Sendable (Result<KFCrossPlatformImage?, KingfisherError>) -> Void)
+    {
+        var optionsWithoutProcessor = options
+        optionsWithoutProcessor.processor = DefaultImageProcessor.default
+
+        let processor = options.processor
+        let processingQueue = options.processingQueue ?? self.processingQueue
+
+        originalCache.retrieveImage(forKey: key, options: optionsWithoutProcessor) { result in
+            result.match(
+                onSuccess: { cacheResult in
+                    guard let image = cacheResult.image else {
+                        completionHandler(.success(nil))
+                        return
+                    }
+                    processingQueue.execute {
+                        completionHandler(
+                            Self.process(.image(image), with: processor, options: options, decode: false)
+                        )
+                    }
+                },
+                onFailure: { completionHandler(.failure($0)) }
+            )
+        }
+    }
+
+    // The original is passed to the processor as data whenever it is still on disk. Deserializing it
+    // first costs a full size decode, which a data based processor such as `DownsamplingImageProcessor`
+    // then re-encodes to get back to the data it wanted. Reading the data also keeps a large original
+    // out of the memory cache, where it would be evicted again right after the processor has run.
+    private func processOriginal(
+        in originalCache: ImageCache,
+        key: String,
+        options: KingfisherParsedOptionsInfo,
+        identifier: String,
+        completionHandler: @escaping @Sendable (Result<KFCrossPlatformImage?, KingfisherError>) -> Void)
+    {
+        // The original is stored unprocessed, so look it up without a processor. The read serves every coalesced
+        // request, so it answers for the group rather than for whichever one started it: one request's check
+        // would abandon work the others are still waiting for. Each still applies its own on delivery.
+        let optionsWithoutProcessor: KingfisherParsedOptionsInfo = {
+            var copy = options
+            copy.processor = DefaultImageProcessor.default
+            copy.sourceTaskIdentifierChecker = { [weak coalescer = originalProcessingCoalescer] in
+                coalescer?.anyCurrent(identifier) ?? true
+            }
+            return copy
+        }()
+
+        let processor = options.processor
+        let processingQueue = options.processingQueue ?? self.processingQueue
+        let coalescer = originalProcessingCoalescer
+        // Whoever is already waiting when this read starts is answered by it. A request that joins later is
+        // not, which is what the stale arm below uses to decide whether the read has to happen again.
+        let waitingAtStart = coalescer.participantCount(identifier)
+
+        // A memory hit is already decoded, so there is nothing for the data route to save.
+        if let image = originalCache.retrieveImageInMemoryCache(forKey: key, options: optionsWithoutProcessor) {
+            processingQueue.execute { completionHandler(Self.process(.image(image), with: processor, options: options, decode: false)) }
+            return
+        }
+
+        if options.fromMemoryCacheOrRefresh {
+            completionHandler(.success(nil))
+            return
+        }
+
+        originalCache.retrieveDataInDiskCache(
+            forKey: key,
+            options: optionsWithoutProcessor,
+            callbackQueue: .mainCurrentOrAsync)
+        {
+            [weak self] result in
+            switch result {
+            case .success(.data(let data)):
+                processingQueue.execute {
+                    // Reading the data skips the decode `backgroundDecode` used to be applied to, and that was
+                    // the original, which is dropped right after processing. Apply it to the displayed image.
+                    let processed = Self.process(.data(data), with: processor, options: options, decode: options.backgroundDecode)
+                    guard case .failure = processed else {
+                        completionHandler(processed)
+                        return
+                    }
+
+                    // A processor may accept an image but not data. Falling back keeps it working.
+                    guard let image = optionsWithoutProcessor.cacheSerializer.image(
+                        with: data, options: optionsWithoutProcessor
+                    ) else {
+                        // Undecodable data is a cache miss, not a processing failure. The caller falls
+                        // back to downloading, which is how a corrupt original heals itself.
+                        completionHandler(.success(nil))
+                        return
+                    }
+                    completionHandler(Self.process(.image(image), with: processor, options: options, decode: options.backgroundDecode))
+                }
+            case .success(.stale):
+                // The read was abandoned for the group as it stood at the staleness check, and that verdict only
+                // arrives here after a queue hop. Anyone who joined since did no read of their own, so the miss
+                // is not theirs to receive: read again for them. A retry needs a newly joined request, and a
+                // request joins once, so the number of retries cannot exceed the number of requests.
+                guard let self,
+                      coalescer.participantCount(identifier) > waitingAtStart,
+                      coalescer.anyCurrent(identifier)
+                else {
+                    completionHandler(.success(nil))
+                    return
+                }
+                self.processOriginal(
+                    in: originalCache,
+                    key: key,
+                    options: options,
+                    identifier: identifier,
+                    completionHandler: completionHandler
+                )
+
+            case .success(.notFound):
+                completionHandler(.success(nil))
+            case .failure(let error):
+                completionHandler(.failure(error))
+            }
+        }
+    }
+
+    private static func process(
+        _ item: ImageProcessItem,
+        with processor: any ImageProcessor,
+        options: KingfisherParsedOptionsInfo,
+        decode: Bool) -> Result<KFCrossPlatformImage?, KingfisherError>
+    {
+        guard let processedImage = processor.process(item: item, options: options) else {
+            return .failure(
+                KingfisherError.processorError(reason: .processingFailed(processor: processor, item: item))
+            )
+        }
+        guard decode else { return .success(processedImage) }
+        return .success(processedImage.kf.decoded)
+    }
+
+    // Requests share the work only when they would compute the same image.
+    private static func originalProcessingIdentifier(
+        originalCache: ImageCache,
+        key: String,
+        options: KingfisherParsedOptionsInfo) -> String
+    {
+        let cacheIdentifier = UInt(bitPattern: ObjectIdentifier(originalCache))
+        return "\(cacheIdentifier)|\(key)|\(options.processor.identifier)|\(options.scaleFactor)|\(options.forcedExtension ?? "")"
     }
 }
 
@@ -1268,6 +1438,113 @@ class RetrievingContext<SourceType>: @unchecked Sendable {
             _propagationErrors.append(item)
             return _propagationErrors
         }
+    }
+}
+
+/// Shares one original image read and process between the requests that would each perform it.
+///
+/// The download path already does this: a single `SessionDataTask` collects every callback and
+/// `ImageDataProcessor` runs each distinct processor once over the downloaded data. Without the same
+/// on the cache hit path, every view showing an image decodes and processes the original itself.
+/// Guarantees a coalesced entry is drained, even if the work that should have reported it is dropped.
+///
+/// A user supplied processing queue can release a block without running it. Without this the entry stays in
+/// `pending` and every later request for that key joins a leader that will never report.
+final class OriginalProcessingDrain: @unchecked Sendable {
+
+    private let identifier: String
+    private let coalescer: OriginalImageProcessingCoalescer
+    private let lock = NSLock()
+    private var reported = false
+
+    init(identifier: String, coalescer: OriginalImageProcessingCoalescer) {
+        self.identifier = identifier
+        self.coalescer = coalescer
+    }
+
+    func finish(_ result: Result<KFCrossPlatformImage?, KingfisherError>) {
+        lock.lock()
+        if reported {
+            lock.unlock()
+            return
+        }
+        reported = true
+        lock.unlock()
+        coalescer.finish(identifier, result: result)
+    }
+
+    deinit {
+        // Degrades to a cache miss, so the joined requests heal by downloading.
+        finish(.success(nil))
+    }
+}
+
+class OriginalImageProcessingCoalescer: @unchecked Sendable {
+
+    typealias Completion = @Sendable (Result<KFCrossPlatformImage?, KingfisherError>) -> Void
+
+    private struct Participant {
+        let completion: Completion
+        let isCurrent: (@Sendable () -> Bool)?
+    }
+
+    private let stateQueue: DispatchQueue
+    private var pending: [String: [Participant]] = [:]
+
+    init() {
+        let stateQueueName = "com.onevcat.Kingfisher.OriginalImageProcessingCoalescer.stateQueue.\(UUID().uuidString)"
+        self.stateQueue = DispatchQueue(label: stateQueueName)
+    }
+
+    /// Adds `completion` to `identifier`, and returns whether the caller should perform the work.
+    ///
+    /// `isCurrent` is the joining request's own liveness check, `nil` when it has none and is therefore always
+    /// current. It is kept so the shared work can be abandoned once every request waiting on it has gone away.
+    func join(
+        _ identifier: String,
+        isCurrent: (@Sendable () -> Bool)?,
+        completion: @escaping Completion) -> Bool
+    {
+        let participant = Participant(completion: completion, isCurrent: isCurrent)
+        return stateQueue.sync { () -> Bool in
+            if pending[identifier] == nil {
+                pending[identifier] = [participant]
+                return true
+            }
+            pending[identifier]?.append(participant)
+            return false
+        }
+    }
+
+    /// How many requests are waiting on `identifier`.
+    ///
+    /// Only `join` adds and only `finish` removes the whole entry, so for the life of one entry this only ever
+    /// grows — which makes it usable as a join count.
+    func participantCount(_ identifier: String) -> Int {
+        stateQueue.sync { pending[identifier]?.count ?? 0 }
+    }
+
+    /// Whether any request waiting on `identifier` is still current.
+    ///
+    /// `true` when nothing is waiting, so a race can never abandon work on an empty group. The checks belong to
+    /// callers, so they are copied out and run with the lock released: calling one while `stateQueue` is held
+    /// would deadlock the serial queue if it re-entered.
+    func anyCurrent(_ identifier: String) -> Bool {
+        let participants = stateQueue.sync { pending[identifier] }
+        guard let participants = participants, !participants.isEmpty else { return true }
+        for participant in participants {
+            guard let isCurrent = participant.isCurrent else { return true }
+            if isCurrent() { return true }
+        }
+        return false
+    }
+
+    /// Reports `result` to everything waiting on `identifier`. Calling it again is a no-op.
+    func finish(_ identifier: String, result: Result<KFCrossPlatformImage?, KingfisherError>) {
+        // Taken out of `pending` under the lock, then called outside it. A completion may start a
+        // download or re-enter the manager, and `stateQueue` is serial.
+        let participants = stateQueue.sync { pending.removeValue(forKey: identifier) ?? [] }
+        participants.forEach { $0.completion(result) }
     }
 }
 

--- a/Sources/General/KingfisherManager.swift
+++ b/Sources/General/KingfisherManager.swift
@@ -981,13 +981,11 @@ public class KingfisherManager: @unchecked Sendable {
         fallbackToDownload: @escaping @Sendable () -> Void,
         completionHandler: (@Sendable (Result<RetrieveImageResult, KingfisherError>) -> Void)?)
     {
-        // Only reading and processing the original is shared between coalesced requests. Everything
-        // below stays per request, so a single request behaves as before.
-        let deliver: @Sendable (Result<KFCrossPlatformImage?, KingfisherError>) -> Void = { result in
+        let processingQueue = options.processingQueue ?? self.processingQueue
+
+        let complete: @Sendable (Result<KFCrossPlatformImage?, KingfisherError>) -> Void = { result in
             result.match(
                 onSuccess: { processedImage in
-                    // This request may have been superseded while the shared read was in flight. The read is
-                    // deliberately not gated on any one request's checker, so the verdict is applied here.
                     if processedImage != nil, options.isSourceTaskStale {
                         let error = KingfisherError.cacheError(reason: .imageNotExisting(key: key))
                         options.callbackQueue.execute { completionHandler?(.failure(error)) }
@@ -1050,41 +1048,74 @@ public class KingfisherManager: @unchecked Sendable {
             )
         }
 
-        // A serializer whose data only it can read keeps the previous route verbatim, and is not coalesced: a
-        // shared read carries one serializer, and only this one can turn its own bytes back into an image.
-        guard options.cacheSerializer.producesDecodableImageData else {
+        // Only the disk read and the processor run over its bytes are shared. Background decoding, the
+        // deserializing fallback, the image modifier and the cache store all use this request's own options.
+        let deliver: @Sendable (Result<SharedOriginalImage, KingfisherError>) -> Void = { shared in
+            switch shared {
+            case .failure(let error):
+                complete(.failure(error))
+
+            case .success(.none):
+                complete(.success(nil))
+
+            case .success(.processed(let image)):
+                guard options.backgroundDecode else {
+                    complete(.success(image))
+                    return
+                }
+                processingQueue.execute { complete(.success(image.kf.decoded)) }
+
+            case .success(.unprocessedData(let data)):
+                processingQueue.execute {
+                    guard let image = options.cacheSerializer.image(with: data, options: options) else {
+                        complete(.success(nil))
+                        return
+                    }
+                    let processed = Self.process(.image(image), with: options.processor, options: options)
+                    guard options.backgroundDecode else {
+                        complete(processed)
+                        return
+                    }
+                    complete(processed.map { $0?.kf.decoded })
+                }
+            }
+        }
+
+        // A serializer that does not declare its data decodable is the only one that can read what it wrote,
+        // so its requests keep the deserializing route and are not shared.
+        guard options.cacheSerializer.producesDecodableImageData, !options.fromMemoryCacheOrRefresh else {
             loadOriginalImage(from: originalCache, key: key, options: options, completionHandler: deliver)
             return
         }
 
-        let identifier = Self.originalProcessingIdentifier(originalCache: originalCache, key: key, options: options)
+        let identity = OriginalProcessingIdentity(cache: originalCache, key: key, options: options)
 
         // An identical read and process is already running. It reports to every joiner when it lands.
         guard originalProcessingCoalescer.join(
-            identifier,
+            identity,
             isCurrent: options.sourceTaskIdentifierChecker,
             completion: deliver
         ) else { return }
 
         // Held strongly, so the joined requests are still answered if this manager goes away, and drained on
         // deinit so a dropped processing block cannot strand them.
-        let drain = OriginalProcessingDrain(identifier: identifier, coalescer: originalProcessingCoalescer)
-        processOriginal(in: originalCache, key: key, options: options, identifier: identifier) { result in
+        let drain = OriginalProcessingDrain(identity: identity, coalescer: originalProcessingCoalescer)
+        processOriginal(in: originalCache, key: key, options: options, identity: identity) { result in
             drain.finish(result)
         }
     }
 
-    // Master's route, for a serializer whose data only it can read. `options` is passed through untouched apart
-    // from the processor, so the staleness checks inside `retrieveImageInDiskCache` still short-circuit a
-    // superseded request before it deserializes and promotes a full size original into the memory cache.
+    // The route for a serializer that only it can read: the original is deserialized before the processor sees it.
     private func loadOriginalImage(
         from originalCache: ImageCache,
         key: String,
         options: KingfisherParsedOptionsInfo,
-        completionHandler: @escaping @Sendable (Result<KFCrossPlatformImage?, KingfisherError>) -> Void)
+        completionHandler: @escaping @Sendable (Result<SharedOriginalImage, KingfisherError>) -> Void)
     {
         var optionsWithoutProcessor = options
         optionsWithoutProcessor.processor = DefaultImageProcessor.default
+        // The original is discarded once the processor has run. Decoding is applied to the delivered image.
+        optionsWithoutProcessor.backgroundDecode = false
 
         let processor = options.processor
         let processingQueue = options.processingQueue ?? self.processingQueue
@@ -1093,12 +1124,13 @@ public class KingfisherManager: @unchecked Sendable {
             result.match(
                 onSuccess: { cacheResult in
                     guard let image = cacheResult.image else {
-                        completionHandler(.success(nil))
+                        completionHandler(.success(.none))
                         return
                     }
                     processingQueue.execute {
                         completionHandler(
-                            Self.process(.image(image), with: processor, options: options, decode: false)
+                            Self.process(.image(image), with: processor, options: options)
+                                .map { $0.map(SharedOriginalImage.processed) ?? .none }
                         )
                     }
                 },
@@ -1107,25 +1139,24 @@ public class KingfisherManager: @unchecked Sendable {
         }
     }
 
-    // The original is passed to the processor as data whenever it is still on disk. Deserializing it
-    // first costs a full size decode, which a data based processor such as `DownsamplingImageProcessor`
-    // then re-encodes to get back to the data it wanted. Reading the data also keeps a large original
-    // out of the memory cache, where it would be evicted again right after the processor has run.
+    // The original is passed to the processor as data whenever it is still on disk. Deserializing it first costs
+    // a full size decode, which a data based processor such as `DownsamplingImageProcessor` then re-encodes to
+    // get back to the data it wanted. Reading the data also keeps a large original out of the memory cache.
     private func processOriginal(
         in originalCache: ImageCache,
         key: String,
         options: KingfisherParsedOptionsInfo,
-        identifier: String,
-        completionHandler: @escaping @Sendable (Result<KFCrossPlatformImage?, KingfisherError>) -> Void)
+        identity: OriginalProcessingIdentity,
+        completionHandler: @escaping @Sendable (Result<SharedOriginalImage, KingfisherError>) -> Void)
     {
-        // The original is stored unprocessed, so look it up without a processor. The read serves every coalesced
-        // request, so it answers for the group rather than for whichever one started it: one request's check
-        // would abandon work the others are still waiting for. Each still applies its own on delivery.
+        // The original is stored unprocessed, so look it up without a processor. The read serves every request
+        // waiting on it, so it is abandoned only once they have all gone away; each still applies its own
+        // staleness when the result is delivered.
         let optionsWithoutProcessor: KingfisherParsedOptionsInfo = {
             var copy = options
             copy.processor = DefaultImageProcessor.default
             copy.sourceTaskIdentifierChecker = { [weak coalescer = originalProcessingCoalescer] in
-                coalescer?.anyCurrent(identifier) ?? true
+                coalescer?.anyCurrent(identity) ?? true
             }
             return copy
         }()
@@ -1133,18 +1164,21 @@ public class KingfisherManager: @unchecked Sendable {
         let processor = options.processor
         let processingQueue = options.processingQueue ?? self.processingQueue
         let coalescer = originalProcessingCoalescer
-        // Whoever is already waiting when this read starts is answered by it. A request that joins later is
-        // not, which is what the stale arm below uses to decide whether the read has to happen again.
-        let waitingAtStart = coalescer.participantCount(identifier)
+        let waitingAtStart = coalescer.participantCount(identity)
 
         // A memory hit is already decoded, so there is nothing for the data route to save.
         if let image = originalCache.retrieveImageInMemoryCache(forKey: key, options: optionsWithoutProcessor) {
-            processingQueue.execute { completionHandler(Self.process(.image(image), with: processor, options: options, decode: false)) }
+            processingQueue.execute {
+                completionHandler(
+                    Self.process(.image(image), with: processor, options: options)
+                        .map { $0.map(SharedOriginalImage.processed) ?? .none }
+                )
+            }
             return
         }
 
         if options.fromMemoryCacheOrRefresh {
-            completionHandler(.success(nil))
+            completionHandler(.success(.none))
             return
         }
 
@@ -1157,47 +1191,36 @@ public class KingfisherManager: @unchecked Sendable {
             switch result {
             case .success(.data(let data)):
                 processingQueue.execute {
-                    // Reading the data skips the decode `backgroundDecode` used to be applied to, and that was
-                    // the original, which is dropped right after processing. Apply it to the displayed image.
-                    let processed = Self.process(.data(data), with: processor, options: options, decode: options.backgroundDecode)
-                    guard case .failure = processed else {
-                        completionHandler(processed)
+                    // A processor is free to accept an image but not data. Reporting the bytes lets each
+                    // request deserialize them with its own serializer instead of sharing one result.
+                    guard let image = processor.process(item: .data(data), options: options) else {
+                        completionHandler(.success(.unprocessedData(data)))
                         return
                     }
-
-                    // A processor may accept an image but not data. Falling back keeps it working.
-                    guard let image = optionsWithoutProcessor.cacheSerializer.image(
-                        with: data, options: optionsWithoutProcessor
-                    ) else {
-                        // Undecodable data is a cache miss, not a processing failure. The caller falls
-                        // back to downloading, which is how a corrupt original heals itself.
-                        completionHandler(.success(nil))
-                        return
-                    }
-                    completionHandler(Self.process(.image(image), with: processor, options: options, decode: options.backgroundDecode))
+                    completionHandler(.success(.processed(image)))
                 }
+
             case .success(.stale):
-                // The read was abandoned for the group as it stood at the staleness check, and that verdict only
-                // arrives here after a queue hop. Anyone who joined since did no read of their own, so the miss
-                // is not theirs to receive: read again for them. A retry needs a newly joined request, and a
-                // request joins once, so the number of retries cannot exceed the number of requests.
+                // The read was abandoned for the requests waiting on it at the staleness check, and that verdict
+                // reaches here after a queue hop. Anyone who joined since performed no read, so the read happens
+                // again for them. A retry needs a newly joined request, and a request joins once.
                 guard let self,
-                      coalescer.participantCount(identifier) > waitingAtStart,
-                      coalescer.anyCurrent(identifier)
+                      coalescer.participantCount(identity) > waitingAtStart,
+                      coalescer.anyCurrent(identity)
                 else {
-                    completionHandler(.success(nil))
+                    completionHandler(.success(.none))
                     return
                 }
                 self.processOriginal(
                     in: originalCache,
                     key: key,
                     options: options,
-                    identifier: identifier,
+                    identity: identity,
                     completionHandler: completionHandler
                 )
 
             case .success(.notFound):
-                completionHandler(.success(nil))
+                completionHandler(.success(.none))
             case .failure(let error):
                 completionHandler(.failure(error))
             }
@@ -1207,26 +1230,14 @@ public class KingfisherManager: @unchecked Sendable {
     private static func process(
         _ item: ImageProcessItem,
         with processor: any ImageProcessor,
-        options: KingfisherParsedOptionsInfo,
-        decode: Bool) -> Result<KFCrossPlatformImage?, KingfisherError>
+        options: KingfisherParsedOptionsInfo) -> Result<KFCrossPlatformImage?, KingfisherError>
     {
         guard let processedImage = processor.process(item: item, options: options) else {
             return .failure(
                 KingfisherError.processorError(reason: .processingFailed(processor: processor, item: item))
             )
         }
-        guard decode else { return .success(processedImage) }
-        return .success(processedImage.kf.decoded)
-    }
-
-    // Requests share the work only when they would compute the same image.
-    private static func originalProcessingIdentifier(
-        originalCache: ImageCache,
-        key: String,
-        options: KingfisherParsedOptionsInfo) -> String
-    {
-        let cacheIdentifier = UInt(bitPattern: ObjectIdentifier(originalCache))
-        return "\(cacheIdentifier)|\(key)|\(options.processor.identifier)|\(options.scaleFactor)|\(options.forcedExtension ?? "")"
+        return .success(processedImage)
     }
 }
 
@@ -1441,28 +1452,65 @@ class RetrievingContext<SourceType>: @unchecked Sendable {
     }
 }
 
-/// Shares one original image read and process between the requests that would each perform it.
+/// What an original cache hit can share between the requests waiting on it.
+enum SharedOriginalImage: Sendable {
+
+    /// The processor produced this image from the stored data.
+    case processed(KFCrossPlatformImage)
+
+    /// The processor did not accept the stored data. Each request deserializes it with its own serializer.
+    case unprocessedData(Data)
+
+    /// No usable original.
+    case none
+}
+
+/// Identifies a shared original read and process.
 ///
-/// The download path already does this: a single `SessionDataTask` collects every callback and
-/// `ImageDataProcessor` runs each distinct processor once over the downloaded data. Without the same
-/// on the cache hit path, every view showing an image decodes and processes the original itself.
+/// Requests share the work only when the processor, and the inputs it is given, would produce the same image.
+struct OriginalProcessingIdentity: Hashable {
+
+    private let cache: ObjectIdentifier
+    private let key: String
+    private let processorIdentifier: String
+    /// The bit pattern of the scale, so that every value including `nan` is equal to itself.
+    private let scale: UInt64
+    private let forcedExtension: String?
+    private let preloadAllAnimationData: Bool
+    private let onlyLoadFirstFrame: Bool
+    private let diskCacheAccessExtendingExpiration: ExpirationExtending
+    private let memoryCacheAccessExtendingExpiration: ExpirationExtending
+
+    init(cache: ImageCache, key: String, options: KingfisherParsedOptionsInfo) {
+        self.cache = ObjectIdentifier(cache)
+        self.key = key
+        self.processorIdentifier = options.processor.identifier
+        self.scale = Double(options.scaleFactor).bitPattern
+        self.forcedExtension = options.forcedExtension
+        self.preloadAllAnimationData = options.preloadAllAnimationData
+        self.onlyLoadFirstFrame = options.onlyLoadFirstFrame
+        self.diskCacheAccessExtendingExpiration = options.diskCacheAccessExtendingExpiration
+        self.memoryCacheAccessExtendingExpiration = options.memoryCacheAccessExtendingExpiration
+    }
+}
+
 /// Guarantees a coalesced entry is drained, even if the work that should have reported it is dropped.
 ///
 /// A user supplied processing queue can release a block without running it. Without this the entry stays in
 /// `pending` and every later request for that key joins a leader that will never report.
 final class OriginalProcessingDrain: @unchecked Sendable {
 
-    private let identifier: String
+    private let identity: OriginalProcessingIdentity
     private let coalescer: OriginalImageProcessingCoalescer
     private let lock = NSLock()
     private var reported = false
 
-    init(identifier: String, coalescer: OriginalImageProcessingCoalescer) {
-        self.identifier = identifier
+    init(identity: OriginalProcessingIdentity, coalescer: OriginalImageProcessingCoalescer) {
+        self.identity = identity
         self.coalescer = coalescer
     }
 
-    func finish(_ result: Result<KFCrossPlatformImage?, KingfisherError>) {
+    func finish(_ result: Result<SharedOriginalImage, KingfisherError>) {
         lock.lock()
         if reported {
             lock.unlock()
@@ -1470,18 +1518,22 @@ final class OriginalProcessingDrain: @unchecked Sendable {
         }
         reported = true
         lock.unlock()
-        coalescer.finish(identifier, result: result)
+        coalescer.finish(identity, result: result)
     }
 
     deinit {
         // Degrades to a cache miss, so the joined requests heal by downloading.
-        finish(.success(nil))
+        finish(.success(.none))
     }
 }
 
+/// Shares one original image read and process between the requests that would each perform it.
+///
+/// The download path already does this: a single `SessionDataTask` collects every callback and
+/// `ImageDataProcessor` runs each distinct processor once over the downloaded data.
 class OriginalImageProcessingCoalescer: @unchecked Sendable {
 
-    typealias Completion = @Sendable (Result<KFCrossPlatformImage?, KingfisherError>) -> Void
+    typealias Completion = @Sendable (Result<SharedOriginalImage, KingfisherError>) -> Void
 
     private struct Participant {
         let completion: Completion
@@ -1489,48 +1541,48 @@ class OriginalImageProcessingCoalescer: @unchecked Sendable {
     }
 
     private let stateQueue: DispatchQueue
-    private var pending: [String: [Participant]] = [:]
+    private var pending: [OriginalProcessingIdentity: [Participant]] = [:]
 
     init() {
         let stateQueueName = "com.onevcat.Kingfisher.OriginalImageProcessingCoalescer.stateQueue.\(UUID().uuidString)"
         self.stateQueue = DispatchQueue(label: stateQueueName)
     }
 
-    /// Adds `completion` to `identifier`, and returns whether the caller should perform the work.
+    /// Adds `completion` to `identity`, and returns whether the caller should perform the work.
     ///
     /// `isCurrent` is the joining request's own liveness check, `nil` when it has none and is therefore always
     /// current. It is kept so the shared work can be abandoned once every request waiting on it has gone away.
     func join(
-        _ identifier: String,
+        _ identity: OriginalProcessingIdentity,
         isCurrent: (@Sendable () -> Bool)?,
         completion: @escaping Completion) -> Bool
     {
         let participant = Participant(completion: completion, isCurrent: isCurrent)
         return stateQueue.sync { () -> Bool in
-            if pending[identifier] == nil {
-                pending[identifier] = [participant]
+            if pending[identity] == nil {
+                pending[identity] = [participant]
                 return true
             }
-            pending[identifier]?.append(participant)
+            pending[identity]?.append(participant)
             return false
         }
     }
 
-    /// How many requests are waiting on `identifier`.
+    /// How many requests are waiting on `identity`.
     ///
     /// Only `join` adds and only `finish` removes the whole entry, so for the life of one entry this only ever
     /// grows — which makes it usable as a join count.
-    func participantCount(_ identifier: String) -> Int {
-        stateQueue.sync { pending[identifier]?.count ?? 0 }
+    func participantCount(_ identity: OriginalProcessingIdentity) -> Int {
+        stateQueue.sync { pending[identity]?.count ?? 0 }
     }
 
-    /// Whether any request waiting on `identifier` is still current.
+    /// Whether any request waiting on `identity` is still current.
     ///
     /// `true` when nothing is waiting, so a race can never abandon work on an empty group. The checks belong to
     /// callers, so they are copied out and run with the lock released: calling one while `stateQueue` is held
     /// would deadlock the serial queue if it re-entered.
-    func anyCurrent(_ identifier: String) -> Bool {
-        let participants = stateQueue.sync { pending[identifier] }
+    func anyCurrent(_ identity: OriginalProcessingIdentity) -> Bool {
+        let participants = stateQueue.sync { pending[identity] }
         guard let participants = participants, !participants.isEmpty else { return true }
         for participant in participants {
             guard let isCurrent = participant.isCurrent else { return true }
@@ -1539,11 +1591,11 @@ class OriginalImageProcessingCoalescer: @unchecked Sendable {
         return false
     }
 
-    /// Reports `result` to everything waiting on `identifier`. Calling it again is a no-op.
-    func finish(_ identifier: String, result: Result<KFCrossPlatformImage?, KingfisherError>) {
+    /// Reports `result` to everything waiting on `identity`. Calling it again is a no-op.
+    func finish(_ identity: OriginalProcessingIdentity, result: Result<SharedOriginalImage, KingfisherError>) {
         // Taken out of `pending` under the lock, then called outside it. A completion may start a
         // download or re-enter the manager, and `stateQueue` is serial.
-        let participants = stateQueue.sync { pending.removeValue(forKey: identifier) ?? [] }
+        let participants = stateQueue.sync { pending.removeValue(forKey: identity) ?? [] }
         participants.forEach { $0.completion(result) }
     }
 }

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -2319,3 +2319,141 @@ actor ActorArray<Element> {
         value.append(newElement)
     }
 }
+
+// MARK: - Original cache hit
+
+/// Records which `ImageProcessItem` case it was given, and how often it ran.
+final class ItemRecordingProcessor: ImageProcessor, @unchecked Sendable {
+
+    let identifier = "com.onevcat.Kingfisher.test.ItemRecordingProcessor"
+
+    private let lock = NSLock()
+    private var _dataCount = 0
+    private var _imageCount = 0
+
+    var dataCount: Int { lock.lock(); defer { lock.unlock() }; return _dataCount }
+    var imageCount: Int { lock.lock(); defer { lock.unlock() }; return _imageCount }
+    var runCount: Int { dataCount + imageCount }
+
+    func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
+        lock.lock()
+        switch item {
+        case .data: _dataCount += 1
+        case .image: _imageCount += 1
+        }
+        lock.unlock()
+        return DefaultImageProcessor.default.process(item: item, options: options)
+    }
+}
+
+/// Serializes like the default one, but does not declare its data decodable, and counts deserializations.
+final class RecordingCacheSerializer: CacheSerializer, @unchecked Sendable {
+
+    private let lock = NSLock()
+    private var _imageCallCount = 0
+    var imageCallCount: Int { lock.lock(); defer { lock.unlock() }; return _imageCallCount }
+
+    func data(with image: KFCrossPlatformImage, original: Data?) -> Data? {
+        DefaultCacheSerializer.default.data(with: image, original: original)
+    }
+
+    func image(with data: Data, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
+        lock.lock()
+        _imageCallCount += 1
+        lock.unlock()
+        return DefaultCacheSerializer.default.image(with: data, options: options)
+    }
+}
+
+extension KingfisherManagerTests {
+
+    func testOriginalCacheHitGivesTheProcessorTheData() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        let processor = ItemRecordingProcessor()
+        let cache = manager.cache
+
+        stub(url, data: testImageData)
+
+        // Store the unprocessed original only, then drop the memory copy so the disk is the source.
+        cache.store(testImage, original: testImageData, forKey: url.cacheKey, toDisk: true) { _ in
+            cache.clearMemoryCache()
+            self.manager.retrieveImage(with: url, options: [.processor(processor)]) { result in
+                XCTAssertNotNil(result.value?.image)
+                XCTAssertEqual(processor.dataCount, 1, "the processor should receive the stored bytes")
+                XCTAssertEqual(processor.imageCount, 0, "the original should not be decoded first")
+                exp.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testConcurrentOriginalCacheHitsProcessTheOriginalOnce() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        let processor = ItemRecordingProcessor()
+        let cache = manager.cache
+        let requestCount = 10
+
+        stub(url, data: testImageData)
+
+        cache.store(testImage, original: testImageData, forKey: url.cacheKey, toDisk: true) { _ in
+            cache.clearMemoryCache()
+
+            let group = DispatchGroup()
+            let delivered = LockIsolated(0)
+
+            for _ in 0 ..< requestCount {
+                group.enter()
+                self.manager.retrieveImage(with: url, options: [.processor(processor)]) { result in
+                    if result.value?.image != nil {
+                        delivered.withValue { $0 += 1 }
+                    }
+                    group.leave()
+                }
+            }
+
+            group.notify(queue: .main) {
+                XCTAssertEqual(delivered.value, requestCount, "every request should be answered")
+                XCTAssertEqual(processor.runCount, 1, "the original should be processed once for the group")
+                exp.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    func testOriginalCacheHitDeserializesWhenTheSerializerDoesNotDeclareDecodableData() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        let processor = ItemRecordingProcessor()
+        let serializer = RecordingCacheSerializer()
+        let cache = manager.cache
+
+        stub(url, data: testImageData)
+
+        cache.store(
+            testImage,
+            original: testImageData,
+            forKey: url.cacheKey,
+            cacheSerializer: serializer,
+            toDisk: true
+        ) { _ in
+            cache.clearMemoryCache()
+            let options: KingfisherOptionsInfo = [.processor(processor), .cacheSerializer(serializer)]
+            self.manager.retrieveImage(with: url, options: options) { result in
+                XCTAssertNotNil(result.value?.image)
+                XCTAssertGreaterThan(serializer.imageCallCount, 0, "the serializer should still be used")
+                XCTAssertEqual(processor.dataCount, 0, "raw bytes should not be given to the processor")
+                XCTAssertEqual(processor.imageCount, 1)
+                exp.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+
+    func testProducesDecodableImageDataDefaults() {
+        XCTAssertTrue(DefaultCacheSerializer.default.producesDecodableImageData)
+        XCTAssertTrue(FormatIndicatedCacheSerializer.png.producesDecodableImageData)
+        XCTAssertFalse(RecordingCacheSerializer().producesDecodableImageData)
+    }
+}

--- a/Tests/KingfisherTests/KingfisherManagerTests.swift
+++ b/Tests/KingfisherTests/KingfisherManagerTests.swift
@@ -2325,7 +2325,11 @@ actor ActorArray<Element> {
 /// Records which `ImageProcessItem` case it was given, and how often it ran.
 final class ItemRecordingProcessor: ImageProcessor, @unchecked Sendable {
 
-    let identifier = "com.onevcat.Kingfisher.test.ItemRecordingProcessor"
+    let identifier: String
+
+    init(identifier: String = "com.onevcat.Kingfisher.test.ItemRecordingProcessor") {
+        self.identifier = identifier
+    }
 
     private let lock = NSLock()
     private var _dataCount = 0
@@ -2348,6 +2352,12 @@ final class ItemRecordingProcessor: ImageProcessor, @unchecked Sendable {
 
 /// Serializes like the default one, but does not declare its data decodable, and counts deserializations.
 final class RecordingCacheSerializer: CacheSerializer, @unchecked Sendable {
+
+    let producesDecodableImageData: Bool
+
+    init(declaresDecodableData: Bool = false) {
+        self.producesDecodableImageData = declaresDecodableData
+    }
 
     private let lock = NSLock()
     private var _imageCallCount = 0
@@ -2378,6 +2388,7 @@ extension KingfisherManagerTests {
         // Store the unprocessed original only, then drop the memory copy so the disk is the source.
         cache.store(testImage, original: testImageData, forKey: url.cacheKey, toDisk: true) { _ in
             cache.clearMemoryCache()
+            XCTAssertTrue(cache.imageCachedType(forKey: url.cacheKey).cached)
             self.manager.retrieveImage(with: url, options: [.processor(processor)]) { result in
                 XCTAssertNotNil(result.value?.image)
                 XCTAssertEqual(processor.dataCount, 1, "the processor should receive the stored bytes")
@@ -2451,9 +2462,201 @@ extension KingfisherManagerTests {
         waitForExpectations(timeout: 3, handler: nil)
     }
 
+    func testProcessingIdentityIsTotalForNonFiniteScale() {
+        let options = KingfisherParsedOptionsInfo([.scaleFactor(CGFloat.nan)])
+        let identity = OriginalProcessingIdentity(cache: manager.cache, key: "key", options: options)
+
+        XCTAssertEqual(identity, identity)
+
+        var table: [OriginalProcessingIdentity: Int] = [:]
+        table[identity] = 1
+        XCTAssertEqual(table[identity], 1)
+    }
+
     func testProducesDecodableImageDataDefaults() {
         XCTAssertTrue(DefaultCacheSerializer.default.producesDecodableImageData)
         XCTAssertTrue(FormatIndicatedCacheSerializer.png.producesDecodableImageData)
         XCTAssertFalse(RecordingCacheSerializer().producesDecodableImageData)
+    }
+}
+
+extension KingfisherManagerTests {
+
+    func testDelimiterBearingIdentitiesAreNotShared() {
+        let exp = expectation(description: #function)
+        let cache = manager.cache
+
+        // `a|b` with processor `c`, and `a` with processor `b|c`, are different requests.
+        let firstProvider = SimpleImageDataProvider(cacheKey: "a|b") { .success(testImageData) }
+        let secondProvider = SimpleImageDataProvider(cacheKey: "a") { .success(testImageData) }
+        let firstProcessor = ItemRecordingProcessor(identifier: "c")
+        let secondProcessor = ItemRecordingProcessor(identifier: "b|c")
+
+        cache.store(testImage, original: testImageData, forKey: "a|b", toDisk: true) { _ in
+            cache.store(testImage, original: testImageData, forKey: "a", toDisk: true) { _ in
+                cache.clearMemoryCache()
+
+                let group = DispatchGroup()
+                let delivered = LockIsolated(0)
+
+                group.enter()
+                _ = self.manager.retrieveImage(
+                    with: .provider(firstProvider), options: [.processor(firstProcessor)]
+                ) { result in
+                    XCTAssertNotNil(result.value?.image)
+                    delivered.withValue { $0 += 1 }
+                    group.leave()
+                }
+
+                group.enter()
+                _ = self.manager.retrieveImage(
+                    with: .provider(secondProvider), options: [.processor(secondProcessor)]
+                ) { result in
+                    XCTAssertNotNil(result.value?.image)
+                    delivered.withValue { $0 += 1 }
+                    group.leave()
+                }
+
+                group.notify(queue: .main) {
+                    XCTAssertEqual(delivered.value, 2)
+                    XCTAssertEqual(firstProcessor.runCount, 1)
+                    XCTAssertEqual(secondProcessor.runCount, 1)
+                    exp.fulfill()
+                }
+            }
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    func testDifferingAnimatedImageCreatingOptionsAreNotShared() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        let cache = manager.cache
+
+        stub(url, data: testImageGIFData)
+
+        let gifImage = KingfisherWrapper<KFCrossPlatformImage>.animatedImage(data: testImageGIFData, options: .init())!
+        cache.store(gifImage, original: testImageGIFData, forKey: url.cacheKey, toDisk: true) { _ in
+            cache.clearMemoryCache()
+            // The requests below must reach the original cache hit rather than downloading.
+            XCTAssertTrue(cache.imageCachedType(forKey: url.cacheKey).cached)
+
+            let group = DispatchGroup()
+            let onlyFirstFrame = LockIsolated([String: Bool]())
+
+            group.enter()
+            self.manager.retrieveImage(
+                with: url, options: [.processor(SimpleProcessor()), .onlyLoadFirstFrame]
+            ) { result in
+                onlyFirstFrame.withValue { $0["first"] = result.value?.image.creatingOptions?.onlyFirstFrame }
+                group.leave()
+            }
+
+            group.enter()
+            self.manager.retrieveImage(with: url, options: [.processor(SimpleProcessor())]) { result in
+                onlyFirstFrame.withValue { $0["all"] = result.value?.image.creatingOptions?.onlyFirstFrame }
+                group.leave()
+            }
+
+            group.notify(queue: .main) {
+                XCTAssertEqual(onlyFirstFrame.value["first"], true)
+                XCTAssertEqual(onlyFirstFrame.value["all"], false)
+                exp.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    func testBackgroundDecodeIsAppliedPerRequest() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        let processor = ItemRecordingProcessor()
+        let cache = manager.cache
+
+        stub(url, data: testImageData)
+
+        cache.store(testImage, original: testImageData, forKey: url.cacheKey, toDisk: true) { _ in
+            cache.clearMemoryCache()
+
+            let group = DispatchGroup()
+            let delivered = LockIsolated(0)
+
+            group.enter()
+            self.manager.retrieveImage(
+                with: url, options: [.processor(processor), .backgroundDecode]
+            ) { result in
+                XCTAssertNotNil(result.value?.image)
+                delivered.withValue { $0 += 1 }
+                group.leave()
+            }
+
+            group.enter()
+            self.manager.retrieveImage(with: url, options: [.processor(processor)]) { result in
+                XCTAssertNotNil(result.value?.image)
+                delivered.withValue { $0 += 1 }
+                group.leave()
+            }
+
+            group.notify(queue: .main) {
+                XCTAssertEqual(delivered.value, 2)
+                XCTAssertEqual(processor.runCount, 1, "background decoding should not split the shared work")
+                exp.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
+    func testSerializerFallbackIsAppliedPerRequest() {
+        let exp = expectation(description: #function)
+        let url = testURLs[0]
+        let cache = manager.cache
+        let processor = ImageOnlyProcessor()
+        let firstSerializer = RecordingCacheSerializer(declaresDecodableData: true)
+        let secondSerializer = RecordingCacheSerializer(declaresDecodableData: true)
+
+        stub(url, data: testImageData)
+
+        cache.store(testImage, original: testImageData, forKey: url.cacheKey, toDisk: true) { _ in
+            cache.clearMemoryCache()
+
+            let group = DispatchGroup()
+
+            group.enter()
+            self.manager.retrieveImage(
+                with: url, options: [.processor(processor), .cacheSerializer(firstSerializer)]
+            ) { result in
+                XCTAssertNotNil(result.value?.image)
+                group.leave()
+            }
+
+            group.enter()
+            self.manager.retrieveImage(
+                with: url, options: [.processor(processor), .cacheSerializer(secondSerializer)]
+            ) { result in
+                XCTAssertNotNil(result.value?.image)
+                group.leave()
+            }
+
+            group.notify(queue: .main) {
+                // The processor rejects data, so each request deserializes with the serializer it passed.
+                XCTAssertGreaterThan(firstSerializer.imageCallCount, 0)
+                XCTAssertGreaterThan(secondSerializer.imageCallCount, 0)
+                exp.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+}
+
+/// Accepts an image, and rejects data.
+final class ImageOnlyProcessor: ImageProcessor, @unchecked Sendable {
+
+    let identifier = "com.onevcat.Kingfisher.test.ImageOnlyProcessor"
+
+    func process(item: ImageProcessItem, options: KingfisherParsedOptionsInfo) -> KFCrossPlatformImage? {
+        switch item {
+        case .image(let image): return image
+        case .data: return nil
+        }
     }
 }


### PR DESCRIPTION
When a processed image misses the cache but its original is on disk, thumbnail requests currently deserialize the original and encode it again before downsampling. Overlapping requests repeat that work. This change passes decodable cached bytes directly to the processor and shares the default read/processing path, without promoting the full-size original to memory.

Synchronous loads and requests with an explicit processing queue stay independent, so a visible request cannot wait behind another request's suspended queue. They retain the data path. Background decode, serializer fallback, modifiers, stores, and callbacks remain per request. Cache subclasses keep their retrieval overrides; custom serializers must opt in to direct decoding.

Validation: 378 macOS tests and 417 iOS 18.5 simulator tests passed; regressions observed failing before the scheduling and cache-override fixes; mutation checks for background decoding. The cache tests also check shared processing and prevent network fallback from hiding a failed disk read.

Builds on #2572 and preserves @abadiHariri's commits `84ad8e89` and `1a2882da` unchanged, followed by the scheduling and cache-override fixes. **Use Create a merge commit** to preserve this history and let GitHub mark #2572 as indirectly merged. Squash or rebase merging will not preserve the original commit identities.
